### PR TITLE
feat: implement panel navigation via PgUp/PgDn and refactor selection logic into dedicated methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ grafatui --config examples/demo/grafatui.toml
 | `[` / `]` | Pan left / right (time) |
 | `0` | Reset to live mode |
 | `↑` / `↓` or `k` / `j` | Select previous/next panel |
-| `PgUp` / `PgDn` | Scroll vertically |
+| `PgUp` / `PgDn` | Scroll vertically (normal) / select previous or next panel (fullscreen) |
 | `Home` / `End` | Jump to top / bottom |
 | `y` | Toggle Y-axis mode |
 | `1`..`9` | Toggle series visibility |

--- a/src/app.rs
+++ b/src/app.rs
@@ -306,6 +306,22 @@ impl AppState {
         }
     }
 
+    /// Selects the previous panel, keeping the dashboard scrolled to it.
+    fn select_previous_panel(&mut self) {
+        if self.selected_panel > 0 {
+            self.selected_panel -= 1;
+            self.scroll_to_selected_panel();
+        }
+    }
+
+    /// Selects the next panel, keeping the dashboard scrolled to it.
+    fn select_next_panel(&mut self) {
+        if self.selected_panel < self.panels.len().saturating_sub(1) {
+            self.selected_panel += 1;
+            self.scroll_to_selected_panel();
+        }
+    }
+
     /// Pan right: shift the time window forward (toward "now").
     pub fn pan_right(&mut self) {
         // Shift by 25% of the current range
@@ -584,6 +600,37 @@ mod tests {
         // Check cursor movement
         app.move_cursor(1);
     }
+
+    #[test]
+    fn test_select_panel_navigation_is_bounded() {
+        let prom = prom::PromClient::new("http://localhost:9090".to_string());
+        let mut app = AppState::new(
+            prom,
+            Duration::from_secs(3600),
+            Duration::from_secs(60),
+            Duration::from_millis(1000),
+            "Test".to_string(),
+            default_queries(vec![
+                "up".to_string(),
+                "process_cpu_seconds_total".to_string(),
+            ]),
+            0,
+            Theme::default(),
+            "dashed".to_string(),
+        );
+
+        app.select_previous_panel();
+        assert_eq!(app.selected_panel, 0);
+
+        app.select_next_panel();
+        assert_eq!(app.selected_panel, 1);
+
+        app.select_next_panel();
+        assert_eq!(app.selected_panel, 1);
+
+        app.select_previous_panel();
+        assert_eq!(app.selected_panel, 0);
+    }
 }
 
 pub fn default_queries(mut provided: Vec<String>) -> Vec<PanelState> {
@@ -717,6 +764,12 @@ where
                             KeyCode::Char('r') | KeyCode::Char('R') => {
                                 app.refresh().await?;
                             }
+                            KeyCode::PageUp => {
+                                app.select_previous_panel();
+                            }
+                            KeyCode::PageDown => {
+                                app.select_next_panel();
+                            }
                             // Allow some navigation/interaction in fullscreen too?
                             // For now, just basic ones.
                             KeyCode::Char('+') => {
@@ -799,18 +852,10 @@ where
                                 app.refresh().await?;
                             }
                             KeyCode::Up | KeyCode::Char('k') => {
-                                if app.selected_panel > 0 {
-                                    app.selected_panel -= 1;
-                                    // Auto-scroll to ensure selected panel is visible
-                                    app.scroll_to_selected_panel();
-                                }
+                                app.select_previous_panel();
                             }
                             KeyCode::Down | KeyCode::Char('j') => {
-                                if app.selected_panel < app.panels.len().saturating_sub(1) {
-                                    app.selected_panel += 1;
-                                    // Auto-scroll to ensure selected panel is visible
-                                    app.scroll_to_selected_panel();
-                                }
+                                app.select_next_panel();
                             }
                             KeyCode::PageUp => {
                                 app.vertical_scroll = app.vertical_scroll.saturating_sub(10);


### PR DESCRIPTION
## Description

Adds fullscreen panel navigation with `PgUp` and `PgDn`, allowing users to move to the previous or next graph without leaving fullscreen mode. This avoids the previous workflow of exiting fullscreen, selecting another panel, and entering fullscreen again.

Also refactors existing normal-mode panel navigation to reuse the same bounded selection helpers, adds a unit test for navigation boundaries, and updates the README keyboard controls.

Fixes # 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have used Conventional Commits for my commit messages