### PR TITLE
fix: pin UI time bounds to last refresh and optimize render loop for event-driven updates

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -23,7 +23,6 @@ use futures::StreamExt;
 use ratatui::{Terminal, style::Color};
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
-use tokio::time::sleep;
 
 /// Represents the state of a single dashboard panel.
 #[derive(Debug, Clone)]
@@ -192,6 +191,8 @@ pub struct AppState {
     pub panels: Vec<PanelState>,
     /// Timestamp of the last successful refresh.
     pub last_refresh: Instant,
+    /// Query end timestamp used by the currently rendered data.
+    pub view_end_ts: i64,
     /// Vertical scroll offset.
     pub vertical_scroll: usize,
     /// Dashboard title.
@@ -251,6 +252,7 @@ impl AppState {
             refresh_every,
             panels,
             last_refresh: Instant::now() - refresh_every,
+            view_end_ts: chrono::Utc::now().timestamp(),
             vertical_scroll: 0,
             title,
             debug_bar: false,
@@ -327,10 +329,21 @@ impl AppState {
         self.time_offset.as_secs() == 0
     }
 
+    /// Returns the displayed time window bounds.
+    pub fn time_bounds(&self) -> (f64, f64) {
+        let end_ts = self.view_end_ts as f64;
+        (end_ts - self.range.as_secs_f64(), end_ts)
+    }
+
+    /// Moves the inspection cursor to the center of the displayed time window.
+    pub fn center_cursor(&mut self) {
+        let (start_ts, end_ts) = self.time_bounds();
+        self.cursor_x = Some((start_ts + end_ts) / 2.0);
+    }
+
     /// Move cursor left/right by one step.
     pub fn move_cursor(&mut self, direction: i32) {
-        let end_ts = (chrono::Utc::now().timestamp() - self.time_offset.as_secs() as i64) as f64;
-        let start_ts = end_ts - self.range.as_secs_f64();
+        let (start_ts, end_ts) = self.time_bounds();
 
         if let Some(current_x) = self.cursor_x {
             let step_secs = self.step.as_secs_f64();
@@ -364,6 +377,7 @@ impl AppState {
             p.last_error = err;
         }
 
+        self.view_end_ts = end_ts;
         self.last_refresh = Instant::now();
         Ok(())
     }
@@ -494,6 +508,20 @@ fn downsample(points: Vec<(f64, f64)>, max_points: usize) -> Vec<(f64, f64)> {
 mod tests {
     use super::*;
 
+    fn create_test_app() -> AppState {
+        AppState::new(
+            prom::PromClient::new("http://localhost:9090".to_string()),
+            Duration::from_secs(3600),
+            Duration::from_secs(60),
+            Duration::from_millis(1000),
+            "Test".to_string(),
+            vec![],
+            0,
+            Theme::default(),
+            "dashed".to_string(),
+        )
+    }
+
     #[test]
     fn test_expand_expr_rate_interval() {
         let vars = HashMap::new();
@@ -561,18 +589,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_empty_panels() {
-        let prom = prom::PromClient::new("http://localhost:9090".to_string());
-        let mut app = AppState::new(
-            prom,
-            Duration::from_secs(3600),
-            Duration::from_secs(60),
-            Duration::from_millis(1000),
-            "Test".to_string(),
-            vec![], // Empty panels
-            0,
-            Theme::default(),
-            "dashed".to_string(),
-        );
+        let mut app = create_test_app();
 
         // Should not panic on refresh
         assert!(app.refresh().await.is_ok());
@@ -583,6 +600,34 @@ mod tests {
 
         // Check cursor movement
         app.move_cursor(1);
+    }
+
+    #[test]
+    fn test_time_bounds_use_refreshed_window() {
+        let mut app = create_test_app();
+        app.view_end_ts = 1_700_000_000;
+
+        assert_eq!(app.time_bounds(), (1_699_996_400.0, 1_700_000_000.0));
+
+        app.time_offset = Duration::from_secs(300);
+        assert_eq!(app.time_bounds(), (1_699_996_400.0, 1_700_000_000.0));
+    }
+
+    #[test]
+    fn test_center_and_move_cursor_use_refreshed_window() {
+        let mut app = create_test_app();
+        app.view_end_ts = 1_700_000_000;
+
+        app.center_cursor();
+        assert_eq!(app.cursor_x, Some(1_699_998_200.0));
+
+        app.cursor_x = Some(1_700_000_000.0);
+        app.move_cursor(1);
+        assert_eq!(app.cursor_x, Some(1_700_000_000.0));
+
+        app.cursor_x = Some(1_699_996_400.0);
+        app.move_cursor(-1);
+        assert_eq!(app.cursor_x, Some(1_699_996_400.0));
     }
 }
 
@@ -621,16 +666,20 @@ pub fn parse_duration(s: &str) -> Result<Duration> {
 pub async fn run_app<B: ratatui::backend::Backend>(
     terminal: &mut Terminal<B>,
     app: &mut AppState,
-    tick_rate: Duration,
+    _tick_rate: Duration,
 ) -> Result<()>
 where
     <B as ratatui::backend::Backend>::Error: Send + Sync + 'static,
 {
-    loop {
-        terminal.draw(|f| ui::draw_ui(f, app))?;
+    let mut needs_draw = true;
 
-        let timeout = tick_rate.saturating_sub(app.last_refresh.elapsed().min(tick_rate));
-        let should_refresh = app.last_refresh.elapsed() >= app.refresh_every;
+    loop {
+        if needs_draw {
+            terminal.draw(|f| ui::draw_ui(f, app))?;
+            needs_draw = false;
+        }
+
+        let timeout = app.refresh_every.saturating_sub(app.last_refresh.elapsed());
 
         if event::poll(timeout)? {
             match event::read()? {
@@ -706,12 +755,7 @@ where
                             }
                             KeyCode::Char('v') => {
                                 app.mode = AppMode::FullscreenInspect;
-                                // Initialize cursor
-                                let end_ts = (chrono::Utc::now().timestamp()
-                                    - app.time_offset.as_secs() as i64)
-                                    as f64;
-                                let start_ts = end_ts - app.range.as_secs_f64();
-                                app.cursor_x = Some((start_ts + end_ts) / 2.0);
+                                app.center_cursor();
                             }
                             KeyCode::Char('q') => return Ok(()),
                             KeyCode::Char('r') | KeyCode::Char('R') => {
@@ -788,11 +832,7 @@ where
                             }
                             KeyCode::Char('v') => {
                                 app.mode = AppMode::Inspect;
-                                let end_ts = (chrono::Utc::now().timestamp()
-                                    - app.time_offset.as_secs() as i64)
-                                    as f64;
-                                let start_ts = end_ts - app.range.as_secs_f64();
-                                app.cursor_x = Some((start_ts + end_ts) / 2.0);
+                                app.center_cursor();
                             }
                             KeyCode::Char('q') => return Ok(()),
                             KeyCode::Char('r') | KeyCode::Char('R') => {
@@ -929,10 +969,7 @@ where
                                             (mouse.column.saturating_sub(panel_rect.x + 1)) as f64;
                                         let fraction = (relative_x / chart_width).clamp(0.0, 1.0);
 
-                                        let end_ts = (chrono::Utc::now().timestamp()
-                                            - app.time_offset.as_secs() as i64)
-                                            as f64;
-                                        let start_ts = end_ts - app.range.as_secs_f64();
+                                        let (start_ts, _) = app.time_bounds();
 
                                         app.cursor_x =
                                             Some(start_ts + fraction * app.range.as_secs_f64());
@@ -952,12 +989,13 @@ where
                 },
                 _ => {}
             }
+
+            needs_draw = true;
         }
 
-        if should_refresh {
+        if app.last_refresh.elapsed() >= app.refresh_every {
             app.refresh().await?;
+            needs_draw = true;
         }
-
-        sleep(Duration::from_millis(10)).await;
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,7 +25,7 @@ pub struct Args {
     #[arg(long, value_name = "FILE")]
     pub grafana_json: Option<PathBuf>,
 
-    /// UI tick rate in milliseconds (screen refresh cadence)
+    /// Legacy UI tick rate in milliseconds; redraws now happen on input and data refresh
     #[arg(long, default_value = "250")]
     pub tick_rate: u64,
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -571,10 +571,8 @@ fn render_graph_panel(
     let chart_area = chunks[0];
     let legend_area = chunks[1];
 
-    // Determine x bounds from range window (unix seconds)
-    // Use app.time_offset to shift the window
-    let now = (chrono::Utc::now().timestamp() - app.time_offset.as_secs() as i64) as f64;
-    let start = now - app.range.as_secs_f64();
+    // Determine x bounds from the last refreshed query window.
+    let (start, now) = app.time_bounds();
 
     // Calculate y_bounds once
     let y_bounds = calculate_y_bounds(p);


### PR DESCRIPTION
## Description

This fixes an issue where the UI continued redrawing between data refreshes and recalculated graph time bounds from the current wall clock on each draw.

As a result, graphs could appear to blink or shift slightly even when no new Prometheus data had been fetched, and x-axis timestamps kept advancing every second despite the displayed data still belonging to the previous refresh window.

The change stores the query window end timestamp from the last refresh and uses it consistently for graph rendering and inspect cursor behavior. The main loop now redraws only after user input or an actual data refresh, reducing unnecessary rendering work between refreshes.

Fixes #35 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have used Conventional Commits for my commit messages