### PR TITLE
28 implement auto grid for graphs

### DIFF
--- a/GRAFANA_COMPATIBILITY.md
+++ b/GRAFANA_COMPATIBILITY.md
@@ -172,7 +172,7 @@ This document provides a comprehensive feature-parity table between the [Grafana
 | `fieldConfig.defaults.mappings` | ❌ Not Implemented | Value mappings not supported |
 | `fieldConfig.defaults.noValue` | ❌ Not Implemented | |
 | `fieldConfig.defaults.displayName` | ❌ Not Implemented | |
-| `fieldConfig.defaults.custom` | ❌ Not Implemented | |
+| `fieldConfig.defaults.custom` | 🟡 Partially Supported | Used for thresholds style and axis grid visibility |
 | `fieldConfig.defaults.custom.drawStyle` | ❌ Not Implemented | Always drawn as lines |
 | `fieldConfig.defaults.custom.lineWidth` | ❌ Not Implemented | TUI limitation |
 | `fieldConfig.defaults.custom.fillOpacity` | ⛔ Not Applicable | TUI limitation |
@@ -180,6 +180,7 @@ This document provides a comprehensive feature-parity table between the [Grafana
 | `fieldConfig.defaults.custom.stacking` | ❌ Not Implemented | No stacked charts |
 | `fieldConfig.defaults.custom.axisPlacement` | ❌ Not Implemented | |
 | `fieldConfig.defaults.custom.axisLabel` | ❌ Not Implemented | |
+| `fieldConfig.defaults.custom.axisGridShow` | ✅ Supported | Controls per-panel autogrid guide lines for graph/time-series panels |
 | `fieldConfig.defaults.custom.scaleDistribution` | ❌ Not Implemented | Always linear |
 | `fieldConfig.overrides` | ❌ Not Implemented | |
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ refresh_rate = 1000
 time_range = "1h"
 theme = "dracula"
 threshold_marker = "dashed"
+autogrid = true
 grafana_json = "~/.config/grafatui/my-dashboard.json"
 ```
 
@@ -207,6 +208,7 @@ grafatui --config examples/demo/grafatui.toml
 | `PgUp` / `PgDn` | Scroll vertically |
 | `Home` / `End` | Jump to top / bottom |
 | `y` | Toggle Y-axis mode |
+| `g` | Toggle autogrid guide lines |
 | `1`..`9` | Toggle series visibility |
 | `f` / `Enter` | Fullscreen mode |
 | `v` | Value inspection mode |

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ grafatui [OPTIONS]
 | `--var <KEY=VALUE>` | Override dashboard variables | - |
 | `--theme <NAME>` | UI theme | `default` |
 | `--threshold-marker <MARKER>` | Marker for threshold lines (`dashed`, `dot`, `block`, `quadrant`, etc.) | `dashed` |
+| `--autogrid-color <COLOR>` | Color for autogrid lines and labels (`gray`, `dark-gray`, `#666666`, etc.) | `dark-gray` |
 | `--refresh-rate <MS>` | Data fetch interval (milliseconds) | `1000` |
 | `--config <FILE>` | Custom config file path | - |
 
@@ -158,6 +159,7 @@ time_range = "1h"
 theme = "dracula"
 threshold_marker = "dashed"
 autogrid = true
+autogrid_color = "dark-gray"
 grafana_json = "~/.config/grafatui/my-dashboard.json"
 ```
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -222,6 +222,8 @@ pub struct AppState {
     pub threshold_marker: String,
     /// Global runtime toggle for automatic grid rendering.
     pub autogrid_enabled: bool,
+    /// Color used for automatic grid lines and labels.
+    pub autogrid_color: Color,
 }
 
 impl AppState {
@@ -270,6 +272,7 @@ impl AppState {
             cursor_x: None,
             threshold_marker,
             autogrid_enabled: true,
+            autogrid_color: Color::DarkGray,
         }
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -54,6 +54,8 @@ pub struct PanelState {
     pub min: Option<f64>,
     /// Optional maximum value for gauge and thresholds.
     pub max: Option<f64>,
+    /// Whether to render automatic grid lines for this panel.
+    pub autogrid: Option<bool>,
 }
 
 /// Visualization types supported by Grafatui.
@@ -218,6 +220,8 @@ pub struct AppState {
     pub cursor_x: Option<f64>,
     /// Global marker set for rendering thresholds
     pub threshold_marker: String,
+    /// Global runtime toggle for automatic grid rendering.
+    pub autogrid_enabled: bool,
 }
 
 impl AppState {
@@ -233,6 +237,7 @@ impl AppState {
     /// * `panels` - The list of panels to display.
     /// * `skipped_panels` - The count of panels that were skipped during import.
     /// * `theme` - The UI theme to use.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         prometheus: prom::PromClient,
         range: Duration,
@@ -264,12 +269,13 @@ impl AppState {
             search_results: Vec::new(),
             cursor_x: None,
             threshold_marker,
+            autogrid_enabled: true,
         }
     }
 
     /// Zoom in: halve the time range.
     pub fn zoom_in(&mut self) {
-        self.range = self.range / 2;
+        self.range /= 2;
         if self.range < Duration::from_secs(10) {
             self.range = Duration::from_secs(10);
         }
@@ -277,7 +283,7 @@ impl AppState {
 
     /// Zoom out: double the time range.
     pub fn zoom_out(&mut self) {
-        self.range = self.range * 2;
+        self.range *= 2;
         self.range = self.range.min(Duration::from_secs(7 * 24 * 3600));
     }
 
@@ -490,102 +496,6 @@ fn downsample(points: Vec<(f64, f64)>, max_points: usize) -> Vec<(f64, f64)> {
         .collect()
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_expand_expr_rate_interval() {
-        let vars = HashMap::new();
-        let step = Duration::from_secs(15);
-        // heuristic: max(15*4, 60) = 60s
-        let expr = "rate(http_requests_total[$__rate_interval])";
-        let expanded = expand_expr(expr, step, &vars);
-        assert_eq!(expanded, "rate(http_requests_total[60s])");
-
-        let step = Duration::from_secs(30);
-        // heuristic: max(30*4, 60) = 120s
-        let expr = "rate(http_requests_total[$__rate_interval])";
-        let expanded = expand_expr(expr, step, &vars);
-        assert_eq!(expanded, "rate(http_requests_total[120s])");
-    }
-
-    #[test]
-    fn test_expand_expr_vars() {
-        let mut vars = HashMap::new();
-        vars.insert("job".to_string(), "node-exporter".to_string());
-        vars.insert("instance".to_string(), "localhost:9100".to_string());
-
-        let step = Duration::from_secs(15);
-
-        // Test $var
-        let expr = "up{job=\"$job\"}";
-        let expanded = expand_expr(expr, step, &vars);
-        assert_eq!(expanded, "up{job=\"node-exporter\"}");
-
-        // Test ${var}
-        let expr = "up{instance=\"${instance}\"}";
-        let expanded = expand_expr(expr, step, &vars);
-        assert_eq!(expanded, "up{instance=\"localhost:9100\"}");
-
-        // Test multiple vars
-        let expr =
-            "rate(http_requests_total{job=\"$job\", instance=\"$instance\"}[$__rate_interval])";
-        let expanded = expand_expr(expr, step, &vars);
-        assert_eq!(
-            expanded,
-            "rate(http_requests_total{job=\"node-exporter\", instance=\"localhost:9100\"}[60s])"
-        );
-    }
-
-    #[test]
-    fn test_format_legend() {
-        let mut metric = HashMap::new();
-        metric.insert("job".to_string(), "node".to_string());
-        metric.insert("instance".to_string(), "localhost".to_string());
-
-        let fmt = "Job: {{job}} - {{instance}}";
-        assert_eq!(format_legend(fmt, &metric), "Job: node - localhost");
-
-        let fmt2 = "Static Text";
-        assert_eq!(format_legend(fmt2, &metric), "Static Text");
-    }
-
-    #[test]
-    fn test_downsample() {
-        let points: Vec<(f64, f64)> = (0..1000).map(|i| (i as f64, i as f64)).collect();
-        let downsampled = downsample(points, 100);
-        assert_eq!(downsampled.len(), 100);
-        assert_eq!(downsampled.last().unwrap().1, 999.0);
-    }
-
-    #[tokio::test]
-    async fn test_empty_panels() {
-        let prom = prom::PromClient::new("http://localhost:9090".to_string());
-        let mut app = AppState::new(
-            prom,
-            Duration::from_secs(3600),
-            Duration::from_secs(60),
-            Duration::from_millis(1000),
-            "Test".to_string(),
-            vec![], // Empty panels
-            0,
-            Theme::default(),
-            "dashed".to_string(),
-        );
-
-        // Should not panic on refresh
-        assert!(app.refresh().await.is_ok());
-
-        // Check navigation safety
-        app.scroll_to_selected_panel();
-        assert_eq!(app.selected_panel, 0);
-
-        // Check cursor movement
-        app.move_cursor(1);
-    }
-}
-
 pub fn default_queries(mut provided: Vec<String>) -> Vec<PanelState> {
     if provided.is_empty() {
         provided = vec![
@@ -610,6 +520,7 @@ pub fn default_queries(mut provided: Vec<String>) -> Vec<PanelState> {
             thresholds: None,
             min: None,
             max: None,
+            autogrid: None,
         })
         .collect()
 }
@@ -727,29 +638,21 @@ where
                                 app.zoom_in();
                                 app.refresh().await?;
                             }
-                            KeyCode::Char('[') => {
-                                if key.modifiers.contains(KeyModifiers::SHIFT) {
-                                    app.pan_left();
-                                    app.refresh().await?;
-                                }
+                            KeyCode::Char('[') if key.modifiers.contains(KeyModifiers::SHIFT) => {
+                                app.pan_left();
+                                app.refresh().await?;
                             }
-                            KeyCode::Left => {
-                                if key.modifiers.contains(KeyModifiers::SHIFT) {
-                                    app.pan_left();
-                                    app.refresh().await?;
-                                }
+                            KeyCode::Left if key.modifiers.contains(KeyModifiers::SHIFT) => {
+                                app.pan_left();
+                                app.refresh().await?;
                             }
-                            KeyCode::Char(']') => {
-                                if key.modifiers.contains(KeyModifiers::SHIFT) {
-                                    app.pan_right();
-                                    app.refresh().await?;
-                                }
+                            KeyCode::Char(']') if key.modifiers.contains(KeyModifiers::SHIFT) => {
+                                app.pan_right();
+                                app.refresh().await?;
                             }
-                            KeyCode::Right => {
-                                if key.modifiers.contains(KeyModifiers::SHIFT) {
-                                    app.pan_right();
-                                    app.refresh().await?;
-                                }
+                            KeyCode::Right if key.modifiers.contains(KeyModifiers::SHIFT) => {
+                                app.pan_right();
+                                app.refresh().await?;
                             }
                             KeyCode::Char('0') => {
                                 app.reset_to_live();
@@ -763,6 +666,9 @@ where
                                     };
                                 }
                             }
+                            KeyCode::Char('g') => {
+                                app.autogrid_enabled = !app.autogrid_enabled;
+                            }
                             _ => {}
                         }
                     } else if app.mode == AppMode::FullscreenInspect {
@@ -770,6 +676,9 @@ where
                             KeyCode::Esc | KeyCode::Char('v') => {
                                 app.mode = AppMode::Fullscreen;
                                 app.cursor_x = None;
+                            }
+                            KeyCode::Char('g') => {
+                                app.autogrid_enabled = !app.autogrid_enabled;
                             }
                             KeyCode::Left => {
                                 app.move_cursor(-1);
@@ -798,19 +707,17 @@ where
                             KeyCode::Char('r') | KeyCode::Char('R') => {
                                 app.refresh().await?;
                             }
-                            KeyCode::Up | KeyCode::Char('k') => {
-                                if app.selected_panel > 0 {
-                                    app.selected_panel -= 1;
-                                    // Auto-scroll to ensure selected panel is visible
-                                    app.scroll_to_selected_panel();
-                                }
+                            KeyCode::Up | KeyCode::Char('k') if app.selected_panel > 0 => {
+                                app.selected_panel -= 1;
+                                // Auto-scroll to ensure selected panel is visible
+                                app.scroll_to_selected_panel();
                             }
-                            KeyCode::Down | KeyCode::Char('j') => {
-                                if app.selected_panel < app.panels.len().saturating_sub(1) {
-                                    app.selected_panel += 1;
-                                    // Auto-scroll to ensure selected panel is visible
-                                    app.scroll_to_selected_panel();
-                                }
+                            KeyCode::Down | KeyCode::Char('j')
+                                if app.selected_panel < app.panels.len().saturating_sub(1) =>
+                            {
+                                app.selected_panel += 1;
+                                // Auto-scroll to ensure selected panel is visible
+                                app.scroll_to_selected_panel();
                             }
                             KeyCode::PageUp => {
                                 app.vertical_scroll = app.vertical_scroll.saturating_sub(10);
@@ -818,7 +725,7 @@ where
                             KeyCode::PageDown => {
                                 app.vertical_scroll = app.vertical_scroll.saturating_add(10);
                             }
-                            KeyCode::Char(c) if c.is_digit(10) => {
+                            KeyCode::Char(c) if c.is_ascii_digit() => {
                                 if let Some(digit) = c.to_digit(10) {
                                     if let Some(panel) = app.panels.get_mut(app.selected_panel) {
                                         if digit == 0 {
@@ -844,6 +751,9 @@ where
                                     };
                                 }
                             }
+                            KeyCode::Char('g') => {
+                                app.autogrid_enabled = !app.autogrid_enabled;
+                            }
                             KeyCode::Home => {
                                 app.vertical_scroll = 0;
                             }
@@ -858,29 +768,21 @@ where
                                 app.zoom_in();
                                 app.refresh().await?;
                             }
-                            KeyCode::Char('[') => {
-                                if key.modifiers.contains(KeyModifiers::SHIFT) {
-                                    app.pan_left();
-                                    app.refresh().await?;
-                                }
+                            KeyCode::Char('[') if key.modifiers.contains(KeyModifiers::SHIFT) => {
+                                app.pan_left();
+                                app.refresh().await?;
                             }
-                            KeyCode::Left => {
-                                if key.modifiers.contains(KeyModifiers::SHIFT) {
-                                    app.pan_left();
-                                    app.refresh().await?;
-                                }
+                            KeyCode::Left if key.modifiers.contains(KeyModifiers::SHIFT) => {
+                                app.pan_left();
+                                app.refresh().await?;
                             }
-                            KeyCode::Char(']') => {
-                                if key.modifiers.contains(KeyModifiers::SHIFT) {
-                                    app.pan_right();
-                                    app.refresh().await?;
-                                }
+                            KeyCode::Char(']') if key.modifiers.contains(KeyModifiers::SHIFT) => {
+                                app.pan_right();
+                                app.refresh().await?;
                             }
-                            KeyCode::Right => {
-                                if key.modifiers.contains(KeyModifiers::SHIFT) {
-                                    app.pan_right();
-                                    app.refresh().await?;
-                                }
+                            KeyCode::Right if key.modifiers.contains(KeyModifiers::SHIFT) => {
+                                app.pan_right();
+                                app.refresh().await?;
                             }
                             KeyCode::Char('0') => {
                                 app.reset_to_live();
@@ -959,5 +861,101 @@ where
         }
 
         sleep(Duration::from_millis(10)).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_expand_expr_rate_interval() {
+        let vars = HashMap::new();
+        let step = Duration::from_secs(15);
+        // heuristic: max(15*4, 60) = 60s
+        let expr = "rate(http_requests_total[$__rate_interval])";
+        let expanded = expand_expr(expr, step, &vars);
+        assert_eq!(expanded, "rate(http_requests_total[60s])");
+
+        let step = Duration::from_secs(30);
+        // heuristic: max(30*4, 60) = 120s
+        let expr = "rate(http_requests_total[$__rate_interval])";
+        let expanded = expand_expr(expr, step, &vars);
+        assert_eq!(expanded, "rate(http_requests_total[120s])");
+    }
+
+    #[test]
+    fn test_expand_expr_vars() {
+        let mut vars = HashMap::new();
+        vars.insert("job".to_string(), "node-exporter".to_string());
+        vars.insert("instance".to_string(), "localhost:9100".to_string());
+
+        let step = Duration::from_secs(15);
+
+        // Test $var
+        let expr = "up{job=\"$job\"}";
+        let expanded = expand_expr(expr, step, &vars);
+        assert_eq!(expanded, "up{job=\"node-exporter\"}");
+
+        // Test ${var}
+        let expr = "up{instance=\"${instance}\"}";
+        let expanded = expand_expr(expr, step, &vars);
+        assert_eq!(expanded, "up{instance=\"localhost:9100\"}");
+
+        // Test multiple vars
+        let expr =
+            "rate(http_requests_total{job=\"$job\", instance=\"$instance\"}[$__rate_interval])";
+        let expanded = expand_expr(expr, step, &vars);
+        assert_eq!(
+            expanded,
+            "rate(http_requests_total{job=\"node-exporter\", instance=\"localhost:9100\"}[60s])"
+        );
+    }
+
+    #[test]
+    fn test_format_legend() {
+        let mut metric = HashMap::new();
+        metric.insert("job".to_string(), "node".to_string());
+        metric.insert("instance".to_string(), "localhost".to_string());
+
+        let fmt = "Job: {{job}} - {{instance}}";
+        assert_eq!(format_legend(fmt, &metric), "Job: node - localhost");
+
+        let fmt2 = "Static Text";
+        assert_eq!(format_legend(fmt2, &metric), "Static Text");
+    }
+
+    #[test]
+    fn test_downsample() {
+        let points: Vec<(f64, f64)> = (0..1000).map(|i| (i as f64, i as f64)).collect();
+        let downsampled = downsample(points, 100);
+        assert_eq!(downsampled.len(), 100);
+        assert_eq!(downsampled.last().unwrap().1, 999.0);
+    }
+
+    #[tokio::test]
+    async fn test_empty_panels() {
+        let prom = prom::PromClient::new("http://localhost:9090".to_string());
+        let mut app = AppState::new(
+            prom,
+            Duration::from_secs(3600),
+            Duration::from_secs(60),
+            Duration::from_millis(1000),
+            "Test".to_string(),
+            vec![], // Empty panels
+            0,
+            Theme::default(),
+            "dashed".to_string(),
+        );
+
+        // Should not panic on refresh
+        assert!(app.refresh().await.is_ok());
+
+        // Check navigation safety
+        app.scroll_to_selected_panel();
+        assert_eq!(app.selected_panel, 0);
+
+        // Check cursor movement
+        app.move_cursor(1);
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -49,6 +49,10 @@ pub struct Args {
     #[arg(long, value_name = "MARKER")]
     pub threshold_marker: Option<String>,
 
+    /// Color to use for automatic grid lines and labels (e.g., gray, dark-gray, #666666).
+    #[arg(long, value_name = "COLOR")]
+    pub autogrid_color: Option<String>,
+
     /// Configuration file path (e.g., ./grafatui.toml).
     #[arg(long, value_name = "FILE")]
     pub config: Option<PathBuf>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,6 +30,7 @@ pub struct Config {
     pub theme: Option<String>,
     pub grafana_json: Option<PathBuf>,
     pub threshold_marker: Option<String>,
+    pub autogrid: Option<bool>,
     pub vars: Option<HashMap<String, String>>,
 }
 
@@ -96,6 +97,7 @@ mod tests {
             prometheus_url = "http://localhost:9090"
             refresh_rate = 5000
             theme = "dracula"
+            autogrid = false
         "#;
         let config: Config = toml::from_str(toml_str).unwrap();
         assert_eq!(
@@ -104,6 +106,7 @@ mod tests {
         );
         assert_eq!(config.refresh_rate, Some(5000));
         assert_eq!(config.theme, Some("dracula".to_string()));
+        assert_eq!(config.autogrid, Some(false));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,6 +31,7 @@ pub struct Config {
     pub grafana_json: Option<PathBuf>,
     pub threshold_marker: Option<String>,
     pub autogrid: Option<bool>,
+    pub autogrid_color: Option<String>,
     pub vars: Option<HashMap<String, String>>,
 }
 
@@ -98,6 +99,7 @@ mod tests {
             refresh_rate = 5000
             theme = "dracula"
             autogrid = false
+            autogrid_color = "gray"
         "#;
         let config: Config = toml::from_str(toml_str).unwrap();
         assert_eq!(
@@ -107,6 +109,7 @@ mod tests {
         assert_eq!(config.refresh_rate, Some(5000));
         assert_eq!(config.theme, Some("dracula".to_string()));
         assert_eq!(config.autogrid, Some(false));
+        assert_eq!(config.autogrid_color, Some("gray".to_string()));
     }
 
     #[test]

--- a/src/grafana.rs
+++ b/src/grafana.rs
@@ -42,6 +42,7 @@ pub struct QueryPanel {
     pub thresholds: Option<crate::app::Thresholds>,
     pub min: Option<f64>,
     pub max: Option<f64>,
+    pub autogrid: Option<bool>,
 }
 
 /// Grid position extracted from Grafana.
@@ -109,6 +110,8 @@ struct RawFieldConfigDefaults {
 
 #[derive(Debug, Deserialize)]
 struct RawCustom {
+    #[serde(rename = "axisGridShow")]
+    axis_grid_show: Option<bool>,
     #[serde(rename = "thresholdsStyle")]
     thresholds_style: Option<RawThresholdsStyle>,
 }
@@ -239,11 +242,16 @@ fn collect_panels(out: &mut DashboardImport, panels: Vec<RawPanel>) -> Result<()
             let mut thresholds = None;
             let mut min = None;
             let mut max = None;
+            let mut autogrid = None;
 
             if let Some(fc) = p.field_config {
                 if let Some(defaults) = fc.defaults {
                     min = defaults.min;
                     max = defaults.max;
+                    autogrid = defaults
+                        .custom
+                        .as_ref()
+                        .and_then(|custom| custom.axis_grid_show);
 
                     if let Some(th) = defaults.thresholds {
                         let mode = match th.mode.as_deref() {
@@ -303,6 +311,7 @@ fn collect_panels(out: &mut DashboardImport, panels: Vec<RawPanel>) -> Result<()
                     thresholds,
                     min,
                     max,
+                    autogrid,
                 });
             }
         } else if !kind.is_empty() && kind != "row" {
@@ -351,5 +360,41 @@ mod tests {
             .and_then(|c| c.value.as_ref())
             .or(v.current.as_ref().and_then(|c| c.text.as_ref()));
         assert_eq!(val.unwrap().as_str(), Some("node-exporter"));
+    }
+
+    #[test]
+    fn test_parse_axis_grid_show() {
+        let json = r#"
+        {
+            "title": "Grid Test",
+            "panels": [
+                {
+                    "type": "timeseries",
+                    "title": "Grid Off",
+                    "targets": [{ "expr": "up" }],
+                    "fieldConfig": {
+                        "defaults": {
+                            "custom": {
+                                "axisGridShow": false
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "timeseries",
+                    "title": "Grid Default",
+                    "targets": [{ "expr": "up" }]
+                }
+            ]
+        }
+        "#;
+        let path = std::env::temp_dir().join("grafatui-axis-grid-test.json");
+        std::fs::write(&path, json).unwrap();
+
+        let dashboard = load_grafana_dashboard(&path).unwrap();
+        std::fs::remove_file(path).unwrap();
+
+        assert_eq!(dashboard.queries[0].autogrid, Some(false));
+        assert_eq!(dashboard.queries[1].autogrid, None);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,6 +90,12 @@ async fn main() -> Result<()> {
     let refresh_rate = args.refresh_rate.or(config.refresh_rate).unwrap_or(1000);
     let refresh_every = Duration::from_millis(refresh_rate);
     let autogrid_enabled = config.autogrid.unwrap_or(true);
+    let autogrid_color = args
+        .autogrid_color
+        .or(config.autogrid_color)
+        .map(|color| theme::parse_grafana_color(&color))
+        .filter(|color| *color != ratatui::style::Color::Reset)
+        .unwrap_or(ratatui::style::Color::DarkGray);
 
     let mut vars: HashMap<String, String> = HashMap::new();
 
@@ -174,6 +180,7 @@ async fn main() -> Result<()> {
         marker_name,
     );
     state.autogrid_enabled = autogrid_enabled;
+    state.autogrid_color = autogrid_color;
     state.vars = vars; // <— pass variables into the app
     state.refresh().await?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,6 +89,7 @@ async fn main() -> Result<()> {
 
     let refresh_rate = args.refresh_rate.or(config.refresh_rate).unwrap_or(1000);
     let refresh_every = Duration::from_millis(refresh_rate);
+    let autogrid_enabled = config.autogrid.unwrap_or(true);
 
     let mut vars: HashMap<String, String> = HashMap::new();
 
@@ -128,6 +129,7 @@ async fn main() -> Result<()> {
                 thresholds: q.thresholds,
                 min: q.min,
                 max: q.max,
+                autogrid: q.autogrid,
             })
             .collect();
         (format!("{} (imported)", d.title), ps, d.skipped_panels)
@@ -171,6 +173,7 @@ async fn main() -> Result<()> {
         theme,
         marker_name,
     );
+    state.autogrid_enabled = autogrid_enabled;
     state.vars = vars; // <— pass variables into the app
     state.refresh().await?;
 

--- a/src/prom.rs
+++ b/src/prom.rs
@@ -21,6 +21,10 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+type QueryCache = Arc<Mutex<HashMap<String, (i64, i64, Duration, Vec<Series>)>>>;
+type QueryWaiter = tokio::sync::oneshot::Sender<Result<Vec<Series>, String>>;
+type InflightQueries = Arc<Mutex<HashMap<String, Vec<QueryWaiter>>>>;
+
 /// A simple Prometheus HTTP client.
 #[derive(Debug, Clone)]
 pub struct PromClient {
@@ -29,10 +33,9 @@ pub struct PromClient {
     /// HTTP client.
     client: reqwest::Client,
     /// Query cache: expr -> (start, end, step, data)
-    cache: Arc<Mutex<HashMap<String, (i64, i64, Duration, Vec<Series>)>>>,
+    cache: QueryCache,
     /// In-flight requests: key -> list of waiters
-    inflight:
-        Arc<Mutex<HashMap<String, Vec<tokio::sync::oneshot::Sender<Result<Vec<Series>, String>>>>>>,
+    inflight: InflightQueries,
 }
 
 impl PromClient {

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -214,6 +214,10 @@ pub fn parse_grafana_color(c: &str) -> Color {
         "orange" | "dark-orange" => Color::Rgb(255, 165, 0),
         "light-orange" => Color::Rgb(255, 200, 100),
         "cyan" => Color::Cyan,
+        "gray" | "grey" => Color::Gray,
+        "dark-gray" | "dark-grey" => Color::DarkGray,
+        "white" => Color::White,
+        "black" => Color::Black,
         _ => Color::Reset,
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1237,13 +1237,46 @@ fn write_centered_label(
     color: Color,
 ) {
     let label_width = label.chars().count() as u16;
-    let half_width = label_width / 2;
-    let max_start = max_x.saturating_sub(label_width);
-    if max_start < min_x {
+    let Some(start_x) = centered_label_start(center, label_width, min_x, max_x) else {
         return;
+    };
+
+    let buf = frame.buffer_mut();
+    for offset in 0..label_width {
+        let Some(cell) = buf.cell((start_x.saturating_add(offset), y)) else {
+            return;
+        };
+        if !is_blank_cell(cell) {
+            return;
+        }
     }
-    let x = center.saturating_sub(half_width).clamp(min_x, max_start);
-    write_label(frame, x, y, label, color, true);
+
+    let style = Style::default().fg(color);
+    for (offset, ch) in label.chars().enumerate() {
+        if let Some(cell) = buf.cell_mut((start_x.saturating_add(offset as u16), y)) {
+            cell.set_char(ch).set_style(style);
+        }
+    }
+}
+
+fn centered_label_start(center: u16, label_width: u16, min_x: u16, max_x: u16) -> Option<u16> {
+    if label_width == 0 || max_x <= min_x {
+        return None;
+    }
+
+    let half_width = label_width / 2;
+    // For even-length labels, bias one cell right so the visual midpoint better matches
+    // the target chart column instead of consistently leaning left.
+    let mut start_x = center.checked_sub(half_width)?;
+    if label_width % 2 == 0 {
+        start_x = start_x.saturating_add(1);
+    }
+    let end_x_exclusive = start_x.saturating_add(label_width);
+    if start_x < min_x || end_x_exclusive > max_x {
+        return None;
+    }
+
+    Some(start_x)
 }
 
 fn write_label(frame: &mut Frame, x: u16, y: u16, label: &str, color: Color, blank_only: bool) {
@@ -1833,6 +1866,18 @@ mod tests {
         assert_eq!(value_to_plot_x(5.0, [0.0, 10.0], plot), Some(15));
         assert_eq!(value_to_plot_x(0.0, [0.0, 10.0], plot), None);
         assert_eq!(value_to_plot_x(10.0, [0.0, 10.0], plot), None);
+    }
+
+    #[test]
+    fn test_centered_label_start_returns_centered_position_when_it_fits() {
+        assert_eq!(centered_label_start(50, 8, 10, 90), Some(47));
+        assert_eq!(centered_label_start(50, 7, 10, 90), Some(47));
+    }
+
+    #[test]
+    fn test_centered_label_start_skips_labels_that_would_be_clamped() {
+        assert_eq!(centered_label_start(12, 8, 10, 90), None);
+        assert_eq!(centered_label_start(88, 8, 10, 90), None);
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -113,12 +113,13 @@ pub fn draw_ui(frame: &mut Frame, app: &AppState) {
     };
 
     let summary = format!(
-        "Mode: {} | Prom: {} | range={} step={:?} refresh={} | panels={} (skipped {}) errors={} | keys: ↑/↓ scroll, r refresh, +/- range, q quit, ? debug:{}",
+        "Mode: {} | Prom: {} | range={} step={:?} refresh={} | grid={} | panels={} (skipped {}) errors={} | keys: ↑/↓ scroll, r refresh, +/- range, q quit, ? debug:{}",
         mode_display,
         app.prometheus.base,
         format_duration(app.range),
         app.step,
         format_duration(app.refresh_every),
+        if app.autogrid_enabled { "on" } else { "off" },
         panel_count_display,
         app.skipped_panels,
         errors,
@@ -137,7 +138,7 @@ pub fn draw_ui(frame: &mut Frame, app: &AppState) {
                     (g.y, g.x)
                 })
         } else {
-            app.panels.get(0)
+            app.panels.first()
         };
 
         if let Some(p) = debug_panel {
@@ -578,6 +579,7 @@ fn render_graph_panel(
 
     // Calculate y_bounds once
     let y_bounds = calculate_y_bounds(p);
+    let show_autogrid = app.autogrid_enabled && p.autogrid.unwrap_or(true);
 
     // Prepare datasets (without names for the chart itself to avoid built-in legend)
     let mut chart_datasets = Vec::new();
@@ -678,7 +680,7 @@ fn render_graph_panel(
             name = format!("Series {}", i);
         }
 
-        legend_items.push(Span::styled(format!("■ "), Style::default().fg(color)));
+        legend_items.push(Span::styled("■ ".to_string(), Style::default().fg(color)));
         legend_items.push(Span::styled(
             format!("{}  ", name),
             Style::default().fg(theme.text),
@@ -715,19 +717,31 @@ fn render_graph_panel(
         Span::styled(format_time(now), Style::default().fg(theme.text)),
     ];
 
-    let y_axis_height = chart_area.height.saturating_sub(1).max(2) as usize;
+    let chart_bottom = chart_area.bottom().saturating_sub(2); // x-axis occupies last rows
+    let chart_top = chart_area.top();
+    let plot_height = chart_bottom.saturating_sub(chart_top).saturating_add(1);
+    let y_axis_height = usize::from(plot_height).max(2);
     let mut y_labels = vec![Span::raw(""); y_axis_height];
+    let autogrid_value_ticks = if show_autogrid {
+        calculate_value_grid_ticks(y_bounds, plot_height)
+    } else {
+        Vec::new()
+    };
 
     y_labels[0] = Span::styled(format_si(y_bounds[0]), Style::default().fg(theme.text));
     y_labels[y_axis_height - 1] =
         Span::styled(format_si(y_bounds[1]), Style::default().fg(theme.text));
 
     if y_bounds[1] > y_bounds[0] {
+        for grid_val in &autogrid_value_ticks {
+            if let Some(index) = y_axis_label_index(*grid_val, y_bounds, y_axis_height) {
+                y_labels[index] =
+                    Span::styled(format_si(*grid_val), Style::default().fg(Color::DarkGray));
+            }
+        }
+
         for (th_val, color) in &threshold_labels_info {
-            if *th_val > y_bounds[0] && *th_val < y_bounds[1] {
-                let ratio = (*th_val - y_bounds[0]) / (y_bounds[1] - y_bounds[0]);
-                let index = (ratio * (y_axis_height - 1) as f64).round() as usize;
-                let index = index.min(y_axis_height - 2).max(1);
+            if let Some(index) = y_axis_label_index(*th_val, y_bounds, y_axis_height) {
                 y_labels[index] = Span::styled(format_si(*th_val), Style::default().fg(*color));
             }
         }
@@ -756,8 +770,12 @@ fn render_graph_panel(
 
     let chart_left = chart_area.left() + y_max_width + 1; // +1 for the | axis line
     let chart_right = chart_area.right();
-    let chart_bottom = chart_area.bottom().saturating_sub(2); // x-axis occupies last rows
-    let chart_top = chart_area.top();
+    let plot_bounds = PlotBounds {
+        left: chart_left,
+        right: chart_right,
+        top: chart_top,
+        bottom: chart_bottom,
+    };
 
     // Render threshold markers after chart rendering by merging only onto blank cells.
     // This guarantees data curves keep precedence wherever both map to the same terminal cell.
@@ -766,30 +784,20 @@ fn render_graph_panel(
             .x_axis(
                 Axis::default()
                     .bounds([start, now])
-                    .labels(x_labels)
+                    .labels(x_labels.clone())
                     .style(Style::default().fg(theme.text)),
             )
             .y_axis(
                 Axis::default()
                     .style(Style::default().fg(Color::Gray))
                     .bounds(y_bounds)
-                    .labels(y_labels),
+                    .labels(y_labels.clone()),
             );
 
         let mut threshold_buf = ratatui::buffer::Buffer::empty(chart_area);
         threshold_chart.render(chart_area, &mut threshold_buf);
 
-        let buf = frame.buffer_mut();
-        for y in chart_top..=chart_bottom {
-            for x in chart_left..chart_right {
-                let Some(src_cell) = threshold_buf.cell((x, y)) else {
-                    continue;
-                };
-                if let Some(dst_cell) = buf.cell_mut((x, y)) {
-                    overlay_threshold_cell(dst_cell, src_cell);
-                }
-            }
-        }
+        merge_overlay_buffer(frame, &threshold_buf, plot_bounds);
     }
 
     // Render custom raw lines by hijacking buffer space
@@ -814,7 +822,7 @@ fn render_graph_panel(
                                 continue;
                             }
                             if let Some(cell) = buf.cell_mut((x, phys_y)) {
-                                if should_draw_threshold_on_cell(cell) {
+                                if is_blank_cell(cell) {
                                     cell.set_char(line_char)
                                         .set_style(Style::default().fg(*color));
                                 }
@@ -826,6 +834,49 @@ fn render_graph_panel(
         }
     }
 
+    if show_autogrid && chart_top <= chart_bottom {
+        let plot_width = chart_right.saturating_sub(chart_left);
+        let autogrid_time_ticks = calculate_time_grid_ticks(start, now, plot_width);
+        let autogrid_datasets = build_autogrid_datasets(
+            [start, now],
+            y_bounds,
+            &autogrid_time_ticks,
+            &autogrid_value_ticks,
+            plot_width,
+            plot_height,
+        );
+        let autogrid_overlay_datasets: Vec<_> = autogrid_datasets
+            .iter()
+            .map(|dataset| {
+                Dataset::default()
+                    .name("")
+                    .marker(ratatui::symbols::Marker::Braille)
+                    .graph_type(GraphType::Line)
+                    .style(Style::default().fg(Color::DarkGray))
+                    .data(dataset)
+            })
+            .collect();
+
+        let autogrid_chart = Chart::new(autogrid_overlay_datasets)
+            .x_axis(
+                Axis::default()
+                    .bounds([start, now])
+                    .labels(x_labels)
+                    .style(Style::default().fg(theme.text)),
+            )
+            .y_axis(
+                Axis::default()
+                    .style(Style::default().fg(Color::Gray))
+                    .bounds(y_bounds)
+                    .labels(y_labels),
+            );
+
+        let mut autogrid_buf = ratatui::buffer::Buffer::empty(chart_area);
+        autogrid_chart.render(chart_area, &mut autogrid_buf);
+
+        merge_overlay_buffer(frame, &autogrid_buf, plot_bounds);
+    }
+
     // Render custom legend
     if legend_height > 0 {
         let legend = Paragraph::new(Line::from(legend_items)).wrap(Wrap { trim: true });
@@ -833,14 +884,221 @@ fn render_graph_panel(
     }
 }
 
-fn should_draw_threshold_on_cell(cell: &ratatui::buffer::Cell) -> bool {
+#[derive(Debug, Clone, Copy)]
+struct PlotBounds {
+    left: u16,
+    right: u16,
+    top: u16,
+    bottom: u16,
+}
+
+fn merge_overlay_buffer(
+    frame: &mut Frame,
+    overlay_buf: &ratatui::buffer::Buffer,
+    plot: PlotBounds,
+) {
+    let buf = frame.buffer_mut();
+    for y in plot.top..=plot.bottom {
+        for x in plot.left..plot.right {
+            let Some(src_cell) = overlay_buf.cell((x, y)) else {
+                continue;
+            };
+            if let Some(dst_cell) = buf.cell_mut((x, y)) {
+                overlay_cell_if_blank(dst_cell, src_cell);
+            }
+        }
+    }
+}
+
+fn is_blank_cell(cell: &ratatui::buffer::Cell) -> bool {
     cell.symbol().chars().all(char::is_whitespace)
 }
 
-fn overlay_threshold_cell(dst: &mut ratatui::buffer::Cell, src: &ratatui::buffer::Cell) {
-    if should_draw_threshold_on_cell(dst) && !should_draw_threshold_on_cell(src) {
+fn overlay_cell_if_blank(dst: &mut ratatui::buffer::Cell, src: &ratatui::buffer::Cell) {
+    if is_blank_cell(dst) && !is_blank_cell(src) {
         dst.set_symbol(src.symbol()).set_style(src.style());
     }
+}
+
+fn y_axis_label_index(value: f64, y_bounds: [f64; 2], y_axis_height: usize) -> Option<usize> {
+    if value <= y_bounds[0] || value >= y_bounds[1] || y_axis_height < 3 {
+        return None;
+    }
+
+    let ratio = (value - y_bounds[0]) / (y_bounds[1] - y_bounds[0]);
+    let index_from_bottom = (ratio * (y_axis_height - 1) as f64).round() as usize;
+    Some(index_from_bottom.min(y_axis_height - 2).max(1))
+}
+
+fn calculate_value_grid_ticks(y_bounds: [f64; 2], chart_height: u16) -> Vec<f64> {
+    let min = y_bounds[0];
+    let max = y_bounds[1];
+    if !min.is_finite() || !max.is_finite() || max <= min || chart_height < 4 {
+        return Vec::new();
+    }
+
+    let target_lines = (usize::from(chart_height) / 6).clamp(2, 4);
+    let step = nice_grid_step(max - min, target_lines);
+    if step <= 0.0 || !step.is_finite() {
+        return Vec::new();
+    }
+
+    let mut ticks = Vec::new();
+    let mut tick = (min / step).ceil() * step;
+    while tick < max {
+        if tick > min {
+            ticks.push(tick);
+        }
+        tick += step;
+    }
+    ticks
+}
+
+fn nice_grid_step(range: f64, target_lines: usize) -> f64 {
+    if range <= 0.0 || !range.is_finite() || target_lines == 0 {
+        return 0.0;
+    }
+
+    let raw_step = range / target_lines as f64;
+    let magnitude = 10_f64.powf(raw_step.log10().floor());
+    let fraction = raw_step / magnitude;
+    let nice_fraction = if fraction <= 1.0 {
+        1.0
+    } else if fraction <= 2.0 {
+        2.0
+    } else if fraction <= 5.0 {
+        5.0
+    } else {
+        10.0
+    };
+    nice_fraction * magnitude
+}
+
+fn calculate_time_grid_ticks(start: f64, end: f64, chart_width: u16) -> Vec<f64> {
+    if !start.is_finite() || !end.is_finite() || end <= start || chart_width < 8 {
+        return Vec::new();
+    }
+
+    let range = end - start;
+    let mut step = base_time_grid_step(range);
+    let max_ticks = (usize::from(chart_width) / 20).clamp(3, 8);
+    while count_interior_ticks(start, end, step) > max_ticks {
+        step = next_time_grid_step(step);
+    }
+
+    let mut ticks = Vec::new();
+    let mut tick = (start / step).ceil() * step;
+    while tick < end {
+        if tick > start {
+            ticks.push(tick);
+        }
+        tick += step;
+    }
+    ticks
+}
+
+fn base_time_grid_step(range: f64) -> f64 {
+    const MINUTE: f64 = 60.0;
+    const HOUR: f64 = 60.0 * MINUTE;
+    const DAY: f64 = 24.0 * HOUR;
+
+    if range <= 10.0 * MINUTE {
+        MINUTE
+    } else if range <= 30.0 * MINUTE {
+        5.0 * MINUTE
+    } else if range <= 90.0 * MINUTE {
+        30.0 * MINUTE
+    } else if range <= 3.0 * HOUR {
+        HOUR
+    } else if range <= 6.0 * HOUR {
+        2.0 * HOUR
+    } else if range <= 12.0 * HOUR {
+        3.0 * HOUR
+    } else if range <= DAY {
+        6.0 * HOUR
+    } else if range <= 2.0 * DAY {
+        12.0 * HOUR
+    } else {
+        DAY
+    }
+}
+
+fn next_time_grid_step(step: f64) -> f64 {
+    const STEPS: [f64; 10] = [
+        60.0, 300.0, 600.0, 1800.0, 3600.0, 7200.0, 10800.0, 21600.0, 43200.0, 86400.0,
+    ];
+
+    STEPS
+        .iter()
+        .copied()
+        .find(|candidate| *candidate > step)
+        .unwrap_or(step * 2.0)
+}
+
+fn count_interior_ticks(start: f64, end: f64, step: f64) -> usize {
+    if step <= 0.0 {
+        return 0;
+    }
+
+    let mut count = 0;
+    let mut tick = (start / step).ceil() * step;
+    while tick < end {
+        if tick > start {
+            count += 1;
+        }
+        tick += step;
+    }
+    count
+}
+
+fn build_autogrid_datasets(
+    x_bounds: [f64; 2],
+    y_bounds: [f64; 2],
+    time_ticks: &[f64],
+    value_ticks: &[f64],
+    plot_width: u16,
+    plot_height: u16,
+) -> Vec<Vec<(f64, f64)>> {
+    if x_bounds[1] <= x_bounds[0] || y_bounds[1] <= y_bounds[0] {
+        return Vec::new();
+    }
+
+    let mut datasets = Vec::new();
+    let vertical_samples = usize::from(plot_height).saturating_mul(4).max(2);
+    let horizontal_samples = usize::from(plot_width).saturating_mul(2).max(2);
+
+    for tick in time_ticks {
+        if *tick <= x_bounds[0] || *tick >= x_bounds[1] {
+            continue;
+        }
+        datasets.push(
+            (0..=vertical_samples)
+                .map(|i| {
+                    let y = interpolate(y_bounds[0], y_bounds[1], i, vertical_samples);
+                    (*tick, y)
+                })
+                .collect(),
+        );
+    }
+
+    for tick in value_ticks {
+        if *tick <= y_bounds[0] || *tick >= y_bounds[1] {
+            continue;
+        }
+        datasets.push(
+            (0..=horizontal_samples)
+                .map(|i| {
+                    let x = interpolate(x_bounds[0], x_bounds[1], i, horizontal_samples);
+                    (x, *tick)
+                })
+                .collect(),
+        );
+    }
+    datasets
+}
+
+fn interpolate(start: f64, end: f64, index: usize, total: usize) -> f64 {
+    start + (end - start) * index as f64 / total as f64
 }
 
 fn render_gauge(frame: &mut Frame, area: Rect, p: &PanelState, app: &AppState) {
@@ -857,7 +1115,7 @@ fn render_gauge(frame: &mut Frame, area: Rect, p: &PanelState, app: &AppState) {
     let min = p.min.unwrap_or(0.0);
     let max = p
         .max
-        .unwrap_or_else(|| if value > 100.0 { value * 1.2 } else { 100.0 });
+        .unwrap_or(if value > 100.0 { value * 1.2 } else { 100.0 });
 
     let color = p.get_color_for_value(value).unwrap_or(theme.palette[0]);
 
@@ -1267,6 +1525,7 @@ mod tests {
             thresholds: None,
             min: None,
             max: None,
+            autogrid: None,
         }
     }
 
@@ -1334,41 +1593,117 @@ mod tests {
     }
 
     #[test]
-    fn test_should_draw_threshold_on_cell_empty() {
+    fn test_is_blank_cell_empty() {
         let cell = ratatui::buffer::Cell::default();
-        assert!(should_draw_threshold_on_cell(&cell));
+        assert!(is_blank_cell(&cell));
     }
 
     #[test]
-    fn test_should_draw_threshold_on_cell_filled() {
+    fn test_is_blank_cell_filled() {
         let mut cell = ratatui::buffer::Cell::default();
         cell.set_char('x');
-        assert!(!should_draw_threshold_on_cell(&cell));
+        assert!(!is_blank_cell(&cell));
     }
 
     #[test]
-    fn test_overlay_threshold_cell_copies_when_destination_is_empty() {
+    fn test_overlay_cell_if_blank_copies_when_destination_is_empty() {
         let mut dst = ratatui::buffer::Cell::default();
         let mut src = ratatui::buffer::Cell::default();
         src.set_char('-').set_style(Style::default().fg(Color::Red));
 
-        overlay_threshold_cell(&mut dst, &src);
+        overlay_cell_if_blank(&mut dst, &src);
 
         assert_eq!(dst.symbol(), "-");
         assert_eq!(dst.style().fg, Some(Color::Red));
     }
 
     #[test]
-    fn test_overlay_threshold_cell_keeps_existing_destination_marker() {
+    fn test_overlay_cell_if_blank_keeps_existing_destination_marker() {
         let mut dst = ratatui::buffer::Cell::default();
         dst.set_char('x')
             .set_style(Style::default().fg(Color::LightBlue));
         let mut src = ratatui::buffer::Cell::default();
         src.set_char('-').set_style(Style::default().fg(Color::Red));
 
-        overlay_threshold_cell(&mut dst, &src);
+        overlay_cell_if_blank(&mut dst, &src);
 
         assert_eq!(dst.symbol(), "x");
         assert_eq!(dst.style().fg, Some(Color::LightBlue));
+    }
+
+    #[test]
+    fn test_y_axis_label_index_matches_chart_orientation() {
+        assert_eq!(y_axis_label_index(10.0, [0.0, 20.0], 11), Some(5));
+        assert_eq!(y_axis_label_index(5.0, [0.0, 20.0], 11), Some(3));
+        assert_eq!(y_axis_label_index(15.0, [0.0, 20.0], 11), Some(8));
+        assert_eq!(y_axis_label_index(0.0, [0.0, 20.0], 11), None);
+        assert_eq!(y_axis_label_index(20.0, [0.0, 20.0], 11), None);
+    }
+
+    #[test]
+    fn test_calculate_value_grid_ticks_round_values() {
+        let ticks = calculate_value_grid_ticks([329.0, 1287.0], 20);
+        assert_eq!(ticks, vec![500.0, 1000.0]);
+    }
+
+    #[test]
+    fn test_calculate_value_grid_ticks_excludes_boundaries() {
+        let ticks = calculate_value_grid_ticks([0.0, 100.0], 20);
+        assert!(!ticks.contains(&0.0));
+        assert!(!ticks.contains(&100.0));
+    }
+
+    #[test]
+    fn test_calculate_value_grid_ticks_invalid_ranges() {
+        assert!(calculate_value_grid_ticks([1.0, 1.0], 20).is_empty());
+        assert!(calculate_value_grid_ticks([2.0, 1.0], 20).is_empty());
+        assert!(calculate_value_grid_ticks([f64::NAN, 1.0], 20).is_empty());
+        assert!(calculate_value_grid_ticks([0.0, 1.0], 3).is_empty());
+    }
+
+    #[test]
+    fn test_calculate_time_grid_ticks_two_hour_window() {
+        let start = 41_820.0; // 11:37 UTC
+        let end = start + 2.0 * 60.0 * 60.0;
+
+        let ticks = calculate_time_grid_ticks(start, end, 80);
+
+        assert_eq!(ticks, vec![43_200.0, 46_800.0]); // 12:00, 13:00 UTC
+    }
+
+    #[test]
+    fn test_calculate_time_grid_ticks_one_hour_window() {
+        let start = 44_520.0; // 12:22 UTC
+        let end = start + 60.0 * 60.0;
+
+        let ticks = calculate_time_grid_ticks(start, end, 80);
+
+        assert_eq!(ticks, vec![45_000.0, 46_800.0]); // 12:30, 13:00 UTC
+    }
+
+    #[test]
+    fn test_calculate_time_grid_ticks_five_minute_window() {
+        let start = 43_335.0; // 12:02:15 UTC
+        let end = start + 5.0 * 60.0;
+
+        let ticks = calculate_time_grid_ticks(start, end, 120);
+
+        assert_eq!(
+            ticks,
+            vec![43_380.0, 43_440.0, 43_500.0, 43_560.0, 43_620.0]
+        );
+    }
+
+    #[test]
+    fn test_build_autogrid_datasets() {
+        let datasets = build_autogrid_datasets([0.0, 10.0], [0.0, 10.0], &[5.0], &[5.0], 10, 5);
+
+        assert_eq!(datasets.len(), 2);
+        assert_eq!(datasets[0].first(), Some(&(5.0, 0.0)));
+        assert_eq!(datasets[0].last(), Some(&(5.0, 10.0)));
+        assert_eq!(datasets[0].len(), 21);
+        assert_eq!(datasets[1].first(), Some(&(0.0, 5.0)));
+        assert_eq!(datasets[1].last(), Some(&(10.0, 5.0)));
+        assert_eq!(datasets[1].len(), 21);
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -712,9 +712,16 @@ fn render_graph_panel(
         );
     }
 
+    let time_range_secs = now - start;
     let x_labels = vec![
-        Span::styled(format_time(start), Style::default().fg(theme.text)),
-        Span::styled(format_time(now), Style::default().fg(theme.text)),
+        Span::styled(
+            format_axis_time(start, time_range_secs),
+            Style::default().fg(theme.text),
+        ),
+        Span::styled(
+            format_axis_time(now, time_range_secs),
+            Style::default().fg(theme.text),
+        ),
     ];
 
     let chart_bottom = chart_area.bottom().saturating_sub(2); // x-axis occupies last rows
@@ -865,6 +872,7 @@ fn render_graph_panel(
             plot_bounds,
             [start, now],
             &autogrid_time_ticks,
+            time_range_secs,
             app.autogrid_color,
         );
     }
@@ -1171,6 +1179,7 @@ fn render_autogrid_time_labels(
     plot: PlotBounds,
     x_bounds: [f64; 2],
     ticks: &[f64],
+    range_secs: f64,
     color: Color,
 ) {
     let y = plot.bottom.saturating_add(1);
@@ -1182,7 +1191,7 @@ fn render_autogrid_time_labels(
                 y,
                 plot.left,
                 plot.right,
-                &format_time(*tick),
+                &format_axis_time(*tick, range_secs),
                 color,
             );
         }
@@ -1643,6 +1652,33 @@ fn format_time(ts: f64) -> String {
     }
 }
 
+fn format_axis_time(ts: f64, range_secs: f64) -> String {
+    use chrono::{TimeZone, Timelike};
+
+    const DAY: f64 = 24.0 * 60.0 * 60.0;
+    if range_secs < DAY {
+        return format_time(ts);
+    }
+
+    let Some(dt) = chrono::Utc.timestamp_opt(ts as i64, 0).single() else {
+        return format!("{}", ts);
+    };
+
+    if range_secs < 7.0 * DAY {
+        if dt.hour() == 0 && dt.minute() == 0 && dt.second() == 0 {
+            dt.format("%b %d").to_string()
+        } else {
+            dt.format("%b %d %Hh").to_string()
+        }
+    } else if range_secs < 90.0 * DAY {
+        dt.format("%b %d").to_string()
+    } else if range_secs < 730.0 * DAY {
+        dt.format("%Y-%m").to_string()
+    } else {
+        dt.format("%Y").to_string()
+    }
+}
+
 /// Generate a color from a string using hash-based approach.
 /// Uses HSL color space to ensure visually distinct, vibrant colors.
 fn get_hash_color(name: &str) -> Color {
@@ -1932,6 +1968,61 @@ mod tests {
             ticks,
             vec![43_380.0, 43_440.0, 43_500.0, 43_560.0, 43_620.0]
         );
+    }
+
+    #[test]
+    fn test_format_axis_time_uses_time_for_short_ranges() {
+        use chrono::TimeZone;
+
+        let ts = chrono::Utc
+            .with_ymd_and_hms(2026, 4, 30, 12, 34, 56)
+            .single()
+            .unwrap()
+            .timestamp() as f64;
+
+        assert_eq!(format_axis_time(ts, 60.0 * 60.0), "12:34:56");
+    }
+
+    #[test]
+    fn test_format_axis_time_uses_date_for_multi_day_midnight_ticks() {
+        use chrono::TimeZone;
+
+        let ts = chrono::Utc
+            .with_ymd_and_hms(2026, 4, 30, 0, 0, 0)
+            .single()
+            .unwrap()
+            .timestamp() as f64;
+
+        assert_eq!(format_axis_time(ts, 2.0 * 24.0 * 60.0 * 60.0), "Apr 30");
+    }
+
+    #[test]
+    fn test_format_axis_time_keeps_hour_for_multi_day_non_midnight_ticks() {
+        use chrono::TimeZone;
+
+        let ts = chrono::Utc
+            .with_ymd_and_hms(2026, 4, 30, 12, 0, 0)
+            .single()
+            .unwrap()
+            .timestamp() as f64;
+
+        assert_eq!(format_axis_time(ts, 2.0 * 24.0 * 60.0 * 60.0), "Apr 30 12h");
+    }
+
+    #[test]
+    fn test_format_axis_time_scales_to_wider_ranges() {
+        use chrono::TimeZone;
+
+        let ts = chrono::Utc
+            .with_ymd_and_hms(2026, 4, 30, 12, 0, 0)
+            .single()
+            .unwrap()
+            .timestamp() as f64;
+        let day = 24.0 * 60.0 * 60.0;
+
+        assert_eq!(format_axis_time(ts, 14.0 * day), "Apr 30");
+        assert_eq!(format_axis_time(ts, 120.0 * day), "2026-04");
+        assert_eq!(format_axis_time(ts, 800.0 * day), "2026");
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -732,23 +732,8 @@ fn render_graph_panel(
     y_labels[y_axis_height - 1] =
         Span::styled(format_si(y_bounds[1]), Style::default().fg(theme.text));
 
-    if y_bounds[1] > y_bounds[0] {
-        for grid_val in &autogrid_value_ticks {
-            if let Some(index) = y_axis_label_index(*grid_val, y_bounds, y_axis_height) {
-                y_labels[index] =
-                    Span::styled(format_si(*grid_val), Style::default().fg(Color::DarkGray));
-            }
-        }
-
-        for (th_val, color) in &threshold_labels_info {
-            if let Some(index) = y_axis_label_index(*th_val, y_bounds, y_axis_height) {
-                y_labels[index] = Span::styled(format_si(*th_val), Style::default().fg(*color));
-            }
-        }
-    }
-
     // Evaluate y_max_width before moving y_labels into Chart block
-    let y_max_width = y_labels.iter().map(|s| s.width() as u16).max().unwrap_or(0);
+    let y_max_width = y_label_width(&y_labels, &autogrid_value_ticks, &threshold_labels_info);
 
     let chart = Chart::new(chart_datasets)
         // No block, as we rendered it outside
@@ -852,7 +837,7 @@ fn render_graph_panel(
                     .name("")
                     .marker(ratatui::symbols::Marker::Braille)
                     .graph_type(GraphType::Line)
-                    .style(Style::default().fg(Color::DarkGray))
+                    .style(Style::default().fg(app.autogrid_color))
                     .data(dataset)
             })
             .collect();
@@ -875,7 +860,27 @@ fn render_graph_panel(
         autogrid_chart.render(chart_area, &mut autogrid_buf);
 
         merge_overlay_buffer(frame, &autogrid_buf, plot_bounds);
+        render_autogrid_time_labels(
+            frame,
+            plot_bounds,
+            [start, now],
+            &autogrid_time_ticks,
+            app.autogrid_color,
+        );
     }
+
+    render_intermediate_y_labels(
+        frame,
+        YLabelArea {
+            left: chart_area.left(),
+            width: y_max_width,
+        },
+        plot_bounds,
+        y_bounds,
+        &autogrid_value_ticks,
+        &threshold_labels_info,
+        app.autogrid_color,
+    );
 
     // Render custom legend
     if legend_height > 0 {
@@ -890,6 +895,12 @@ struct PlotBounds {
     right: u16,
     top: u16,
     bottom: u16,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct YLabelArea {
+    left: u16,
+    width: u16,
 }
 
 fn merge_overlay_buffer(
@@ -918,16 +929,6 @@ fn overlay_cell_if_blank(dst: &mut ratatui::buffer::Cell, src: &ratatui::buffer:
     if is_blank_cell(dst) && !is_blank_cell(src) {
         dst.set_symbol(src.symbol()).set_style(src.style());
     }
-}
-
-fn y_axis_label_index(value: f64, y_bounds: [f64; 2], y_axis_height: usize) -> Option<usize> {
-    if value <= y_bounds[0] || value >= y_bounds[1] || y_axis_height < 3 {
-        return None;
-    }
-
-    let ratio = (value - y_bounds[0]) / (y_bounds[1] - y_bounds[0]);
-    let index_from_bottom = (ratio * (y_axis_height - 1) as f64).round() as usize;
-    Some(index_from_bottom.min(y_axis_height - 2).max(1))
 }
 
 fn calculate_value_grid_ticks(y_bounds: [f64; 2], chart_height: u16) -> Vec<f64> {
@@ -1099,6 +1100,163 @@ fn build_autogrid_datasets(
 
 fn interpolate(start: f64, end: f64, index: usize, total: usize) -> f64 {
     start + (end - start) * index as f64 / total as f64
+}
+
+fn y_label_width(
+    axis_labels: &[Span<'_>],
+    autogrid_ticks: &[f64],
+    threshold_labels: &[(f64, Color)],
+) -> u16 {
+    let axis_width = axis_labels
+        .iter()
+        .map(|label| label.width() as u16)
+        .max()
+        .unwrap_or(0);
+    let grid_width = autogrid_ticks
+        .iter()
+        .map(|tick| format_si(*tick).len() as u16)
+        .max()
+        .unwrap_or(0);
+    let threshold_width = threshold_labels
+        .iter()
+        .map(|(tick, _)| format_si(*tick).len() as u16)
+        .max()
+        .unwrap_or(0);
+
+    axis_width.max(grid_width).max(threshold_width)
+}
+
+fn render_intermediate_y_labels(
+    frame: &mut Frame,
+    label_area: YLabelArea,
+    plot: PlotBounds,
+    y_bounds: [f64; 2],
+    autogrid_ticks: &[f64],
+    threshold_labels: &[(f64, Color)],
+    grid_color: Color,
+) {
+    if label_area.width == 0 {
+        return;
+    }
+
+    for tick in autogrid_ticks {
+        if let Some(y) = value_to_y_label_row(*tick, y_bounds, plot) {
+            write_right_aligned_label(
+                frame,
+                label_area.left,
+                y,
+                label_area.width,
+                &format_si(*tick),
+                grid_color,
+            );
+        }
+    }
+
+    for (tick, color) in threshold_labels {
+        if let Some(y) = value_to_y_label_row(*tick, y_bounds, plot) {
+            write_right_aligned_label(
+                frame,
+                label_area.left,
+                y,
+                label_area.width,
+                &format_si(*tick),
+                *color,
+            );
+        }
+    }
+}
+
+fn render_autogrid_time_labels(
+    frame: &mut Frame,
+    plot: PlotBounds,
+    x_bounds: [f64; 2],
+    ticks: &[f64],
+    color: Color,
+) {
+    let y = plot.bottom.saturating_add(1);
+    for tick in ticks {
+        if let Some(x) = value_to_plot_x(*tick, x_bounds, plot) {
+            write_centered_label(
+                frame,
+                x,
+                y,
+                plot.left,
+                plot.right,
+                &format_time(*tick),
+                color,
+            );
+        }
+    }
+}
+
+fn value_to_plot_y(value: f64, y_bounds: [f64; 2], plot: PlotBounds) -> Option<u16> {
+    if value <= y_bounds[0] || value >= y_bounds[1] || y_bounds[1] <= y_bounds[0] {
+        return None;
+    }
+
+    let height = plot.bottom.saturating_sub(plot.top) as f64;
+    let ratio = (value - y_bounds[0]) / (y_bounds[1] - y_bounds[0]);
+    let y_offset = (ratio * height).round() as u16;
+    Some(plot.bottom.saturating_sub(y_offset))
+}
+
+fn value_to_y_label_row(value: f64, y_bounds: [f64; 2], plot: PlotBounds) -> Option<u16> {
+    value_to_plot_y(value, y_bounds, plot)
+}
+
+fn value_to_plot_x(value: f64, x_bounds: [f64; 2], plot: PlotBounds) -> Option<u16> {
+    if value <= x_bounds[0] || value >= x_bounds[1] || x_bounds[1] <= x_bounds[0] {
+        return None;
+    }
+
+    let width = plot.right.saturating_sub(plot.left).saturating_sub(1) as f64;
+    let ratio = (value - x_bounds[0]) / (x_bounds[1] - x_bounds[0]);
+    Some(plot.left.saturating_add((ratio * width).round() as u16))
+}
+
+fn write_right_aligned_label(
+    frame: &mut Frame,
+    left: u16,
+    y: u16,
+    width: u16,
+    label: &str,
+    color: Color,
+) {
+    let label_width = label.chars().count() as u16;
+    let x = left.saturating_add(width.saturating_sub(label_width));
+    write_label(frame, x, y, label, color, false);
+}
+
+fn write_centered_label(
+    frame: &mut Frame,
+    center: u16,
+    y: u16,
+    min_x: u16,
+    max_x: u16,
+    label: &str,
+    color: Color,
+) {
+    let label_width = label.chars().count() as u16;
+    let half_width = label_width / 2;
+    let max_start = max_x.saturating_sub(label_width);
+    if max_start < min_x {
+        return;
+    }
+    let x = center.saturating_sub(half_width).clamp(min_x, max_start);
+    write_label(frame, x, y, label, color, true);
+}
+
+fn write_label(frame: &mut Frame, x: u16, y: u16, label: &str, color: Color, blank_only: bool) {
+    let style = Style::default().fg(color);
+    let buf = frame.buffer_mut();
+    for (offset, ch) in label.chars().enumerate() {
+        let Some(cell) = buf.cell_mut((x.saturating_add(offset as u16), y)) else {
+            continue;
+        };
+        if !blank_only || is_blank_cell(cell) {
+            cell.set_char(ch).set_style(style);
+        }
+    }
 }
 
 fn render_gauge(frame: &mut Frame, area: Rect, p: &PanelState, app: &AppState) {
@@ -1632,12 +1790,49 @@ mod tests {
     }
 
     #[test]
-    fn test_y_axis_label_index_matches_chart_orientation() {
-        assert_eq!(y_axis_label_index(10.0, [0.0, 20.0], 11), Some(5));
-        assert_eq!(y_axis_label_index(5.0, [0.0, 20.0], 11), Some(3));
-        assert_eq!(y_axis_label_index(15.0, [0.0, 20.0], 11), Some(8));
-        assert_eq!(y_axis_label_index(0.0, [0.0, 20.0], 11), None);
-        assert_eq!(y_axis_label_index(20.0, [0.0, 20.0], 11), None);
+    fn test_value_to_plot_y_matches_grid_row() {
+        let plot = PlotBounds {
+            left: 0,
+            right: 20,
+            top: 10,
+            bottom: 20,
+        };
+
+        assert_eq!(value_to_plot_y(10.0, [0.0, 20.0], plot), Some(15));
+        assert_eq!(value_to_plot_y(5.0, [0.0, 20.0], plot), Some(17));
+        assert_eq!(value_to_plot_y(15.0, [0.0, 20.0], plot), Some(12));
+        assert_eq!(value_to_plot_y(0.0, [0.0, 20.0], plot), None);
+        assert_eq!(value_to_plot_y(20.0, [0.0, 20.0], plot), None);
+    }
+
+    #[test]
+    fn test_value_to_y_label_row_matches_grid_row() {
+        let plot = PlotBounds {
+            left: 0,
+            right: 20,
+            top: 10,
+            bottom: 20,
+        };
+
+        assert_eq!(value_to_y_label_row(10.0, [0.0, 20.0], plot), Some(15));
+        assert_eq!(value_to_y_label_row(5.0, [0.0, 20.0], plot), Some(17));
+        assert_eq!(value_to_y_label_row(15.0, [0.0, 20.0], plot), Some(12));
+        assert_eq!(value_to_y_label_row(0.0, [0.0, 20.0], plot), None);
+        assert_eq!(value_to_y_label_row(20.0, [0.0, 20.0], plot), None);
+    }
+
+    #[test]
+    fn test_value_to_plot_x_matches_grid_column() {
+        let plot = PlotBounds {
+            left: 10,
+            right: 21,
+            top: 0,
+            bottom: 10,
+        };
+
+        assert_eq!(value_to_plot_x(5.0, [0.0, 10.0], plot), Some(15));
+        assert_eq!(value_to_plot_x(0.0, [0.0, 10.0], plot), None);
+        assert_eq!(value_to_plot_x(10.0, [0.0, 10.0], plot), None);
     }
 
     #[test]


### PR DESCRIPTION
## Description

Implements automatic grid guide lines for graph/timeseries panels, providing visual reference markers at "nice" round values both vertically (value axis) and horizontally (time axis).

**How it works:**

- **Time grid (vertical lines):** Picks round time boundaries based on the current time range — e.g. for a 2h window starting at 11:22, lines appear at 12:00 and 13:00. Uses a cascade of time steps (1min → 5min → 10min → 30min → 1h → … → 1d) and adapts density based on chart width (3–8 lines max).
- **Value grid (horizontal lines):** Uses a "nice numbers" algorithm (snapping to multiples of 1, 2, 5 × 10ⁿ) to place 2–4 lines at round values within the Y-axis range — e.g. for a range of 329–1287, lines appear at 500 and 1000.
- Grid lines render as a subtle `DarkGray` Braille overlay that only draws on blank cells, so data curves always have visual priority.

**Configuration (3 levels, coarsest → finest):**

1. **Global config** (`config.toml`): `autogrid = true` (default) or `autogrid = false`
2. **Per-panel from Grafana JSON**: respects `fieldConfig.defaults.custom.axisGridShow` — if explicitly disabled on a panel in Grafana, grafaTUI honors that
3. **Runtime toggle**: press `g` to toggle autogrid on/off at any time

Fixes #28

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have used Conventional Commits for my commit messages