### PR TITLE
feat: implement dashboard variable support and add Prometheus builtin interval/range variable expansion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -825,6 +825,7 @@ dependencies = [
  "futures",
  "humantime",
  "ratatui",
+ "regex",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ tokio = { version = "1.48.0", features = ["full"] }
 toml = "0.8.19"
 directories = "5.0.1"
 urlencoding = "2.1.3"
+regex = "1.12.3"
 
 [package.metadata.deb]
 maintainer = "Federico D'Ambrosio <fedexist@gmail.com>"

--- a/GRAFANA_COMPATIBILITY.md
+++ b/GRAFANA_COMPATIBILITY.md
@@ -111,11 +111,11 @@ This document provides a comprehensive feature-parity table between the [Grafana
 | Variable | Status | Notes |
 |---|---|---|
 | `$__rate_interval` | ✅ Supported | Computed as `max(step × 4, 60s)` |
-| `$__interval` | ❌ Not Implemented | |
-| `$__interval_ms` | ❌ Not Implemented | |
-| `$__range` | ❌ Not Implemented | |
-| `$__range_s` | ❌ Not Implemented | |
-| `$__range_ms` | ❌ Not Implemented | |
+| `$__interval` | ✅ Supported | Computed from the current range and panel resolution, bounded by `--step` |
+| `$__interval_ms` | ✅ Supported | Millisecond form of `$__interval` |
+| `$__range` | ✅ Supported | Current dashboard time range |
+| `$__range_s` | ✅ Supported | Current dashboard time range in seconds |
+| `$__range_ms` | ✅ Supported | Current dashboard time range in milliseconds |
 
 ---
 
@@ -128,14 +128,14 @@ This document provides a comprehensive feature-parity table between the [Grafana
 | `templating.list[].current.value` | ✅ Supported | Used as default value |
 | `templating.list[].current.text` | 🔶 Partial | Used as fallback if `value` is missing |
 | `templating.list[].allValue` | ✅ Supported | Used when value is `$__all`, falls back to `.*` |
-| `templating.list[].type` | ❌ Not Implemented | All variables treated as simple values |
-| `templating.list[].query` | ❌ Not Implemented | No dynamic variable queries |
+| `templating.list[].type` | 🔶 Partial | `query` variables are resolved for Prometheus |
+| `templating.list[].query` | 🔶 Partial | Supports Prometheus `label_values(...)` and `query_result(...)` |
 | `templating.list[].datasource` | ❌ Not Implemented | |
-| `templating.list[].regex` | ❌ Not Implemented | |
+| `templating.list[].regex` | 🔶 Partial | Applied to dynamic query variable results |
 | `templating.list[].sort` | ❌ Not Implemented | |
 | `templating.list[].multi` | ❌ Not Implemented | Multi-value selection not supported |
 | `templating.list[].includeAll` | ❌ Not Implemented | |
-| `templating.list[].refresh` | ❌ Not Implemented | Variables are static after import |
+| `templating.list[].refresh` | 🔶 Partial | Dynamic variables refresh before panel queries |
 | `templating.list[].options` | ❌ Not Implemented | No dropdown/picker UI |
 | `templating.list[].hide` | ❌ Not Implemented | |
 | CLI `--var KEY=VALUE` override | ✅ Supported | Overrides dashboard defaults from command line |

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This demo showcases all 7 visualization types (graph, stat, gauge, bar gauge, ta
 ### Grafana Dashboard Import
 - **Import existing dashboards** from JSON files
 - **Supported panels**: graph, timeseries, gauge, bargauge, table, stat, heatmap
-- **Template variables** with CLI overrides
+- **Template variables** with built-in PromQL time variables, dynamic Prometheus query variables, and CLI overrides
 - **Legend formatting** (`{{label}}` syntax)
 - **Grid layouts** using `gridPos`
 - **Thresholds** dynamically applied to metrics and graph limits
@@ -179,6 +179,8 @@ grafatui --prometheus-url http://prod-prom:9090 --grafana-json ./node-exporter.j
 ```bash
 grafatui --grafana-json ./dash.json --var job=node --var instance=server-01
 ```
+
+Grafana query variables such as `label_values(up, instance)` and `query_result(...)` are resolved from Prometheus before panel queries run. Built-in PromQL variables including `$__interval`, `$__interval_ms`, `$__range`, `$__range_s`, `$__range_ms`, and `$__rate_interval` are expanded automatically.
 
 **Use a theme:**
 ```bash

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -52,8 +52,8 @@ For a field-by-field breakdown of Grafana JSON compatibility, see [GRAFANA_COMPA
 | **Value mappings** | Map numeric values to text labels (`fieldConfig.defaults.mappings`) | 🟡 | 📋 |
 | **Reduce options** | Support `calcs` other than "last" for stat/gauge panels | 🟡 | 📋 |
 | **Legend configuration** | Respect `options.legend` display mode, placement, and calcs | 🟡 | 📋 |
-| **Additional PromQL variables** | `$__interval`, `$__range`, `$__range_s` | 🟢 | 📋 |
-| **Dynamic template variables** | Query Prometheus for variable values (`type: "query"`) | 🟡 | 📋 |
+| **Additional PromQL variables** | `$__interval`, `$__interval_ms`, `$__range`, `$__range_s`, `$__range_ms` | ✅ | ✅ |
+| **Dynamic template variables** | Query Prometheus for variable values (`type: "query"`) | ✅ | ✅ |
 | **Draw styles** | Respect `bars`, `points`, `line` from `fieldConfig.defaults.custom.drawStyle` | 🟡 | 📋 |
 | **Stacking** | Stacked area/bar charts from `fieldConfig.defaults.custom.stacking` | 🟡 | 📋 |
 

--- a/src/app/data.rs
+++ b/src/app/data.rs
@@ -19,12 +19,31 @@ use anyhow::Result;
 use std::collections::HashMap;
 use std::time::Duration;
 
-pub(crate) fn expand_expr(expr: &str, step: Duration, vars: &HashMap<String, String>) -> String {
+const PANEL_RESOLUTION_POINTS: u32 = 200;
+
+pub(crate) fn expand_expr(
+    expr: &str,
+    range: Duration,
+    step: Duration,
+    vars: &HashMap<String, String>,
+) -> String {
     let mut s = expr.to_string();
+
+    let interval = interval_duration(range, step);
+    s = replace_builtin(&s, "__interval_ms", &interval.as_millis().to_string());
+    s = replace_builtin(&s, "__interval", &format_prom_duration(interval));
+    s = replace_builtin(&s, "__range_ms", &range.as_millis().to_string());
+    s = replace_builtin(&s, "__range_s", &range.as_secs().to_string());
+    s = replace_builtin(&s, "__range", &format_prom_duration(range));
 
     let interval_secs = std::cmp::max(step.as_secs() * 4, 60);
     let interval_param = format!("{}s", interval_secs);
-    s = s.replace("$__rate_interval", &interval_param);
+    s = replace_builtin(
+        &s,
+        "__rate_interval_ms",
+        &(interval_secs * 1000).to_string(),
+    );
+    s = replace_builtin(&s, "__rate_interval", &interval_param);
 
     for (k, v) in vars {
         s = s.replace(&format!("${{{}}}", k), v);
@@ -32,6 +51,38 @@ pub(crate) fn expand_expr(expr: &str, step: Duration, vars: &HashMap<String, Str
     }
 
     s
+}
+
+fn replace_builtin(expr: &str, name: &str, value: &str) -> String {
+    expr.replace(&format!("${{{}}}", name), value)
+        .replace(&format!("${}", name), value)
+}
+
+fn interval_duration(range: Duration, step: Duration) -> Duration {
+    let resolution = range / PANEL_RESOLUTION_POINTS;
+    let interval = resolution.max(step);
+    interval.max(Duration::from_secs(1))
+}
+
+fn format_prom_duration(duration: Duration) -> String {
+    let secs = duration.as_secs();
+    if secs == 0 {
+        return format!("{}ms", duration.as_millis().max(1));
+    }
+
+    const DAY: u64 = 24 * 60 * 60;
+    const HOUR: u64 = 60 * 60;
+    const MINUTE: u64 = 60;
+
+    if secs % DAY == 0 {
+        format!("{}d", secs / DAY)
+    } else if secs % HOUR == 0 {
+        format!("{}h", secs / HOUR)
+    } else if secs % MINUTE == 0 {
+        format!("{}m", secs / MINUTE)
+    } else {
+        format!("{}s", secs)
+    }
 }
 
 pub(crate) fn format_legend(fmt: &str, metric: &HashMap<String, String>) -> String {
@@ -109,12 +160,12 @@ mod tests {
         let vars = HashMap::new();
         let step = Duration::from_secs(15);
         let expr = "rate(http_requests_total[$__rate_interval])";
-        let expanded = expand_expr(expr, step, &vars);
+        let expanded = expand_expr(expr, Duration::from_secs(300), step, &vars);
         assert_eq!(expanded, "rate(http_requests_total[60s])");
 
         let step = Duration::from_secs(30);
         let expr = "rate(http_requests_total[$__rate_interval])";
-        let expanded = expand_expr(expr, step, &vars);
+        let expanded = expand_expr(expr, Duration::from_secs(300), step, &vars);
         assert_eq!(expanded, "rate(http_requests_total[120s])");
     }
 
@@ -127,20 +178,34 @@ mod tests {
         let step = Duration::from_secs(15);
 
         let expr = "up{job=\"$job\"}";
-        let expanded = expand_expr(expr, step, &vars);
+        let expanded = expand_expr(expr, Duration::from_secs(300), step, &vars);
         assert_eq!(expanded, "up{job=\"node-exporter\"}");
 
         let expr = "up{instance=\"${instance}\"}";
-        let expanded = expand_expr(expr, step, &vars);
+        let expanded = expand_expr(expr, Duration::from_secs(300), step, &vars);
         assert_eq!(expanded, "up{instance=\"localhost:9100\"}");
 
         let expr =
             "rate(http_requests_total{job=\"$job\", instance=\"$instance\"}[$__rate_interval])";
-        let expanded = expand_expr(expr, step, &vars);
+        let expanded = expand_expr(expr, Duration::from_secs(300), step, &vars);
         assert_eq!(
             expanded,
             "rate(http_requests_total{job=\"node-exporter\", instance=\"localhost:9100\"}[60s])"
         );
+    }
+
+    #[test]
+    fn test_expand_expr_builtin_intervals_and_range() {
+        let vars = HashMap::new();
+        let range = Duration::from_secs(24 * 60 * 60);
+        let step = Duration::from_secs(60);
+        let expr = "rate(http_requests_total[$__interval]) offset $__range";
+        let expanded = expand_expr(expr, range, step, &vars);
+        assert_eq!(expanded, "rate(http_requests_total[432s]) offset 1d");
+
+        let expr = "sum_over_time(up[${__range_s}s]) / $__interval_ms / $__range_ms";
+        let expanded = expand_expr(expr, range, step, &vars);
+        assert_eq!(expanded, "sum_over_time(up[86400s]) / 432000 / 86400000");
     }
 
     #[test]

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -18,6 +18,7 @@ mod data;
 mod event_loop;
 mod input;
 mod state;
+mod variables;
 
 pub(crate) use data::{default_queries, parse_duration};
 pub(crate) use event_loop::run_app;

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -15,6 +15,8 @@
  */
 
 use crate::app::data::{downsample, expand_expr, format_legend};
+use crate::app::variables::refresh_query_variables;
+use crate::grafana::TemplateQueryVar;
 use crate::prom;
 use crate::theme::Theme;
 use anyhow::Result;
@@ -202,6 +204,8 @@ pub(crate) struct AppState {
     pub(crate) debug_bar: bool,
     /// Template variables (key -> value).
     pub(crate) vars: HashMap<String, String>,
+    /// Prometheus-backed template variables imported from Grafana.
+    pub(crate) query_vars: Vec<TemplateQueryVar>,
     /// Count of panels skipped during import.
     pub(crate) skipped_panels: usize,
     /// Index of the currently selected panel.
@@ -263,6 +267,7 @@ impl AppState {
             title,
             debug_bar: false,
             vars: HashMap::new(),
+            query_vars: Vec::new(),
             skipped_panels,
             selected_panel: 0,
             theme,
@@ -379,13 +384,24 @@ impl AppState {
     }
 
     pub(crate) async fn refresh(&mut self) -> Result<()> {
-        let prometheus = &self.prometheus;
         let range = self.range;
         let step = self.step;
-        let vars = &self.vars;
 
         // Calculate end timestamp: "now" minus time_offset
         let end_ts = chrono::Utc::now().timestamp() - self.time_offset.as_secs() as i64;
+
+        let _ = refresh_query_variables(
+            &self.prometheus,
+            &self.query_vars,
+            range,
+            step,
+            end_ts,
+            &mut self.vars,
+        )
+        .await;
+
+        let prometheus = &self.prometheus;
+        let vars = &self.vars;
 
         // Create a stream of futures for fetching panel data
         let mut futures = futures::stream::iter(self.panels.iter_mut())
@@ -424,7 +440,7 @@ impl AppState {
         let mut error = None;
 
         for (i, expr) in p.exprs.iter().enumerate() {
-            let expr_expanded = expand_expr(expr, step, vars);
+            let expr_expanded = expand_expr(expr, range, step, vars);
             let legend_fmt = p.legends.get(i).and_then(|x| x.as_ref());
 
             // Calculate start/end for URL display purposes

--- a/src/app/variables.rs
+++ b/src/app/variables.rs
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2025 Federico D'Ambrosio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use super::data::expand_expr;
+use crate::grafana::TemplateQueryVar;
+use crate::prom;
+use anyhow::{Result, anyhow};
+use regex::Regex;
+use std::collections::HashMap;
+use std::time::Duration;
+
+enum PrometheusVariableQuery {
+    LabelValues {
+        metric: Option<String>,
+        label: String,
+    },
+    QueryResult(String),
+}
+
+pub(crate) async fn refresh_query_variables(
+    prometheus: &prom::PromClient,
+    query_vars: &[TemplateQueryVar],
+    range: Duration,
+    step: Duration,
+    end_ts: i64,
+    vars: &mut HashMap<String, String>,
+) -> Result<()> {
+    for query_var in query_vars {
+        let Some(value) =
+            resolve_query_variable(prometheus, query_var, range, step, end_ts, vars).await?
+        else {
+            continue;
+        };
+
+        vars.insert(query_var.name.clone(), value);
+    }
+
+    Ok(())
+}
+
+async fn resolve_query_variable(
+    prometheus: &prom::PromClient,
+    query_var: &TemplateQueryVar,
+    range: Duration,
+    step: Duration,
+    end_ts: i64,
+    vars: &HashMap<String, String>,
+) -> Result<Option<String>> {
+    let expanded_query = expand_expr(&query_var.query, range, step, vars);
+    let query = parse_prometheus_variable_query(&expanded_query)?;
+    let start_ts = end_ts - range.as_secs() as i64;
+    let values = match query {
+        PrometheusVariableQuery::LabelValues { metric, label } => {
+            if let Some(metric) = metric {
+                prometheus
+                    .series_label_values(&metric, &label, start_ts, end_ts)
+                    .await?
+            } else {
+                prometheus.label_values(&label).await?
+            }
+        }
+        PrometheusVariableQuery::QueryResult(query) => {
+            prometheus
+                .query_instant_result_strings(&query, end_ts)
+                .await?
+        }
+    };
+
+    Ok(first_value(apply_regex(
+        values,
+        query_var.regex.as_deref(),
+    )?))
+}
+
+fn parse_prometheus_variable_query(query: &str) -> Result<PrometheusVariableQuery> {
+    if let Some(args) = call_args(query, "label_values") {
+        let args = split_top_level_args(args);
+        return match args.as_slice() {
+            [label] => Ok(PrometheusVariableQuery::LabelValues {
+                metric: None,
+                label: label.trim().to_string(),
+            }),
+            [metric, label] => Ok(PrometheusVariableQuery::LabelValues {
+                metric: Some(metric.trim().to_string()),
+                label: label.trim().to_string(),
+            }),
+            _ => Err(anyhow!("unsupported label_values query: {}", query)),
+        };
+    }
+
+    if let Some(args) = call_args(query, "query_result") {
+        return Ok(PrometheusVariableQuery::QueryResult(
+            args.trim().to_string(),
+        ));
+    }
+
+    Ok(PrometheusVariableQuery::QueryResult(
+        query.trim().to_string(),
+    ))
+}
+
+fn call_args<'a>(query: &'a str, name: &str) -> Option<&'a str> {
+    let query = query.trim();
+    let rest = query.strip_prefix(name)?.trim_start();
+    let inner = rest.strip_prefix('(')?.strip_suffix(')')?;
+    Some(inner)
+}
+
+fn split_top_level_args(args: &str) -> Vec<&str> {
+    let mut parts = Vec::new();
+    let mut start = 0;
+    let mut depth = 0;
+
+    for (idx, ch) in args.char_indices() {
+        match ch {
+            '(' | '[' | '{' => depth += 1,
+            ')' | ']' | '}' => depth -= 1,
+            ',' if depth == 0 => {
+                parts.push(args[start..idx].trim());
+                start = idx + ch.len_utf8();
+            }
+            _ => {}
+        }
+    }
+
+    parts.push(args[start..].trim());
+    parts.into_iter().filter(|part| !part.is_empty()).collect()
+}
+
+fn apply_regex(values: Vec<String>, regex: Option<&str>) -> Result<Vec<String>> {
+    let Some(regex) = regex.map(str::trim).filter(|regex| !regex.is_empty()) else {
+        return Ok(values);
+    };
+
+    let pattern = regex
+        .strip_prefix('/')
+        .and_then(|regex| regex.rsplit_once('/').map(|(pattern, _)| pattern))
+        .unwrap_or(regex);
+    let regex = Regex::new(pattern)?;
+
+    Ok(values
+        .into_iter()
+        .filter_map(|value| {
+            let captures = regex.captures(&value)?;
+            captures
+                .get(1)
+                .or_else(|| captures.get(0))
+                .map(|matched| matched.as_str().to_string())
+        })
+        .collect())
+}
+
+fn first_value(values: Vec<String>) -> Option<String> {
+    values.into_iter().find(|value| !value.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_split_label_values_query() {
+        let PrometheusVariableQuery::LabelValues { metric, label } =
+            parse_prometheus_variable_query("label_values(up{job=~\"$job\"}, instance)").unwrap()
+        else {
+            panic!("expected label_values query");
+        };
+
+        assert_eq!(metric.as_deref(), Some("up{job=~\"$job\"}"));
+        assert_eq!(label, "instance");
+    }
+
+    #[test]
+    fn test_parse_label_values_without_metric() {
+        let PrometheusVariableQuery::LabelValues { metric, label } =
+            parse_prometheus_variable_query("label_values(model_name)").unwrap()
+        else {
+            panic!("expected label_values query");
+        };
+
+        assert!(metric.is_none());
+        assert_eq!(label, "model_name");
+    }
+
+    #[test]
+    fn test_regex_extracts_first_capture_group() {
+        let values = vec![
+            r#"{instance="node-2", job="node"} 1"#.to_string(),
+            r#"{instance="node-1", job="node"} 1"#.to_string(),
+        ];
+
+        let values = apply_regex(values, Some(r#"/instance="([^"]+)"/"#)).unwrap();
+
+        assert_eq!(first_value(values), Some("node-2".to_string()));
+    }
+}

--- a/src/grafana.rs
+++ b/src/grafana.rs
@@ -27,8 +27,21 @@ pub(crate) struct DashboardImport {
     pub(crate) queries: Vec<QueryPanel>,
     /// Variables extracted from `templating.list`.
     pub(crate) vars: HashMap<String, String>,
+    /// Dynamic query variables extracted from `templating.list`.
+    pub(crate) query_vars: Vec<TemplateQueryVar>,
     /// Number of panels that were skipped (unsupported types).
     pub(crate) skipped_panels: usize,
+}
+
+/// A Prometheus-backed Grafana template variable.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct TemplateQueryVar {
+    /// Variable name used in PromQL expressions.
+    pub(crate) name: String,
+    /// Prometheus variable query expression.
+    pub(crate) query: String,
+    /// Optional Grafana regex extractor.
+    pub(crate) regex: Option<String>,
 }
 
 /// A single panel extracted from Grafana.
@@ -69,11 +82,22 @@ struct RawTemplating {
 #[derive(Debug, Deserialize)]
 struct RawVar {
     name: String,
+    #[serde(rename = "type")]
+    var_type: Option<String>,
+    query: Option<RawVarQuery>,
+    definition: Option<String>,
+    regex: Option<String>,
     current: Option<RawVarCurrent>,
     /// The value to use when "All" is selected. Used to replace $__all in queries.
     #[serde(rename = "allValue")]
     all_value: Option<String>,
-    // We could parse 'query' or 'type' if needed, but for now we just want defaults
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum RawVarQuery {
+    String(String),
+    Object { query: Option<String> },
 }
 
 #[derive(Debug, Deserialize)]
@@ -155,6 +179,7 @@ pub(crate) fn load_grafana_dashboard(path: &std::path::Path) -> Result<Dashboard
         serde_json::from_str(&data).with_context(|| "parsing grafana dashboard JSON")?;
 
     let mut vars = HashMap::new();
+    let mut query_vars = Vec::new();
     if let Some(templating) = raw.templating {
         if let Some(list) = templating.list {
             for v in list {
@@ -191,8 +216,19 @@ pub(crate) fn load_grafana_dashboard(path: &std::path::Path) -> Result<Dashboard
                     }
 
                     if !s.is_empty() {
-                        vars.insert(v.name, s);
+                        vars.insert(v.name.clone(), s);
                     }
+                }
+
+                if v.var_type.as_deref() == Some("query")
+                    && !v.current_is_all()
+                    && let Some(query) = v.query_string()
+                {
+                    query_vars.push(TemplateQueryVar {
+                        name: v.name,
+                        query,
+                        regex: v.regex.filter(|regex| !regex.trim().is_empty()),
+                    });
                 }
             }
         }
@@ -202,6 +238,7 @@ pub(crate) fn load_grafana_dashboard(path: &std::path::Path) -> Result<Dashboard
         title: raw.title.unwrap_or_default(),
         queries: vec![],
         vars,
+        query_vars,
         skipped_panels: 0,
     };
 
@@ -209,6 +246,40 @@ pub(crate) fn load_grafana_dashboard(path: &std::path::Path) -> Result<Dashboard
         collect_panels(&mut out, panels)?;
     }
     Ok(out)
+}
+
+impl RawVar {
+    fn query_string(&self) -> Option<String> {
+        let query = self
+            .query
+            .as_ref()
+            .and_then(|query| match query {
+                RawVarQuery::String(query) => Some(query.as_str()),
+                RawVarQuery::Object { query } => query.as_deref(),
+            })
+            .or(self.definition.as_deref())?;
+
+        let query = query.trim();
+        (!query.is_empty()).then(|| query.to_string())
+    }
+
+    fn current_is_all(&self) -> bool {
+        self.current.as_ref().is_some_and(|current| {
+            value_is_all(current.value.as_ref()) || value_is_all(current.text.as_ref())
+        })
+    }
+}
+
+fn value_is_all(value: Option<&serde_json::Value>) -> bool {
+    match value {
+        Some(serde_json::Value::String(value)) => {
+            value == "$__all" || value.eq_ignore_ascii_case("all")
+        }
+        Some(serde_json::Value::Array(values)) => {
+            values.iter().any(|value| value_is_all(Some(value)))
+        }
+        _ => false,
+    }
 }
 
 fn collect_panels(out: &mut DashboardImport, panels: Vec<RawPanel>) -> Result<()> {
@@ -396,5 +467,50 @@ mod tests {
 
         assert_eq!(dashboard.queries[0].autogrid, Some(false));
         assert_eq!(dashboard.queries[1].autogrid, None);
+    }
+
+    #[test]
+    fn test_parse_query_variables() {
+        let json = r#"
+        {
+            "title": "Query Vars",
+            "templating": {
+                "list": [
+                    {
+                        "name": "instance",
+                        "query": "label_values(up, instance)",
+                        "type": "query",
+                        "regex": "/(.+)/",
+                        "includeAll": false,
+                        "current": { "text": "node-1", "value": "node-1" }
+                    },
+                    {
+                        "name": "model",
+                        "query": { "query": "label_values(model_name)" },
+                        "type": "query",
+                        "current": { "text": "llama", "value": "llama" }
+                    },
+                    {
+                        "name": "all_instance",
+                        "query": "label_values(up, instance)",
+                        "type": "query",
+                        "allValue": ".*",
+                        "current": { "text": "All", "value": "$__all" }
+                    }
+                ]
+            }
+        }
+        "#;
+        let path = std::env::temp_dir().join("grafatui-query-vars-test.json");
+        std::fs::write(&path, json).unwrap();
+
+        let dashboard = load_grafana_dashboard(&path).unwrap();
+        std::fs::remove_file(path).unwrap();
+
+        assert_eq!(dashboard.query_vars.len(), 2);
+        assert_eq!(dashboard.query_vars[0].query, "label_values(up, instance)");
+        assert_eq!(dashboard.query_vars[0].regex.as_deref(), Some("/(.+)/"));
+        assert_eq!(dashboard.query_vars[1].query, "label_values(model_name)");
+        assert_eq!(dashboard.vars.get("all_instance"), Some(&".*".to_string()));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ mod prom;
 mod theme;
 mod ui;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 
 use anyhow::{Context, Result};
@@ -98,6 +98,7 @@ async fn main() -> Result<()> {
         .unwrap_or(ratatui::style::Color::DarkGray);
 
     let mut vars: HashMap<String, String> = HashMap::new();
+    let mut query_vars = Vec::new();
 
     let prom = prom::PromClient::new(prometheus_url);
 
@@ -112,6 +113,7 @@ async fn main() -> Result<()> {
         for (k, v) in d.vars {
             vars.insert(k, v);
         }
+        query_vars = d.query_vars;
 
         let ps = d
             .queries
@@ -144,16 +146,20 @@ async fn main() -> Result<()> {
     };
 
     // Merge config vars (if any)
+    let mut pinned_vars = HashSet::new();
     if let Some(config_vars) = config.vars {
         for (k, v) in config_vars {
+            pinned_vars.insert(k.clone());
             vars.insert(k, v);
         }
     }
 
     // CLI vars override dashboard defaults and config vars
     for (k, v) in &args.var {
+        pinned_vars.insert(k.clone());
         vars.insert(k.clone(), v.clone());
     }
+    query_vars.retain(|var| !pinned_vars.contains(&var.name));
 
     // Determine theme
     let theme_name = args
@@ -182,6 +188,7 @@ async fn main() -> Result<()> {
     state.autogrid_enabled = autogrid_enabled;
     state.autogrid_color = autogrid_color;
     state.vars = vars; // <— pass variables into the app
+    state.query_vars = query_vars;
     state.refresh().await?;
 
     // Terminal setup

--- a/src/prom.rs
+++ b/src/prom.rs
@@ -17,6 +17,7 @@
 use anyhow::{Result, anyhow};
 use reqwest::Client;
 use serde::Deserialize;
+use serde::de::DeserializeOwned;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -163,6 +164,78 @@ impl PromClient {
     }
 
     async fn perform_request(&self, url: &str) -> Result<Vec<Series>> {
+        let text = self.get_text(url).await?;
+
+        let body: PromResponse<QueryRangeData> = serde_json::from_str(&text)
+            .map_err(|e| anyhow!("parsing json: {} (body: {})", e, text))?;
+
+        if body.status != "success" {
+            return Err(anyhow!(
+                "prometheus error status: {} — body: {}",
+                body.status,
+                text
+            ));
+        }
+
+        Ok(body.data.result)
+    }
+
+    pub(crate) async fn label_values(&self, label: &str) -> Result<Vec<String>> {
+        let url = format!(
+            "{}/api/v1/label/{}/values",
+            self.base.trim_end_matches('/'),
+            urlencoding::encode(label)
+        );
+        let body: PromResponse<Vec<String>> = self.get_json(&url).await?;
+        ensure_success(&body.status)?;
+        Ok(body.data)
+    }
+
+    pub(crate) async fn series_label_values(
+        &self,
+        metric: &str,
+        label: &str,
+        start: i64,
+        end: i64,
+    ) -> Result<Vec<String>> {
+        let url = format!(
+            "{}/api/v1/series?match[]={}&start={}&end={}",
+            self.base.trim_end_matches('/'),
+            urlencoding::encode(metric),
+            start,
+            end
+        );
+        let body: PromResponse<Vec<HashMap<String, String>>> = self.get_json(&url).await?;
+        ensure_success(&body.status)?;
+        Ok(body
+            .data
+            .into_iter()
+            .filter_map(|series| series.get(label).cloned())
+            .collect())
+    }
+
+    pub(crate) async fn query_instant_result_strings(
+        &self,
+        expr: &str,
+        time: i64,
+    ) -> Result<Vec<String>> {
+        let url = format!(
+            "{}/api/v1/query?query={}&time={}",
+            self.base.trim_end_matches('/'),
+            urlencoding::encode(expr),
+            time
+        );
+        let body: PromResponse<QueryInstantData> = self.get_json(&url).await?;
+        ensure_success(&body.status)?;
+        Ok(body.data.result_strings())
+    }
+
+    async fn get_json<T: DeserializeOwned>(&self, url: &str) -> Result<T> {
+        let text = self.get_text(url).await?;
+        serde_json::from_str(&text).map_err(|e| anyhow!("parsing json: {} (body: {})", e, text))
+    }
+
+    async fn get_text(&self, url: &str) -> Result<String> {
         let resp = self
             .client
             .get(url)
@@ -179,25 +252,22 @@ impl PromClient {
             return Err(anyhow!("prometheus {}: {}", status, text));
         }
 
-        let body: QueryRangeResponse = serde_json::from_str(&text)
-            .map_err(|e| anyhow!("parsing json: {} (body: {})", e, text))?;
+        Ok(text)
+    }
+}
 
-        if body.status != "success" {
-            return Err(anyhow!(
-                "prometheus error status: {} — body: {}",
-                body.status,
-                text
-            ));
-        }
-
-        Ok(body.data.result)
+fn ensure_success(status: &str) -> Result<()> {
+    if status == "success" {
+        Ok(())
+    } else {
+        Err(anyhow!("prometheus error status: {}", status))
     }
 }
 
 #[derive(Debug, Deserialize, Clone)]
-pub(crate) struct QueryRangeResponse {
-    pub(crate) status: String,
-    pub(crate) data: QueryRangeData,
+struct PromResponse<T> {
+    status: String,
+    data: T,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -212,6 +282,64 @@ pub(crate) struct QueryRangeData {
 pub(crate) struct Series {
     pub(crate) metric: std::collections::HashMap<String, String>,
     pub(crate) values: Vec<(f64, String)>, // (ts, value)
+}
+
+#[derive(Debug, Deserialize, Clone)]
+struct QueryInstantData {
+    #[serde(rename = "resultType")]
+    result_type: String,
+    result: serde_json::Value,
+}
+
+impl QueryInstantData {
+    fn result_strings(self) -> Vec<String> {
+        match self.result_type.as_str() {
+            "vector" => vector_result_strings(&self.result),
+            "scalar" | "string" => scalar_result_string(&self.result).into_iter().collect(),
+            _ => Vec::new(),
+        }
+    }
+}
+
+fn vector_result_strings(result: &serde_json::Value) -> Vec<String> {
+    result
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(|sample| {
+            let metric = sample.get("metric")?.as_object()?;
+            let value = sample
+                .get("value")
+                .and_then(|value| value.as_array())
+                .and_then(|value| value.get(1))
+                .and_then(|value| value.as_str())
+                .unwrap_or_default();
+            let mut labels: Vec<_> = metric
+                .iter()
+                .filter_map(|(label, value)| value.as_str().map(|value| (label, value)))
+                .collect();
+            labels.sort_by(|a, b| a.0.cmp(b.0));
+            let labels = labels
+                .into_iter()
+                .map(|(label, value)| format!("{}=\"{}\"", label, value))
+                .collect::<Vec<_>>()
+                .join(", ");
+
+            if labels.is_empty() {
+                Some(value.to_string())
+            } else {
+                Some(format!("{{{}}} {}", labels, value))
+            }
+        })
+        .collect()
+}
+
+fn scalar_result_string(result: &serde_json::Value) -> Option<String> {
+    result
+        .as_array()
+        .and_then(|value| value.get(1))
+        .and_then(|value| value.as_str())
+        .map(ToString::to_string)
 }
 
 #[cfg(test)]
@@ -256,11 +384,33 @@ mod tests {
         }
         "#;
 
-        let resp: QueryRangeResponse = serde_json::from_str(json).unwrap();
+        let resp: PromResponse<QueryRangeData> = serde_json::from_str(json).unwrap();
         assert_eq!(resp.status, "success");
         assert_eq!(resp.data.result_type, "matrix");
         assert_eq!(resp.data.result.len(), 1);
         assert_eq!(resp.data.result[0].metric.get("job").unwrap(), "prometheus");
         assert_eq!(resp.data.result[0].values.len(), 2);
+    }
+
+    #[test]
+    fn test_query_instant_vector_result_strings() {
+        let json = r#"
+        {
+            "resultType": "vector",
+            "result": [
+                {
+                    "metric": { "instance": "node-1", "job": "node" },
+                    "value": [1435781451.781, "1"]
+                }
+            ]
+        }
+        "#;
+
+        let data: QueryInstantData = serde_json::from_str(json).unwrap();
+
+        assert_eq!(
+            data.result_strings(),
+            vec![r#"{instance="node-1", job="node"} 1"#]
+        );
     }
 }


### PR DESCRIPTION
## Description

Adds Grafana-compatible PromQL built-in variable expansion and dynamic Prometheus-backed template variable resolution.

This change supports `$__interval`, `$__interval_ms`, `$__range`, `$__range_s`, `$__range_ms`, and `$__rate_interval_ms` alongside the existing `$__rate_interval` handling. It also parses Grafana `templating.list[]` entries with `type: "query"` and resolves Prometheus variable queries before panel refreshes, including `label_values(...)`, `query_result(...)`, and Grafana regex extraction.

This reduces manual `--var` overrides when importing standard Grafana dashboards that rely on built-in time variables or dynamic Prometheus template variables.

Fixes #42 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have used Conventional Commits for my commit messages