### PR TITLE
22 add thresholds rendering when present in grafana json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "alloc-no-stdlib"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -108,6 +117,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,10 +144,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "brotli"
@@ -159,16 +207,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
-
-[[package]]
-name = "cassowary"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
 name = "castaway"
@@ -256,7 +304,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -283,9 +331,9 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "compact_str"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -331,6 +379,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -341,33 +398,17 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
-version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
-dependencies = [
- "bitflags",
- "crossterm_winapi",
- "mio",
- "parking_lot",
- "rustix 0.38.44",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "crossterm_winapi",
  "derive_more",
  "document-features",
  "mio",
  "parking_lot",
- "rustix 1.1.2",
+ "rustix",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -380,6 +421,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "csscolorparser"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
+dependencies = [
+ "lab",
+ "phf",
 ]
 
 [[package]]
@@ -403,7 +464,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -414,7 +475,22 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.108",
+]
+
+[[package]]
+name = "deltae"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -435,7 +511,17 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -467,7 +553,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -502,10 +588,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set",
+ "regex",
+]
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
+
+[[package]]
+name = "finl_unicode"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -528,6 +656,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -594,7 +728,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -628,6 +762,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -649,9 +793,22 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -663,7 +820,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "clap_mangen",
- "crossterm 0.29.0",
+ "crossterm",
  "directories",
  "futures",
  "humantime",
@@ -682,9 +839,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -692,12 +847,23 @@ name = "hashbrown"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -913,6 +1079,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -947,6 +1119,8 @@ checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -968,7 +1142,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -995,9 +1169,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -1029,6 +1203,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "kasuari"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
+dependencies = [
+ "hashbrown 0.16.0",
+ "portable-atomic",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "lab"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1040,15 +1243,18 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "libc",
 ]
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
+name = "line-clipping"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+checksum = "5f4de44e98ddbf09375cbf4d17714d18f39195f4f4894e8524501726fd9a8a4a"
+dependencies = [
+ "bitflags 2.10.0",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1085,11 +1291,11 @@ checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.0",
 ]
 
 [[package]]
@@ -1099,10 +1305,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "mac_address"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+dependencies = [
+ "nix",
+ "winapi",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "memmem"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -1127,12 +1364,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1152,6 +1438,15 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "parking_lot"
@@ -1177,16 +1472,105 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1207,6 +1591,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1216,12 +1606,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -1262,7 +1668,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1304,13 +1710,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1320,8 +1741,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.3",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rand_core"
@@ -1334,23 +1761,87 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
 dependencies = [
- "bitflags",
- "cassowary",
+ "instability",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-macros",
+ "ratatui-termwiz",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
+dependencies = [
+ "bitflags 2.10.0",
  "compact_str",
- "crossterm 0.28.1",
+ "hashbrown 0.16.0",
+ "indoc",
+ "itertools",
+ "kasuari",
+ "lru",
+ "strum",
+ "thiserror 2.0.17",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
+dependencies = [
+ "cfg-if",
+ "crossterm",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7f1342a13e83e4bb9d0b793d0ea762be633f9582048c892ae9041ef39c936f4"
+dependencies = [
+ "ratatui-core",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-termwiz"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f76fe0bd0ed4295f0321b1676732e2454024c15a35d01904ddb315afd3d545c"
+dependencies = [
+ "ratatui-core",
+ "termwiz",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
+dependencies = [
+ "bitflags 2.10.0",
+ "hashbrown 0.16.0",
  "indoc",
  "instability",
  "itertools",
- "lru",
- "paste",
+ "line-clipping",
+ "ratatui-core",
  "strum",
+ "time",
  "unicode-segmentation",
- "unicode-truncate",
- "unicode-width 0.2.0",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1359,7 +1850,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -1372,6 +1863,35 @@ dependencies = [
  "libredox",
  "thiserror 1.0.69",
 ]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
@@ -1442,27 +1962,14 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "errno",
  "libc",
- "linux-raw-sys 0.11.0",
+ "linux-raw-sys",
  "windows-sys 0.61.2",
 ]
 
@@ -1520,6 +2027,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1546,7 +2059,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -1581,6 +2094,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -1626,6 +2150,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1667,24 +2197,23 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.26.3"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.26.4"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "rustversion",
- "syn",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -1692,6 +2221,17 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -1721,7 +2261,70 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
+]
+
+[[package]]
+name = "terminfo"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
+dependencies = [
+ "fnv",
+ "nom",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "termwiz"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bitflags 2.10.0",
+ "fancy-regex",
+ "filedescriptor",
+ "finl_unicode",
+ "fixedbitset",
+ "hex",
+ "lazy_static",
+ "libc",
+ "log",
+ "memmem",
+ "nix",
+ "num-derive",
+ "num-traits",
+ "ordered-float",
+ "pest",
+ "pest_derive",
+ "phf",
+ "sha2",
+ "signal-hook",
+ "siphasher",
+ "terminfo",
+ "termios",
+ "thiserror 1.0.69",
+ "ucd-trie",
+ "unicode-segmentation",
+ "vtparse",
+ "wezterm-bidi",
+ "wezterm-blob-leases",
+ "wezterm-color-types",
+ "wezterm-dynamic",
+ "wezterm-input-types",
+ "winapi",
 ]
 
 [[package]]
@@ -1750,7 +2353,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -1761,8 +2364,29 @@ checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+dependencies = [
+ "deranged",
+ "libc",
+ "num-conv",
+ "num_threads",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
 
 [[package]]
 name = "tinystr"
@@ -1814,7 +2438,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -1902,7 +2526,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "bytes",
  "futures-util",
  "http",
@@ -1952,6 +2576,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1965,26 +2601,26 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-truncate"
-version = "1.1.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
  "itertools",
  "unicode-segmentation",
- "unicode-width 0.1.14",
+ "unicode-width",
 ]
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
@@ -2023,6 +2659,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+dependencies = [
+ "atomic",
+ "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vtparse"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2043,7 +2706,16 @@ version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.46.0",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -2091,7 +2763,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
  "wasm-bindgen-shared",
 ]
 
@@ -2102,6 +2774,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.10.0",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -2131,6 +2837,78 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32b130c0d2d49f8b6889abc456e795e82525204f27c42cf767cf0d7734e089b8"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "wezterm-bidi"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0a6e355560527dd2d1cf7890652f4f09bb3433b6aadade4c9b5ed76de5f3ec"
+dependencies = [
+ "log",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-blob-leases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
+dependencies = [
+ "getrandom 0.3.4",
+ "mac_address",
+ "sha2",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
+name = "wezterm-color-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de81ef35c9010270d63772bebef2f2d6d1f2d20a983d27505ac850b8c4b4296"
+dependencies = [
+ "csscolorparser",
+ "deltae",
+ "lazy_static",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-dynamic"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
+dependencies = [
+ "log",
+ "ordered-float",
+ "strsim",
+ "thiserror 1.0.69",
+ "wezterm-dynamic-derive",
+]
+
+[[package]]
+name = "wezterm-dynamic-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c0cf2d539c645b448eaffec9ec494b8b19bd5077d9e58cb1ae7efece8d575b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "wezterm-input-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7012add459f951456ec9d6c7e6fc340b1ce15d6fc9629f8c42853412c029e57e"
+dependencies = [
+ "bitflags 1.3.2",
+ "euclid",
+ "lazy_static",
+ "serde",
+ "wezterm-dynamic",
 ]
 
 [[package]]
@@ -2176,7 +2954,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -2187,7 +2965,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -2228,15 +3006,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -2461,6 +3230,94 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn 2.0.108",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.10.0",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2485,7 +3342,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
  "synstructure",
 ]
 
@@ -2506,7 +3363,7 @@ checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -2526,7 +3383,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
  "synstructure",
 ]
 
@@ -2566,7 +3423,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ clap_mangen = "0.2.26"
 crossterm = "0.29.0"
 futures = "0.3.31"
 humantime = "2.3.0"
-ratatui = { version = "0.29.0", features = ["crossterm"] }
+ratatui = { version = "0.30.0", features = ["crossterm"] }
 reqwest = { version = "0.12.24", default-features = false, features = ["json", "gzip", "brotli", "zstd", "rustls-tls"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"

--- a/GRAFANA_COMPATIBILITY.md
+++ b/GRAFANA_COMPATIBILITY.md
@@ -165,8 +165,8 @@ This document provides a comprehensive feature-parity table between the [Grafana
 | `fieldConfig` | ❌ Not Implemented | Top-level field config object is ignored |
 | `fieldConfig.defaults` | ❌ Not Implemented | |
 | `fieldConfig.defaults.unit` | ❌ Not Implemented | Values displayed as raw numbers with SI suffixes |
-| `fieldConfig.defaults.min` | ❌ Not Implemented | Gauge uses hardcoded 0–100 range |
-| `fieldConfig.defaults.max` | ❌ Not Implemented | Gauge auto-scales to `max(100, value×1.2)` |
+| `fieldConfig.defaults.min` | ✅ Supported | Used for interpolating percentage thresholds and Gauge limits |
+| `fieldConfig.defaults.max` | ✅ Supported | Used for scaling gauges and threshold boundaries |
 | `fieldConfig.defaults.decimals` | ❌ Not Implemented | Always uses 2 decimal places |
 | `fieldConfig.defaults.color` | ❌ Not Implemented | Uses theme palette instead |
 | `fieldConfig.defaults.mappings` | ❌ Not Implemented | Value mappings not supported |
@@ -187,11 +187,11 @@ This document provides a comprehensive feature-parity table between the [Grafana
 
 | JSON Field | Status | Notes |
 |---|---|---|
-| `fieldConfig.defaults.thresholds` | ❌ Not Implemented | |
-| `fieldConfig.defaults.thresholds.mode` | ❌ Not Implemented | (`absolute` / `percentage`) |
-| `fieldConfig.defaults.thresholds.steps` | ❌ Not Implemented | |
-| `fieldConfig.defaults.thresholds.steps[].value` | ❌ Not Implemented | |
-| `fieldConfig.defaults.thresholds.steps[].color` | ❌ Not Implemented | |
+| `fieldConfig.defaults.thresholds` | ✅ Supported | Applied to Graph limit lines and dynamic coloring for Stat, Gauge & BarGauge |
+| `fieldConfig.defaults.thresholds.mode` | ✅ Supported | (`absolute` / `percentage`) |
+| `fieldConfig.defaults.thresholds.steps` | ✅ Supported | |
+| `fieldConfig.defaults.thresholds.steps[].value` | ✅ Supported | Evaluated mathematically against metric values |
+| `fieldConfig.defaults.thresholds.steps[].color` | ✅ Supported | Maps keywords (e.g., `green`) and hex codes (e.g., `#FF0000`) |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ This demo showcases all 7 visualization types (graph, stat, gauge, bar gauge, ta
 - **Template variables** with CLI overrides
 - **Legend formatting** (`{{label}}` syntax)
 - **Grid layouts** using `gridPos`
+- **Thresholds** dynamically applied to metrics and graph limits
 
 > 📋 For a detailed breakdown of which Grafana JSON features are supported, see [GRAFANA_COMPATIBILITY.md](GRAFANA_COMPATIBILITY.md).
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ grafatui [OPTIONS]
 | `--step <DURATION>` | Query step resolution (e.g., `5s`, `30s`) | `5s` |
 | `--var <KEY=VALUE>` | Override dashboard variables | - |
 | `--theme <NAME>` | UI theme | `default` |
-| `--threshold-marker <MARKER>` | Marker for threshold lines (`dashed`, `dot`, `block`, etc.) | `dashed` |
+| `--threshold-marker <MARKER>` | Marker for threshold lines (`dashed`, `dot`, `block`, `quadrant`, etc.) | `dashed` |
 | `--refresh-rate <MS>` | Data fetch interval (milliseconds) | `1000` |
 | `--config <FILE>` | Custom config file path | - |
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ grafatui [OPTIONS]
 | `--step <DURATION>` | Query step resolution (e.g., `5s`, `30s`) | `5s` |
 | `--var <KEY=VALUE>` | Override dashboard variables | - |
 | `--theme <NAME>` | UI theme | `default` |
+| `--threshold-marker <MARKER>` | Marker for threshold lines (`dashed`, `dot`, `block`, etc.) | `dashed` |
 | `--refresh-rate <MS>` | Data fetch interval (milliseconds) | `1000` |
 | `--config <FILE>` | Custom config file path | - |
 
@@ -155,6 +156,7 @@ prometheus_url = "http://localhost:9090"
 refresh_rate = 1000
 time_range = "1h"
 theme = "dracula"
+threshold_marker = "dashed"
 grafana_json = "~/.config/grafatui/my-dashboard.json"
 ```
 

--- a/examples/dashboards/thresholds_demo.json
+++ b/examples/dashboards/thresholds_demo.json
@@ -1,0 +1,111 @@
+{
+    "title": "Grafatui Test Dashboard - Thresholds Demo",
+    "templating": {
+        "list": [
+            {
+                "name": "job",
+                "current": {
+                    "text": "prometheus",
+                    "value": "prometheus"
+                }
+            }
+        ]
+    },
+    "panels": [
+        {
+            "type": "graph",
+            "title": "1. Graph - CPU Rate (Absolute Thresholds)",
+            "gridPos": { "x": 0, "y": 0, "w": 12, "h": 12 },
+            "targets": [
+                {
+                    "expr": "rate(process_cpu_seconds_total{job=\"$job\"}[1m]) * 100",
+                    "legendFormat": "CPU Usage"
+                }
+            ],
+            "fieldConfig": {
+                "defaults": {
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            { "color": "green", "value": null },
+                            { "color": "yellow", "value": 11.5 },
+                            { "color": "red", "value": 13.5 }
+                        ]
+                    }
+                }
+            }
+        },
+        {
+            "type": "gauge",
+            "title": "2. Gauge - Memory Usage (Percentage Thresholds)",
+            "gridPos": { "x": 12, "y": 0, "w": 12, "h": 12 },
+            "targets": [
+                {
+                    "expr": "process_resident_memory_bytes{job=\"$job\"} / 1024 / 1024",
+                    "legendFormat": "Memory MB"
+                }
+            ],
+            "fieldConfig": {
+                "defaults": {
+                    "min": 0,
+                    "max": 200,
+                    "thresholds": {
+                        "mode": "percentage",
+                        "steps": [
+                            { "color": "super-light-blue", "value": null },
+                            { "color": "orange", "value": 50.0 },
+                            { "color": "red", "value": 85.0 }
+                        ]
+                    }
+                }
+            }
+        },
+        {
+            "type": "stat",
+            "title": "3. Stat - Goroutines (Absolute Hex Colors)",
+            "gridPos": { "x": 0, "y": 12, "w": 12, "h": 12 },
+            "targets": [
+                {
+                    "expr": "go_goroutines{job=\"$job\"}",
+                    "legendFormat": "Goroutines"
+                }
+            ],
+            "fieldConfig": {
+                "defaults": {
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            { "color": "#00FF00", "value": null },
+                            { "color": "#FFFF00", "value": 40.0 },
+                            { "color": "#FF0000", "value": 60.0 }
+                        ]
+                    }
+                }
+            }
+        },
+        {
+            "type": "bargauge",
+            "title": "4. Bar Gauge - Requests Running (vLLM Nodes)",
+            "gridPos": { "x": 12, "y": 12, "w": 12, "h": 12 },
+            "targets": [
+                {
+                    "expr": "vllm:num_requests_running",
+                    "legendFormat": "{{instance}}"
+                }
+            ],
+            "fieldConfig": {
+                "defaults": {
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            { "color": "green", "value": null },
+                            { "color": "yellow", "value": 15.0 },
+                            { "color": "orange", "value": 30.0 },
+                            { "color": "red", "value": 45.0 }
+                        ]
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/src/app.rs
+++ b/src/app.rs
@@ -20,7 +20,7 @@ use crate::ui;
 use anyhow::Result;
 use crossterm::event::{self, Event, KeyCode, KeyModifiers};
 use futures::StreamExt;
-use ratatui::{style::Color, Terminal};
+use ratatui::{Terminal, style::Color};
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
 use tokio::time::sleep;
@@ -121,7 +121,7 @@ pub struct Thresholds {
 impl PanelState {
     pub fn get_color_for_value(&self, val: f64) -> Option<Color> {
         let thresholds = self.thresholds.as_ref()?;
-        
+
         let mut matched_color = None;
 
         match thresholds.mode {
@@ -143,7 +143,7 @@ impl PanelState {
                 let min = self.min.unwrap_or(0.0);
                 let max = self.max.unwrap_or(100.0);
                 let range = max - min;
-                
+
                 let pct = if range > 0.0 {
                     (val - min) / range * 100.0
                 } else {
@@ -622,7 +622,10 @@ pub async fn run_app<B: ratatui::backend::Backend>(
     terminal: &mut Terminal<B>,
     app: &mut AppState,
     tick_rate: Duration,
-) -> Result<()> {
+) -> Result<()>
+where
+    <B as ratatui::backend::Backend>::Error: Send + Sync + 'static,
+{
     loop {
         terminal.draw(|f| ui::draw_ui(f, app))?;
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -115,6 +115,7 @@ pub struct ThresholdStep {
 pub struct Thresholds {
     pub mode: ThresholdMode,
     pub steps: Vec<ThresholdStep>,
+    pub style: Option<String>,
 }
 
 impl PanelState {
@@ -215,6 +216,8 @@ pub struct AppState {
     pub search_results: Vec<usize>,
     /// Cursor X position (timestamp) for inspection.
     pub cursor_x: Option<f64>,
+    /// Global marker set for rendering thresholds
+    pub threshold_marker: String,
 }
 
 impl AppState {
@@ -239,6 +242,7 @@ impl AppState {
         panels: Vec<PanelState>,
         skipped_panels: usize,
         theme: Theme,
+        threshold_marker: String,
     ) -> Self {
         Self {
             prometheus,
@@ -259,6 +263,7 @@ impl AppState {
             search_query: String::new(),
             search_results: Vec::new(),
             cursor_x: None,
+            threshold_marker,
         }
     }
 
@@ -566,6 +571,7 @@ mod tests {
             vec![], // Empty panels
             0,
             Theme::default(),
+            "dashed".to_string(),
         );
 
         // Should not panic on refresh

--- a/src/app.rs
+++ b/src/app.rs
@@ -20,7 +20,7 @@ use crate::ui;
 use anyhow::Result;
 use crossterm::event::{self, Event, KeyCode, KeyModifiers};
 use futures::StreamExt;
-use ratatui::Terminal;
+use ratatui::{style::Color, Terminal};
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
 use tokio::time::sleep;
@@ -48,6 +48,12 @@ pub struct PanelState {
     pub y_axis_mode: YAxisMode,
     /// Visualization type.
     pub panel_type: PanelType,
+    /// Threshold configuration.
+    pub thresholds: Option<Thresholds>,
+    /// Optional minimum value for gauge and thresholds.
+    pub min: Option<f64>,
+    /// Optional maximum value for gauge and thresholds.
+    pub max: Option<f64>,
 }
 
 /// Visualization types supported by Grafatui.
@@ -91,6 +97,73 @@ pub struct GridUnit {
     pub y: i32,
     pub w: i32,
     pub h: i32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ThresholdMode {
+    Absolute,
+    Percentage,
+}
+
+#[derive(Debug, Clone)]
+pub struct ThresholdStep {
+    pub value: Option<f64>,
+    pub color: Color,
+}
+
+#[derive(Debug, Clone)]
+pub struct Thresholds {
+    pub mode: ThresholdMode,
+    pub steps: Vec<ThresholdStep>,
+}
+
+impl PanelState {
+    pub fn get_color_for_value(&self, val: f64) -> Option<Color> {
+        let thresholds = self.thresholds.as_ref()?;
+        
+        let mut matched_color = None;
+
+        match thresholds.mode {
+            ThresholdMode::Absolute => {
+                for step in &thresholds.steps {
+                    if let Some(step_val) = step.value {
+                        if val >= step_val {
+                            matched_color = Some(step.color);
+                        }
+                    } else {
+                        // Null value represents the base step (lowest possible)
+                        if matched_color.is_none() {
+                            matched_color = Some(step.color);
+                        }
+                    }
+                }
+            }
+            ThresholdMode::Percentage => {
+                let min = self.min.unwrap_or(0.0);
+                let max = self.max.unwrap_or(100.0);
+                let range = max - min;
+                
+                let pct = if range > 0.0 {
+                    (val - min) / range * 100.0
+                } else {
+                    0.0
+                };
+
+                for step in &thresholds.steps {
+                    if let Some(step_val) = step.value {
+                        if pct >= step_val {
+                            matched_color = Some(step.color);
+                        }
+                    } else {
+                        if matched_color.is_none() {
+                            matched_color = Some(step.color);
+                        }
+                    }
+                }
+            }
+        }
+        matched_color
+    }
 }
 
 /// Application mode.
@@ -528,6 +601,9 @@ pub fn default_queries(mut provided: Vec<String>) -> Vec<PanelState> {
             grid: None,
             y_axis_mode: YAxisMode::Auto,
             panel_type: PanelType::Graph,
+            thresholds: None,
+            min: None,
+            max: None,
         })
         .collect()
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -45,7 +45,7 @@ pub struct Args {
     #[arg(long, value_name = "NAME")]
     pub theme: Option<String>,
 
-    /// Marker symbol to use for threshold lines (dot, braille, block, bar, half-block)
+    /// Marker symbol to use for threshold lines (dashed, dot, braille, block, bar, quadrant, sextant, octant)
     #[arg(long, value_name = "MARKER")]
     pub threshold_marker: Option<String>,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -45,6 +45,10 @@ pub struct Args {
     #[arg(long, value_name = "NAME")]
     pub theme: Option<String>,
 
+    /// Marker symbol to use for threshold lines (dot, braille, block, bar, half-block)
+    #[arg(long, value_name = "MARKER")]
+    pub threshold_marker: Option<String>,
+
     /// Configuration file path (e.g., ./grafatui.toml).
     #[arg(long, value_name = "FILE")]
     pub config: Option<PathBuf>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,6 +29,7 @@ pub struct Config {
     pub step: Option<String>,
     pub theme: Option<String>,
     pub grafana_json: Option<PathBuf>,
+    pub threshold_marker: Option<String>,
     pub vars: Option<HashMap<String, String>>,
 }
 

--- a/src/grafana.rs
+++ b/src/grafana.rs
@@ -244,13 +244,13 @@ fn collect_panels(out: &mut DashboardImport, panels: Vec<RawPanel>) -> Result<()
                 if let Some(defaults) = fc.defaults {
                     min = defaults.min;
                     max = defaults.max;
-                    
+
                     if let Some(th) = defaults.thresholds {
                         let mode = match th.mode.as_deref() {
                             Some("percentage") => crate::app::ThresholdMode::Percentage,
                             _ => crate::app::ThresholdMode::Absolute,
                         };
-                        
+
                         let mut steps = Vec::new();
                         if let Some(raw_steps) = th.steps {
                             for s in raw_steps {
@@ -264,18 +264,24 @@ fn collect_panels(out: &mut DashboardImport, panels: Vec<RawPanel>) -> Result<()
                             steps.sort_by(|a, b| {
                                 let a_val = a.value.unwrap_or(f64::NEG_INFINITY);
                                 let b_val = b.value.unwrap_or(f64::NEG_INFINITY);
-                                a_val.partial_cmp(&b_val).unwrap_or(std::cmp::Ordering::Equal)
+                                a_val
+                                    .partial_cmp(&b_val)
+                                    .unwrap_or(std::cmp::Ordering::Equal)
                             });
                         }
-                        
+
                         if !steps.is_empty() {
                             let style = defaults
                                 .custom
                                 .and_then(|c| c.thresholds_style)
                                 .and_then(|t| t.mode)
                                 .unwrap_or_else(|| "line".to_string());
-                                
-                            thresholds = Some(crate::app::Thresholds { mode, steps, style: Some(style) });
+
+                            thresholds = Some(crate::app::Thresholds {
+                                mode,
+                                steps,
+                                style: Some(style),
+                            });
                         }
                     }
                 }

--- a/src/grafana.rs
+++ b/src/grafana.rs
@@ -104,6 +104,18 @@ struct RawFieldConfigDefaults {
     min: Option<f64>,
     max: Option<f64>,
     thresholds: Option<RawThresholds>,
+    custom: Option<RawCustom>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawCustom {
+    #[serde(rename = "thresholdsStyle")]
+    thresholds_style: Option<RawThresholdsStyle>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawThresholdsStyle {
+    mode: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -257,7 +269,13 @@ fn collect_panels(out: &mut DashboardImport, panels: Vec<RawPanel>) -> Result<()
                         }
                         
                         if !steps.is_empty() {
-                            thresholds = Some(crate::app::Thresholds { mode, steps });
+                            let style = defaults
+                                .custom
+                                .and_then(|c| c.thresholds_style)
+                                .and_then(|t| t.mode)
+                                .unwrap_or_else(|| "line".to_string());
+                                
+                            thresholds = Some(crate::app::Thresholds { mode, steps, style: Some(style) });
                         }
                     }
                 }

--- a/src/grafana.rs
+++ b/src/grafana.rs
@@ -39,6 +39,9 @@ pub struct QueryPanel {
     pub legends: Vec<Option<String>>, // Parallel to exprs
     pub grid: Option<GridPos>,
     pub panel_type: crate::app::PanelType,
+    pub thresholds: Option<crate::app::Thresholds>,
+    pub min: Option<f64>,
+    pub max: Option<f64>,
 }
 
 /// Grid position extracted from Grafana.
@@ -87,6 +90,32 @@ struct RawPanel {
     #[serde(rename = "gridPos")]
     grid_pos: Option<RawGridPos>,
     panels: Option<Vec<RawPanel>>, // nested rows
+    #[serde(rename = "fieldConfig")]
+    field_config: Option<RawFieldConfig>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawFieldConfig {
+    defaults: Option<RawFieldConfigDefaults>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawFieldConfigDefaults {
+    min: Option<f64>,
+    max: Option<f64>,
+    thresholds: Option<RawThresholds>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawThresholds {
+    mode: Option<String>,
+    steps: Option<Vec<RawThresholdStep>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawThresholdStep {
+    value: Option<f64>,
+    color: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -195,6 +224,45 @@ fn collect_panels(out: &mut DashboardImport, panels: Vec<RawPanel>) -> Result<()
                 }
             }
 
+            let mut thresholds = None;
+            let mut min = None;
+            let mut max = None;
+
+            if let Some(fc) = p.field_config {
+                if let Some(defaults) = fc.defaults {
+                    min = defaults.min;
+                    max = defaults.max;
+                    
+                    if let Some(th) = defaults.thresholds {
+                        let mode = match th.mode.as_deref() {
+                            Some("percentage") => crate::app::ThresholdMode::Percentage,
+                            _ => crate::app::ThresholdMode::Absolute,
+                        };
+                        
+                        let mut steps = Vec::new();
+                        if let Some(raw_steps) = th.steps {
+                            for s in raw_steps {
+                                let color = s.color.unwrap_or_else(|| "green".to_string());
+                                let parsed_color = crate::theme::parse_grafana_color(&color);
+                                steps.push(crate::app::ThresholdStep {
+                                    value: s.value,
+                                    color: parsed_color,
+                                });
+                            }
+                            steps.sort_by(|a, b| {
+                                let a_val = a.value.unwrap_or(f64::NEG_INFINITY);
+                                let b_val = b.value.unwrap_or(f64::NEG_INFINITY);
+                                a_val.partial_cmp(&b_val).unwrap_or(std::cmp::Ordering::Equal)
+                            });
+                        }
+                        
+                        if !steps.is_empty() {
+                            thresholds = Some(crate::app::Thresholds { mode, steps });
+                        }
+                    }
+                }
+            }
+
             if !exprs.is_empty() {
                 let gp = p.grid_pos.map(|g| GridPos {
                     x: g.x,
@@ -208,6 +276,9 @@ fn collect_panels(out: &mut DashboardImport, panels: Vec<RawPanel>) -> Result<()
                     legends,
                     grid: gp,
                     panel_type,
+                    thresholds,
+                    min,
+                    max,
                 });
             }
         } else if !kind.is_empty() && kind != "row" {

--- a/src/main.rs
+++ b/src/main.rs
@@ -154,6 +154,12 @@ async fn main() -> Result<()> {
         .unwrap_or_else(|| "default".to_string());
     let theme = Theme::from_str(&theme_name);
 
+    // Determine threshold marker
+    let marker_name = args
+        .threshold_marker
+        .or(config.threshold_marker)
+        .unwrap_or_else(|| "dashed".to_string());
+
     let mut state = app::AppState::new(
         prom,
         range,
@@ -163,6 +169,7 @@ async fn main() -> Result<()> {
         panels,
         skipped_panels,
         theme,
+        marker_name,
     );
     state.vars = vars; // <— pass variables into the app
     state.refresh().await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,6 +125,9 @@ async fn main() -> Result<()> {
                 }),
                 y_axis_mode: app::YAxisMode::Auto,
                 panel_type: q.panel_type,
+                thresholds: q.thresholds,
+                min: q.min,
+                max: q.max,
             })
             .collect();
         (format!("{} (imported)", d.title), ps, d.skipped_panels)

--- a/src/main.rs
+++ b/src/main.rs
@@ -158,7 +158,7 @@ async fn main() -> Result<()> {
     let marker_name = args
         .threshold_marker
         .or(config.threshold_marker)
-        .unwrap_or_else(|| "dashed".to_string());
+        .unwrap_or_else(|| "dashed-line".to_string());
 
     let mut state = app::AppState::new(
         prom,

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -191,3 +191,29 @@ impl Theme {
         }
     }
 }
+
+pub fn parse_grafana_color(c: &str) -> Color {
+    if c.starts_with('#') && c.len() >= 7 {
+        let r = u8::from_str_radix(&c[1..3], 16).unwrap_or(0);
+        let g = u8::from_str_radix(&c[3..5], 16).unwrap_or(0);
+        let b = u8::from_str_radix(&c[5..7], 16).unwrap_or(0);
+        return Color::Rgb(r, g, b);
+    }
+    
+    match c.to_lowercase().as_str() {
+        "green" | "dark-green" => Color::Green,
+        "super-light-green" | "light-green" => Color::LightGreen,
+        "yellow" | "dark-yellow" => Color::Yellow,
+        "super-light-yellow" | "light-yellow" => Color::LightYellow,
+        "red" | "dark-red" => Color::Red,
+        "super-light-red" | "light-red" => Color::LightRed,
+        "blue" | "dark-blue" => Color::Blue,
+        "super-light-blue" | "light-blue" => Color::LightBlue,
+        "purple" | "dark-purple" => Color::Magenta,
+        "super-light-purple" | "light-purple" => Color::LightMagenta,
+        "orange" | "dark-orange" => Color::Rgb(255, 165, 0),
+        "light-orange" => Color::Rgb(255, 200, 100),
+        "cyan" => Color::Cyan,
+        _ => Color::Reset,
+    }
+}

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -199,7 +199,7 @@ pub fn parse_grafana_color(c: &str) -> Color {
         let b = u8::from_str_radix(&c[5..7], 16).unwrap_or(0);
         return Color::Rgb(r, g, b);
     }
-    
+
     match c.to_lowercase().as_str() {
         "green" | "dark-green" => Color::Green,
         "super-light-green" | "light-green" => Color::LightGreen,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -571,12 +571,48 @@ fn render_graph_panel(
     let chart_area = chunks[0];
     let legend_area = chunks[1];
 
+    // Determine x bounds from range window (unix seconds)
+    // Use app.time_offset to shift the window
+    let now = (chrono::Utc::now().timestamp() - app.time_offset.as_secs() as i64) as f64;
+    let start = now - app.range.as_secs_f64();
+
+    // Calculate y_bounds once
+    let y_bounds = calculate_y_bounds(p);
+
     // Prepare datasets (without names for the chart itself to avoid built-in legend)
     let mut chart_datasets = Vec::new();
     let mut legend_items = Vec::new();
 
-    // Declare cursor_dataset here to extend its lifetime
+    // Declare helper datasets to extend their lifetimes
     let mut cursor_dataset = vec![];
+    let mut threshold_datasets = vec![];
+
+    // Generate threshold limit lines
+    if let Some(th) = &p.thresholds {
+        for step in th.steps.iter().filter(|s| s.value.is_some()) {
+            let val = step.value.unwrap();
+            let abs_val = match th.mode {
+                crate::app::ThresholdMode::Absolute => val,
+                crate::app::ThresholdMode::Percentage => {
+                    let min = p.min.unwrap_or(0.0);
+                    let max = p.max.unwrap_or(100.0);
+                    min + (val / 100.0) * (max - min)
+                }
+            };
+            threshold_datasets.push(vec![(start, abs_val), (now, abs_val)]);
+        }
+        
+        for (i, step) in th.steps.iter().filter(|s| s.value.is_some()).enumerate() {
+            chart_datasets.push(
+                Dataset::default()
+                    .name("")
+                    .marker(ratatui::symbols::Marker::Dot)
+                    .graph_type(GraphType::Line)
+                    .style(Style::default().fg(step.color))
+                    .data(&threshold_datasets[i]),
+            );
+        }
+    }
 
     for (i, s) in p.series.iter().enumerate() {
         let color = if use_hash_colors {
@@ -615,9 +651,6 @@ fn render_graph_panel(
         );
     }
 
-    // Calculate y_bounds once
-    let y_bounds = calculate_y_bounds(p);
-
     // Add cursor line if inspecting
     if let Some(cx) = cursor_x {
         cursor_dataset.push((cx, y_bounds[0]));
@@ -632,11 +665,6 @@ fn render_graph_panel(
                 .data(&cursor_dataset),
         );
     }
-
-    // Determine x bounds from range window (unix seconds)
-    // Use app.time_offset to shift the window
-    let now = (chrono::Utc::now().timestamp() - app.time_offset.as_secs() as i64) as f64;
-    let start = now - app.range.as_secs_f64();
 
     let x_labels = vec![
         Span::styled(format_time(start), Style::default().fg(theme.text)),
@@ -707,18 +735,37 @@ fn render_gauge(frame: &mut Frame, area: Rect, p: &PanelState, app: &AppState) {
 fn render_bar_gauge(frame: &mut Frame, area: Rect, p: &PanelState, app: &AppState) {
     let theme = &app.theme;
 
-    let mut bars = Vec::new();
+    let mut max_label_len = 3;
 
-    for s in p.series.iter().filter(|s| s.visible) {
-        if let Some(v) = s.value {
-            let color = p.get_color_for_value(v).unwrap_or(theme.palette[0]);
-            let bar = ratatui::widgets::Bar::default()
-                .value(v as u64)
-                .label(ratatui::text::Line::from(s.name.as_str()))
-                .style(Style::default().fg(color))
-                .value_style(Style::default().fg(theme.text).bg(color));
-            bars.push(bar);
-        }
+    let scale = 1000.0;
+
+    // Map intermediate valid series
+    let mut valid_series: Vec<_> = p.series.iter().filter(|s| s.visible && s.value.is_some()).collect();
+
+    // Sort descending safely
+    valid_series.sort_by(|a, b| {
+        let v_a = a.value.unwrap_or(0.0);
+        let v_b = b.value.unwrap_or(0.0);
+        v_b.partial_cmp(&v_a).unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    // Truncate based on area width
+    let max_bars = (area.width / 4).saturating_sub(1).max(1) as usize;
+    valid_series.truncate(max_bars);
+
+    let mut bars = Vec::with_capacity(valid_series.len());
+
+    for s in valid_series {
+        let v = s.value.unwrap();
+        max_label_len = max_label_len.max(s.name.len());
+        let color = p.get_color_for_value(v).unwrap_or(theme.palette[0]);
+        let bar = ratatui::widgets::Bar::default()
+            .value((v * scale) as u64)
+            .text_value(format_si(v))
+            .label(ratatui::text::Line::from(s.name.as_str()))
+            .style(Style::default().fg(color))
+            .value_style(Style::default().fg(theme.text).bg(color));
+        bars.push(bar);
     }
 
     if bars.is_empty() {
@@ -727,12 +774,17 @@ fn render_bar_gauge(frame: &mut Frame, area: Rect, p: &PanelState, app: &AppStat
         return;
     }
 
+    let bar_width = (area.width / bars.len() as u16)
+        .saturating_sub(1)
+        .min(max_label_len as u16)
+        .max(3);
+
     let bar_group = ratatui::widgets::BarGroup::default().bars(&bars);
 
     let bar_chart = ratatui::widgets::BarChart::default()
         .block(Block::default().borders(Borders::NONE))
         .data(bar_group)
-        .bar_width(3)
+        .bar_width(bar_width)
         .bar_gap(1);
 
     frame.render_widget(bar_chart, area);

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -601,7 +601,7 @@ fn render_graph_panel(
                     min + (val / 100.0) * (max - min)
                 }
             };
-            
+
             let mut dataset = Vec::new();
             if app.threshold_marker.starts_with("dashed") || th.style.as_deref() == Some("dashed") {
                 let points_count = 15; // 15 evenly spaced ticks across any width length
@@ -614,11 +614,11 @@ fn render_graph_panel(
                 dataset.push((start, abs_val));
                 dataset.push((now, abs_val));
             }
-            
+
             threshold_datasets.push(dataset);
             threshold_labels_info.push((abs_val, step.color));
         }
-        
+
         for (i, step) in th.steps.iter().filter(|s| s.value.is_some()).enumerate() {
             if app.threshold_marker.ends_with("line") {
                 // Skips dataset rendering; handled via post-render buffer overwrite
@@ -633,7 +633,9 @@ fn render_graph_panel(
                 "quadrant" => (ratatui::symbols::Marker::Quadrant, GraphType::Line),
                 "sextant" => (ratatui::symbols::Marker::Sextant, GraphType::Line),
                 "octant" => (ratatui::symbols::Marker::Octant, GraphType::Line),
-                "dashed" | "dashed-braille" => (ratatui::symbols::Marker::Braille, GraphType::Scatter),
+                "dashed" | "dashed-braille" => {
+                    (ratatui::symbols::Marker::Braille, GraphType::Scatter)
+                }
                 "dashed-block" => (ratatui::symbols::Marker::Block, GraphType::Scatter),
                 "dashed-bar" => (ratatui::symbols::Marker::Bar, GraphType::Scatter),
                 "dashed-half-block" => (ratatui::symbols::Marker::HalfBlock, GraphType::Scatter),
@@ -643,7 +645,7 @@ fn render_graph_panel(
                 "dashed-dot" => (ratatui::symbols::Marker::Dot, GraphType::Scatter),
                 _ => (ratatui::symbols::Marker::Dot, GraphType::Line),
             };
-            
+
             chart_datasets.push(
                 Dataset::default()
                     .name("")
@@ -714,10 +716,11 @@ fn render_graph_panel(
 
     let y_axis_height = chart_area.height.saturating_sub(1).max(2) as usize;
     let mut y_labels = vec![Span::raw(""); y_axis_height];
-    
+
     y_labels[0] = Span::styled(format_si(y_bounds[0]), Style::default().fg(theme.text));
-    y_labels[y_axis_height - 1] = Span::styled(format_si(y_bounds[1]), Style::default().fg(theme.text));
-    
+    y_labels[y_axis_height - 1] =
+        Span::styled(format_si(y_bounds[1]), Style::default().fg(theme.text));
+
     if y_bounds[1] > y_bounds[0] {
         for (th_val, color) in &threshold_labels_info {
             if *th_val > y_bounds[0] && *th_val < y_bounds[1] {
@@ -753,30 +756,33 @@ fn render_graph_panel(
     // Render custom raw lines by hijacking buffer space
     if app.threshold_marker.ends_with("line") && y_bounds[1] > y_bounds[0] {
         let buf = frame.buffer_mut();
-        
+
         let chart_left = chart_area.left() + y_max_width + 1; // +1 for the | axis line
         let chart_right = chart_area.right();
         let chart_bottom = chart_area.bottom().saturating_sub(2); // x-axis occupies last rows
         let chart_top = chart_area.top();
         let chart_h = chart_bottom.saturating_sub(chart_top) as f64;
-    
+
         if chart_h > 0.0 {
             let is_dashed = app.threshold_marker.starts_with("dashed");
             let line_char = if is_dashed { '-' } else { '─' };
-            
+
             for (th_val, color) in &threshold_labels_info {
                 if *th_val > y_bounds[0] && *th_val < y_bounds[1] {
                     let ratio = (*th_val - y_bounds[0]) / (y_bounds[1] - y_bounds[0]);
                     let y_offset = (ratio * chart_h).round() as u16;
                     let phys_y = chart_bottom.saturating_sub(y_offset);
-    
+
                     if phys_y >= chart_top && phys_y <= chart_bottom {
                         for x in chart_left..chart_right {
                             if is_dashed && x % 2 == 0 {
                                 continue;
                             }
                             if let Some(cell) = buf.cell_mut((x, phys_y)) {
-                                cell.set_char(line_char).set_style(Style::default().fg(*color));
+                                if should_draw_threshold_on_cell(cell) {
+                                    cell.set_char(line_char)
+                                        .set_style(Style::default().fg(*color));
+                                }
                             }
                         }
                     }
@@ -792,6 +798,10 @@ fn render_graph_panel(
     }
 }
 
+fn should_draw_threshold_on_cell(cell: &ratatui::buffer::Cell) -> bool {
+    cell.symbol().chars().all(char::is_whitespace)
+}
+
 fn render_gauge(frame: &mut Frame, area: Rect, p: &PanelState, app: &AppState) {
     let theme = &app.theme;
 
@@ -804,8 +814,10 @@ fn render_gauge(frame: &mut Frame, area: Rect, p: &PanelState, app: &AppState) {
         .unwrap_or((0.0, "No data".to_string()));
 
     let min = p.min.unwrap_or(0.0);
-    let max = p.max.unwrap_or_else(|| if value > 100.0 { value * 1.2 } else { 100.0 });
-    
+    let max = p
+        .max
+        .unwrap_or_else(|| if value > 100.0 { value * 1.2 } else { 100.0 });
+
     let color = p.get_color_for_value(value).unwrap_or(theme.palette[0]);
 
     let ratio = if max > min {
@@ -831,7 +843,11 @@ fn render_bar_gauge(frame: &mut Frame, area: Rect, p: &PanelState, app: &AppStat
     let scale = 1000.0;
 
     // Map intermediate valid series
-    let mut valid_series: Vec<_> = p.series.iter().filter(|s| s.visible && s.value.is_some()).collect();
+    let mut valid_series: Vec<_> = p
+        .series
+        .iter()
+        .filter(|s| s.visible && s.value.is_some())
+        .collect();
 
     // Sort descending safely
     valid_series.sort_by(|a, b| {
@@ -891,8 +907,11 @@ fn render_table(frame: &mut Frame, area: Rect, p: &PanelState, app: &AppState) {
         .filter(|s| s.visible)
         .map(|s| {
             let val_str = s.value.map(format_si).unwrap_or_else(|| "-".to_string());
-            let color = s.value.and_then(|v| p.get_color_for_value(v)).unwrap_or(theme.text);
-            
+            let color = s
+                .value
+                .and_then(|v| p.get_color_for_value(v))
+                .unwrap_or(theme.text);
+
             ratatui::widgets::Row::new(vec![
                 ratatui::text::Span::styled(s.name.clone(), Style::default().fg(theme.text)),
                 ratatui::text::Span::styled(val_str, Style::default().fg(color)),
@@ -947,11 +966,7 @@ fn render_stat(frame: &mut Frame, area: Rect, p: &PanelState, app: &AppState) {
     // Render Big Value
     let val_str = format_si(value);
     let big_value = Paragraph::new(val_str)
-        .style(
-            Style::default()
-                .fg(color)
-                .add_modifier(Modifier::BOLD),
-        )
+        .style(Style::default().fg(color).add_modifier(Modifier::BOLD))
         .alignment(Alignment::Center)
         .block(Block::default().borders(Borders::NONE));
 
@@ -1275,5 +1290,18 @@ mod tests {
         // So min should be 0.0 - 1.0 = -1.0.
         assert_eq!(bounds[0], -1.0);
         assert!(bounds[1] > 20.0);
+    }
+
+    #[test]
+    fn test_should_draw_threshold_on_cell_empty() {
+        let cell = ratatui::buffer::Cell::default();
+        assert!(should_draw_threshold_on_cell(&cell));
+    }
+
+    #[test]
+    fn test_should_draw_threshold_on_cell_filled() {
+        let mut cell = ratatui::buffer::Cell::default();
+        cell.set_char('x');
+        assert!(!should_draw_threshold_on_cell(&cell));
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -586,6 +586,7 @@ fn render_graph_panel(
     // Declare helper datasets to extend their lifetimes
     let mut cursor_dataset = vec![];
     let mut threshold_datasets = vec![];
+    let mut threshold_overlay_datasets = Vec::new();
 
     let mut threshold_labels_info = Vec::new();
 
@@ -646,7 +647,7 @@ fn render_graph_panel(
                 _ => (ratatui::symbols::Marker::Dot, GraphType::Line),
             };
 
-            chart_datasets.push(
+            threshold_overlay_datasets.push(
                 Dataset::default()
                     .name("")
                     .marker(marker)
@@ -740,27 +741,61 @@ fn render_graph_panel(
         .x_axis(
             Axis::default()
                 .bounds([start, now])
-                .labels(x_labels)
+                .labels(x_labels.clone())
                 .style(Style::default().fg(theme.text)),
         )
         .y_axis(
             Axis::default()
                 .style(Style::default().fg(Color::Gray))
                 .bounds(y_bounds)
-                .labels(y_labels),
+                .labels(y_labels.clone()),
         );
     // No legend position needed as we disabled names
 
     frame.render_widget(chart, chart_area);
 
+    let chart_left = chart_area.left() + y_max_width + 1; // +1 for the | axis line
+    let chart_right = chart_area.right();
+    let chart_bottom = chart_area.bottom().saturating_sub(2); // x-axis occupies last rows
+    let chart_top = chart_area.top();
+
+    // Render threshold markers after chart rendering by merging only onto blank cells.
+    // This guarantees data curves keep precedence wherever both map to the same terminal cell.
+    if !threshold_overlay_datasets.is_empty() && chart_top <= chart_bottom {
+        let threshold_chart = Chart::new(threshold_overlay_datasets)
+            .x_axis(
+                Axis::default()
+                    .bounds([start, now])
+                    .labels(x_labels)
+                    .style(Style::default().fg(theme.text)),
+            )
+            .y_axis(
+                Axis::default()
+                    .style(Style::default().fg(Color::Gray))
+                    .bounds(y_bounds)
+                    .labels(y_labels),
+            );
+
+        let mut threshold_buf = ratatui::buffer::Buffer::empty(chart_area);
+        threshold_chart.render(chart_area, &mut threshold_buf);
+
+        let buf = frame.buffer_mut();
+        for y in chart_top..=chart_bottom {
+            for x in chart_left..chart_right {
+                let Some(src_cell) = threshold_buf.cell((x, y)) else {
+                    continue;
+                };
+                if let Some(dst_cell) = buf.cell_mut((x, y)) {
+                    overlay_threshold_cell(dst_cell, src_cell);
+                }
+            }
+        }
+    }
+
     // Render custom raw lines by hijacking buffer space
     if app.threshold_marker.ends_with("line") && y_bounds[1] > y_bounds[0] {
         let buf = frame.buffer_mut();
 
-        let chart_left = chart_area.left() + y_max_width + 1; // +1 for the | axis line
-        let chart_right = chart_area.right();
-        let chart_bottom = chart_area.bottom().saturating_sub(2); // x-axis occupies last rows
-        let chart_top = chart_area.top();
         let chart_h = chart_bottom.saturating_sub(chart_top) as f64;
 
         if chart_h > 0.0 {
@@ -800,6 +835,12 @@ fn render_graph_panel(
 
 fn should_draw_threshold_on_cell(cell: &ratatui::buffer::Cell) -> bool {
     cell.symbol().chars().all(char::is_whitespace)
+}
+
+fn overlay_threshold_cell(dst: &mut ratatui::buffer::Cell, src: &ratatui::buffer::Cell) {
+    if should_draw_threshold_on_cell(dst) && !should_draw_threshold_on_cell(src) {
+        dst.set_symbol(src.symbol()).set_style(src.style());
+    }
 }
 
 fn render_gauge(frame: &mut Frame, area: Rect, p: &PanelState, app: &AppState) {
@@ -1303,5 +1344,31 @@ mod tests {
         let mut cell = ratatui::buffer::Cell::default();
         cell.set_char('x');
         assert!(!should_draw_threshold_on_cell(&cell));
+    }
+
+    #[test]
+    fn test_overlay_threshold_cell_copies_when_destination_is_empty() {
+        let mut dst = ratatui::buffer::Cell::default();
+        let mut src = ratatui::buffer::Cell::default();
+        src.set_char('-').set_style(Style::default().fg(Color::Red));
+
+        overlay_threshold_cell(&mut dst, &src);
+
+        assert_eq!(dst.symbol(), "-");
+        assert_eq!(dst.style().fg, Some(Color::Red));
+    }
+
+    #[test]
+    fn test_overlay_threshold_cell_keeps_existing_destination_marker() {
+        let mut dst = ratatui::buffer::Cell::default();
+        dst.set_char('x')
+            .set_style(Style::default().fg(Color::LightBlue));
+        let mut src = ratatui::buffer::Cell::default();
+        src.set_char('-').set_style(Style::default().fg(Color::Red));
+
+        overlay_threshold_cell(&mut dst, &src);
+
+        assert_eq!(dst.symbol(), "x");
+        assert_eq!(dst.style().fg, Some(Color::LightBlue));
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -684,10 +684,10 @@ fn render_gauge(frame: &mut Frame, area: Rect, p: &PanelState, app: &AppState) {
         .find_map(|s| s.value.map(|v| (v, s.name.clone())))
         .unwrap_or((0.0, "No data".to_string()));
 
-    // Determine bounds (simple auto-scale for now, 0 to max(100, value))
-    // TODO: Support min/max from Grafana config
-    let min = 0.0;
-    let max = if value > 100.0 { value * 1.2 } else { 100.0 };
+    let min = p.min.unwrap_or(0.0);
+    let max = p.max.unwrap_or_else(|| if value > 100.0 { value * 1.2 } else { 100.0 });
+    
+    let color = p.get_color_for_value(value).unwrap_or(theme.palette[0]);
 
     let ratio = if max > min {
         ((value - min) / (max - min)).clamp(0.0, 1.0)
@@ -697,7 +697,7 @@ fn render_gauge(frame: &mut Frame, area: Rect, p: &PanelState, app: &AppState) {
 
     let gauge = ratatui::widgets::Gauge::default()
         .block(Block::default().borders(Borders::NONE))
-        .gauge_style(Style::default().fg(theme.palette[0]).bg(Color::DarkGray))
+        .gauge_style(Style::default().fg(color).bg(Color::DarkGray))
         .ratio(ratio)
         .label(format!("{} ({})", format_si(value), name));
 
@@ -707,27 +707,33 @@ fn render_gauge(frame: &mut Frame, area: Rect, p: &PanelState, app: &AppState) {
 fn render_bar_gauge(frame: &mut Frame, area: Rect, p: &PanelState, app: &AppState) {
     let theme = &app.theme;
 
-    // Collect latest values from all visible series
-    let data: Vec<(&str, u64)> = p
-        .series
-        .iter()
-        .filter(|s| s.visible)
-        .filter_map(|s| s.value.map(|v| (s.name.as_str(), v as u64)))
-        .collect();
+    let mut bars = Vec::new();
 
-    if data.is_empty() {
+    for s in p.series.iter().filter(|s| s.visible) {
+        if let Some(v) = s.value {
+            let color = p.get_color_for_value(v).unwrap_or(theme.palette[0]);
+            let bar = ratatui::widgets::Bar::default()
+                .value(v as u64)
+                .label(ratatui::text::Line::from(s.name.as_str()))
+                .style(Style::default().fg(color))
+                .value_style(Style::default().fg(theme.text).bg(color));
+            bars.push(bar);
+        }
+    }
+
+    if bars.is_empty() {
         let para = Paragraph::new("No data").style(Style::default().fg(theme.text));
         frame.render_widget(para, area);
         return;
     }
 
+    let bar_group = ratatui::widgets::BarGroup::default().bars(&bars);
+
     let bar_chart = ratatui::widgets::BarChart::default()
         .block(Block::default().borders(Borders::NONE))
-        .data(&data)
+        .data(bar_group)
         .bar_width(3)
-        .bar_gap(1)
-        .bar_style(Style::default().fg(theme.palette[0]))
-        .value_style(Style::default().fg(theme.text).bg(theme.palette[0]));
+        .bar_gap(1);
 
     frame.render_widget(bar_chart, area);
 }
@@ -742,8 +748,12 @@ fn render_table(frame: &mut Frame, area: Rect, p: &PanelState, app: &AppState) {
         .filter(|s| s.visible)
         .map(|s| {
             let val_str = s.value.map(format_si).unwrap_or_else(|| "-".to_string());
-            ratatui::widgets::Row::new(vec![s.name.clone(), val_str])
-                .style(Style::default().fg(theme.text))
+            let color = s.value.and_then(|v| p.get_color_for_value(v)).unwrap_or(theme.text);
+            
+            ratatui::widgets::Row::new(vec![
+                ratatui::text::Span::styled(s.name.clone(), Style::default().fg(theme.text)),
+                ratatui::text::Span::styled(val_str, Style::default().fg(color)),
+            ])
         })
         .collect();
 
@@ -783,6 +793,8 @@ fn render_stat(frame: &mut Frame, area: Rect, p: &PanelState, app: &AppState) {
         .find_map(|s| s.value.map(|v| (v, s.name.clone())))
         .unwrap_or((0.0, "No data".to_string()));
 
+    let color = p.get_color_for_value(value).unwrap_or(theme.palette[0]);
+
     // Split area into value (top) and sparkline (bottom)
     let chunks = Layout::default()
         .direction(Direction::Vertical)
@@ -794,26 +806,21 @@ fn render_stat(frame: &mut Frame, area: Rect, p: &PanelState, app: &AppState) {
     let big_value = Paragraph::new(val_str)
         .style(
             Style::default()
-                .fg(theme.palette[0])
+                .fg(color)
                 .add_modifier(Modifier::BOLD),
         )
         .alignment(Alignment::Center)
-        .block(Block::default().borders(Borders::NONE)); // Centered vertically?
-
-    // To center vertically, we might need another layout or just rely on the font size/area
-    // Ratatui doesn't have vertical alignment for Paragraph yet (except via padding)
-    // But for now, top alignment is fine or we can pad it.
+        .block(Block::default().borders(Borders::NONE));
 
     frame.render_widget(big_value, chunks[0]);
 
     // Render Sparkline
-    // Collect data points from the first series
     if let Some(s) = p.series.iter().find(|s| s.visible && s.name == name) {
         let data: Vec<u64> = s.points.iter().map(|(_, v)| *v as u64).collect();
         let sparkline = ratatui::widgets::Sparkline::default()
             .block(Block::default().borders(Borders::NONE))
             .data(&data)
-            .style(Style::default().fg(theme.palette[0]));
+            .style(Style::default().fg(color));
         frame.render_widget(sparkline, chunks[1]);
     }
 }
@@ -1058,6 +1065,9 @@ mod tests {
             grid: None,
             y_axis_mode: YAxisMode::Auto,
             panel_type: crate::app::PanelType::Graph,
+            thresholds: None,
+            min: None,
+            max: None,
         }
     }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -620,14 +620,26 @@ fn render_graph_panel(
         }
         
         for (i, step) in th.steps.iter().filter(|s| s.value.is_some()).enumerate() {
+            if app.threshold_marker.ends_with("line") {
+                // Skips dataset rendering; handled via post-render buffer overwrite
+                continue;
+            }
+
             let (marker, graph_type) = match app.threshold_marker.to_lowercase().as_str() {
                 "braille" => (ratatui::symbols::Marker::Braille, GraphType::Line),
                 "block" => (ratatui::symbols::Marker::Block, GraphType::Line),
                 "bar" => (ratatui::symbols::Marker::Bar, GraphType::Line),
                 "half-block" => (ratatui::symbols::Marker::HalfBlock, GraphType::Line),
+                "quadrant" => (ratatui::symbols::Marker::Quadrant, GraphType::Line),
+                "sextant" => (ratatui::symbols::Marker::Sextant, GraphType::Line),
+                "octant" => (ratatui::symbols::Marker::Octant, GraphType::Line),
                 "dashed" | "dashed-braille" => (ratatui::symbols::Marker::Braille, GraphType::Scatter),
                 "dashed-block" => (ratatui::symbols::Marker::Block, GraphType::Scatter),
                 "dashed-bar" => (ratatui::symbols::Marker::Bar, GraphType::Scatter),
+                "dashed-half-block" => (ratatui::symbols::Marker::HalfBlock, GraphType::Scatter),
+                "dashed-quadrant" => (ratatui::symbols::Marker::Quadrant, GraphType::Scatter),
+                "dashed-sextant" => (ratatui::symbols::Marker::Sextant, GraphType::Scatter),
+                "dashed-octant" => (ratatui::symbols::Marker::Octant, GraphType::Scatter),
                 "dashed-dot" => (ratatui::symbols::Marker::Dot, GraphType::Scatter),
                 _ => (ratatui::symbols::Marker::Dot, GraphType::Line),
             };
@@ -707,15 +719,18 @@ fn render_graph_panel(
     y_labels[y_axis_height - 1] = Span::styled(format_si(y_bounds[1]), Style::default().fg(theme.text));
     
     if y_bounds[1] > y_bounds[0] {
-        for (th_val, color) in threshold_labels_info {
-            if th_val > y_bounds[0] && th_val < y_bounds[1] {
-                let ratio = (th_val - y_bounds[0]) / (y_bounds[1] - y_bounds[0]);
+        for (th_val, color) in &threshold_labels_info {
+            if *th_val > y_bounds[0] && *th_val < y_bounds[1] {
+                let ratio = (*th_val - y_bounds[0]) / (y_bounds[1] - y_bounds[0]);
                 let index = (ratio * (y_axis_height - 1) as f64).round() as usize;
                 let index = index.min(y_axis_height - 2).max(1);
-                y_labels[index] = Span::styled(format_si(th_val), Style::default().fg(color));
+                y_labels[index] = Span::styled(format_si(*th_val), Style::default().fg(*color));
             }
         }
     }
+
+    // Evaluate y_max_width before moving y_labels into Chart block
+    let y_max_width = y_labels.iter().map(|s| s.width() as u16).max().unwrap_or(0);
 
     let chart = Chart::new(chart_datasets)
         // No block, as we rendered it outside
@@ -734,6 +749,41 @@ fn render_graph_panel(
     // No legend position needed as we disabled names
 
     frame.render_widget(chart, chart_area);
+
+    // Render custom raw lines by hijacking buffer space
+    if app.threshold_marker.ends_with("line") && y_bounds[1] > y_bounds[0] {
+        let buf = frame.buffer_mut();
+        
+        let chart_left = chart_area.left() + y_max_width + 1; // +1 for the | axis line
+        let chart_right = chart_area.right();
+        let chart_bottom = chart_area.bottom().saturating_sub(2); // x-axis occupies last rows
+        let chart_top = chart_area.top();
+        let chart_h = chart_bottom.saturating_sub(chart_top) as f64;
+    
+        if chart_h > 0.0 {
+            let is_dashed = app.threshold_marker.starts_with("dashed");
+            let line_char = if is_dashed { '-' } else { '─' };
+            
+            for (th_val, color) in &threshold_labels_info {
+                if *th_val > y_bounds[0] && *th_val < y_bounds[1] {
+                    let ratio = (*th_val - y_bounds[0]) / (y_bounds[1] - y_bounds[0]);
+                    let y_offset = (ratio * chart_h).round() as u16;
+                    let phys_y = chart_bottom.saturating_sub(y_offset);
+    
+                    if phys_y >= chart_top && phys_y <= chart_bottom {
+                        for x in chart_left..chart_right {
+                            if is_dashed && x % 2 == 0 {
+                                continue;
+                            }
+                            if let Some(cell) = buf.cell_mut((x, phys_y)) {
+                                cell.set_char(line_char).set_style(Style::default().fg(*color));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
 
     // Render custom legend
     if legend_height > 0 {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -587,6 +587,8 @@ fn render_graph_panel(
     let mut cursor_dataset = vec![];
     let mut threshold_datasets = vec![];
 
+    let mut threshold_labels_info = Vec::new();
+
     // Generate threshold limit lines
     if let Some(th) = &p.thresholds {
         for step in th.steps.iter().filter(|s| s.value.is_some()) {
@@ -599,15 +601,42 @@ fn render_graph_panel(
                     min + (val / 100.0) * (max - min)
                 }
             };
-            threshold_datasets.push(vec![(start, abs_val), (now, abs_val)]);
+            
+            let mut dataset = Vec::new();
+            if app.threshold_marker.starts_with("dashed") || th.style.as_deref() == Some("dashed") {
+                let points_count = 15; // 15 evenly spaced ticks across any width length
+                let step_x = (now - start) / points_count as f64;
+                for i in 0..=points_count {
+                    let x = start + (i as f64 * step_x);
+                    dataset.push((x, abs_val));
+                }
+            } else {
+                dataset.push((start, abs_val));
+                dataset.push((now, abs_val));
+            }
+            
+            threshold_datasets.push(dataset);
+            threshold_labels_info.push((abs_val, step.color));
         }
         
         for (i, step) in th.steps.iter().filter(|s| s.value.is_some()).enumerate() {
+            let (marker, graph_type) = match app.threshold_marker.to_lowercase().as_str() {
+                "braille" => (ratatui::symbols::Marker::Braille, GraphType::Line),
+                "block" => (ratatui::symbols::Marker::Block, GraphType::Line),
+                "bar" => (ratatui::symbols::Marker::Bar, GraphType::Line),
+                "half-block" => (ratatui::symbols::Marker::HalfBlock, GraphType::Line),
+                "dashed" | "dashed-braille" => (ratatui::symbols::Marker::Braille, GraphType::Scatter),
+                "dashed-block" => (ratatui::symbols::Marker::Block, GraphType::Scatter),
+                "dashed-bar" => (ratatui::symbols::Marker::Bar, GraphType::Scatter),
+                "dashed-dot" => (ratatui::symbols::Marker::Dot, GraphType::Scatter),
+                _ => (ratatui::symbols::Marker::Dot, GraphType::Line),
+            };
+            
             chart_datasets.push(
                 Dataset::default()
                     .name("")
-                    .marker(ratatui::symbols::Marker::Dot)
-                    .graph_type(GraphType::Line)
+                    .marker(marker)
+                    .graph_type(graph_type)
                     .style(Style::default().fg(step.color))
                     .data(&threshold_datasets[i]),
             );
@@ -671,10 +700,22 @@ fn render_graph_panel(
         Span::styled(format_time(now), Style::default().fg(theme.text)),
     ];
 
-    let y_labels = vec![
-        Span::styled(format_si(y_bounds[0]), Style::default().fg(theme.text)),
-        Span::styled(format_si(y_bounds[1]), Style::default().fg(theme.text)),
-    ];
+    let y_axis_height = chart_area.height.saturating_sub(1).max(2) as usize;
+    let mut y_labels = vec![Span::raw(""); y_axis_height];
+    
+    y_labels[0] = Span::styled(format_si(y_bounds[0]), Style::default().fg(theme.text));
+    y_labels[y_axis_height - 1] = Span::styled(format_si(y_bounds[1]), Style::default().fg(theme.text));
+    
+    if y_bounds[1] > y_bounds[0] {
+        for (th_val, color) in threshold_labels_info {
+            if th_val > y_bounds[0] && th_val < y_bounds[1] {
+                let ratio = (th_val - y_bounds[0]) / (y_bounds[1] - y_bounds[0]);
+                let index = (ratio * (y_axis_height - 1) as f64).round() as usize;
+                let index = index.min(y_axis_height - 2).max(1);
+                y_labels[index] = Span::styled(format_si(th_val), Style::default().fg(color));
+            }
+        }
+    }
 
     let chart = Chart::new(chart_datasets)
         // No block, as we rendered it outside


### PR DESCRIPTION
## Description

This PR delivers full Grafana threshold support across parsing, state, and rendering, and fixes the visual overlap issue where dashed threshold lines could reduce curve legibility at intersections.

Main changes included in this branch:
- Parse Grafana `fieldConfig.defaults.thresholds`, `min`, and `max` from imported dashboards.
- Add threshold domain models (`ThresholdMode`, `ThresholdStep`, `Thresholds`) and value-to-threshold color resolution in panel state.
- Render threshold limit lines on graph panels with configurable markers/styles.
- Add configurable threshold markers via CLI/config (`--threshold-marker` / `threshold_marker`), with support for additional marker families (including `quadrant`, `sextant`, `octant`) and line-style rendering.
- Fix threshold overlay behavior for line markers: threshold characters are now drawn only on empty cells, so existing data curve glyphs are preserved.
- Apply threshold-based coloring to additional widgets (stat, gauge, bar gauge, table values).
- Add/update docs and compatibility matrix for threshold support and marker configuration.
- Upgrade `ratatui` to `0.30.0` (with lockfile update).

Fixes #22

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have used Conventional Commits for my commit messages