### PR TITLE
feat: add Grafana display formatting

### DIFF
--- a/GRAFANA_COMPATIBILITY.md
+++ b/GRAFANA_COMPATIBILITY.md
@@ -164,21 +164,21 @@ This document provides a comprehensive feature-parity table between the [Grafana
 
 ## Field Configuration (`fieldConfig`)
 
-`fieldConfig` is partially implemented. Thresholds, min/max bounds, threshold
-style, and per-panel autogrid settings are parsed; display formatting and field
-overrides remain the highest-priority gaps.
+`fieldConfig` is partially implemented. Thresholds, min/max bounds, selected
+display formatting fields, threshold style, and per-panel autogrid settings are
+parsed; value mappings, display names, and field overrides remain major gaps.
 
 | JSON Field | Status | Notes |
 |---|---|---|
 | `fieldConfig` | 🔶 Partial | Parsed for supported defaults/custom fields below |
 | `fieldConfig.defaults` | 🔶 Partial | Parsed for min/max, thresholds, and selected custom fields |
-| `fieldConfig.defaults.unit` | ❌ Not Implemented | Values use Grafatui's SI formatter instead |
+| `fieldConfig.defaults.unit` | 🔶 Partial | Common units such as bytes, bits, seconds, milliseconds, percent, percentunit, ops, request rate, and byte rate are formatted; unknown units fall back to Grafatui's compact SI formatter |
 | `fieldConfig.defaults.min` | ✅ Supported | Used for interpolating percentage thresholds and Gauge limits |
 | `fieldConfig.defaults.max` | ✅ Supported | Used for scaling gauges and threshold boundaries |
-| `fieldConfig.defaults.decimals` | ❌ Not Implemented | Always uses 2 decimal places |
+| `fieldConfig.defaults.decimals` | ✅ Supported | Controls numeric precision in panel values, graph axes, legends, and exports |
 | `fieldConfig.defaults.color` | ❌ Not Implemented | Uses theme palette instead |
 | `fieldConfig.defaults.mappings` | ❌ Not Implemented | Value mappings not supported |
-| `fieldConfig.defaults.noValue` | ❌ Not Implemented | |
+| `fieldConfig.defaults.noValue` | 🔶 Partial | Used for null Stat/Table values and exports; empty panels still show Grafatui's `No data` state |
 | `fieldConfig.defaults.displayName` | ❌ Not Implemented | |
 | `fieldConfig.defaults.custom` | 🔶 Partial | Used for threshold style and axis grid visibility |
 | `fieldConfig.defaults.custom.drawStyle` | ❌ Not Implemented | Always drawn as lines |
@@ -285,14 +285,14 @@ tooltips.
 | PromQL Variables | 7 | 0 | 0 | 0 |
 | Templating | 6 | 6 | 6 | 0 |
 | Variable Substitution | 3 | 0 | 5 | 0 |
-| Field Config | 3 | 4 | 13 | 2 |
+| Field Config | 4 | 6 | 10 | 2 |
 | Thresholds | 5 | 0 | 0 | 0 |
 | Panel Options | 0 | 0 | 14 | 0 |
 | Annotations | 0 | 0 | 2 | 0 |
 | Data Links / Transforms | 0 | 0 | 2 | 1 |
 | Alert Rules | 0 | 0 | 3 | 0 |
 | Datasources | 2 | 1 | 5 | 0 |
-| **Total** | **45** | **12** | **88** | **15** |
+| **Total** | **46** | **14** | **85** | **15** |
 
 ---
 
@@ -300,8 +300,8 @@ tooltips.
 
 Based on user feedback, the following missing features are most commonly expected:
 
-1. **Unit formatting** (`fieldConfig.defaults.unit`) — Display values as bytes, percent, duration, etc.
-2. **Value mappings** (`fieldConfig.defaults.mappings`) — Map numeric values to text labels
+1. **Value mappings** (`fieldConfig.defaults.mappings`) — Map numeric values to text labels
+2. **Broader unit formatting** (`fieldConfig.defaults.unit`) — Extend the current common-unit subset to more Grafana unit families
 3. **Reduce options** (`options.reduceOptions`) — Use min/max/mean/total instead of always using the latest value
 4. **Import diagnostics** — Warn clearly about skipped panel types and ignored high-impact fields
 5. **Instant query panel targets** (`targets[].instant`) — Support point-in-time queries for stat/table-style panels

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -44,6 +44,7 @@ These features are shipped and available today:
 | Field config | **Thresholds** | `fieldConfig.defaults.thresholds` for graph limit lines and Stat/Gauge/BarGauge coloring |
 | Field config | **Threshold marker styles** | Dashed line, dot, braille, block, quadrant, sextant, octant, and related modes |
 | Field config | **Field min/max bounds** | `fieldConfig.defaults.min` / `max` for gauge scaling and percentage thresholds |
+| Field config | **Display formatting subset** | Common `unit` values, `decimals`, and `noValue` for supported panel values, axes, legends, and exports |
 | Export | **SVG/PNG snapshots** | Export the visible dashboard to SVG, PNG, or both |
 | Export | **Recording frame bundles** | Changed-frame recordings with manifest metadata and frame caps |
 | Config | **Config file** | TOML-based persistent configuration |
@@ -95,9 +96,8 @@ This is the main backlog, ordered by Grafana parity domain.
 
 | Feature | Grafana field / behavior | User value | Complexity | Status |
 |---|---|---|---|---|
-| **Unit formatting** | `fieldConfig.defaults.unit` | Bytes, seconds, percentages, rates, and counts display naturally | 🟡 | 🔜 |
-| **Decimal precision** | `fieldConfig.defaults.decimals` | Panel values stop showing distracting precision | 🟢 | 🔜 |
-| **No-value fallback** | `fieldConfig.defaults.noValue` | Empty/null stat and table cells show intentional text | 🟢 | 🔜 |
+| **Broader unit formatting** | `fieldConfig.defaults.unit` | Extends the shipped common-unit subset to more Grafana units | 🟡 | 📋 |
+| **Additional no-value coverage** | `fieldConfig.defaults.noValue` | Extends the shipped null-value fallback beyond current Stat/Table/export paths where relevant | 🟢 | 📋 |
 | **Value mappings** | `fieldConfig.defaults.mappings` | Status codes and enum-like values become readable labels | 🟡 | 🔜 |
 | **Display names** | `fieldConfig.defaults.displayName` | Series and table labels match Grafana naming | 🟢 | 📋 |
 | **Color mode subset** | `fieldConfig.defaults.color` | Honors configured color intent where terminal rendering permits | 🟡 | 📋 |
@@ -182,9 +182,9 @@ Goal: imported dashboards should be more readable and less silently degraded.
 | Item | Why it belongs here | Complexity | Status |
 |---|---|---|---|
 | Compatibility matrix refresh | Establish the current truth before adding more parity | 🟢 | 🔜 |
-| Unit formatting | Biggest readability win for real dashboards | 🟡 | 🔜 |
-| Decimal precision and no-value fallback | Small field-config wins that pair naturally with units | 🟢 | 🔜 |
 | Value mappings | Makes status/stat panels useful instead of numeric-only | 🟡 | 🔜 |
+| Broader unit formatting | Expands the shipped common-unit subset to more Grafana dashboards | 🟡 | 📋 |
+| Additional no-value coverage | Completes the shipped fallback behavior where terminal rendering can use it | 🟢 | 📋 |
 | Hidden targets | Prevents helper queries from appearing as normal series | 🟢 | 🔜 |
 | Unsupported panel warnings | Builds trust in imported results | 🟢 | 🔜 |
 | `--validate` import diagnostics | Gives users a non-interactive dashboard check | 🟢 | 🔜 |
@@ -265,11 +265,11 @@ Recommended order for the next focused development cycle:
    - Add tests or fixtures for fields already supported but documented as
      missing.
 
-2. **Implement the field display layer**
-   - Add a shared display configuration model for unit, decimals, no-value, and
-     value mappings.
-   - Use it across Stat, Gauge, BarGauge, Table, Graph labels, legends, and
-     exports.
+2. **Extend the field display layer**
+   - Add value mappings and broaden unit coverage beyond the shipped common
+     units.
+   - Keep the shared display configuration model applied across Stat, Gauge,
+     BarGauge, Table, Graph labels, legends, and exports.
 
 3. **Make unsupported imports visible**
    - Track skipped panel types, hidden/unsupported target behavior, and ignored

--- a/src/app/data.rs
+++ b/src/app/data.rs
@@ -141,6 +141,7 @@ pub(crate) fn default_queries(mut provided: Vec<String>) -> Vec<PanelState> {
             min: None,
             max: None,
             autogrid: None,
+            display: crate::ui::DisplayFormat::default(),
         })
         .collect()
 }

--- a/src/app/event_loop.rs
+++ b/src/app/event_loop.rs
@@ -160,6 +160,7 @@ mod tests {
                 min: None,
                 max: None,
                 autogrid: None,
+                display: crate::ui::DisplayFormat::default(),
             }],
             0,
             Theme::default(),

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -407,6 +407,7 @@ mod tests {
             min: None,
             max: None,
             autogrid: None,
+            display: crate::ui::DisplayFormat::default(),
         }
     }
 

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -20,6 +20,7 @@ use crate::export::{ExportOptions, RecordingState};
 use crate::grafana::TemplateQueryVar;
 use crate::prom;
 use crate::theme::Theme;
+use crate::ui::DisplayFormat;
 use anyhow::Result;
 use futures::StreamExt;
 use ratatui::style::Color;
@@ -57,6 +58,8 @@ pub(crate) struct PanelState {
     pub(crate) max: Option<f64>,
     /// Whether to render automatic grid lines for this panel.
     pub(crate) autogrid: Option<bool>,
+    /// Display formatting imported from Grafana field configuration.
+    pub(crate) display: DisplayFormat,
 }
 
 /// Visualization types supported by Grafatui.

--- a/src/export.rs
+++ b/src/export.rs
@@ -607,6 +607,8 @@ fn render_stat_panel(app: &AppState, panel: &PanelState, rect: PlotRect, out: &m
         return;
     };
 
+    // Mirror the TUI distinction: a visible null series can show Grafana's
+    // noValue fallback, but a panel with no visible series still renders No data.
     let color = series
         .value
         .map(|value| value_color(app, panel, value))

--- a/src/export.rs
+++ b/src/export.rs
@@ -466,7 +466,7 @@ fn render_graph_panel(app: &AppState, panel: &PanelState, rect: PlotRect, out: &
             out,
             plot.left - 8.0,
             y + 4.0,
-            &ui::format_si(tick),
+            &panel.display.format_number(tick),
             grid,
             "end",
             SMALL_FONT_SIZE,
@@ -500,7 +500,7 @@ fn render_graph_panel(app: &AppState, panel: &PanelState, rect: PlotRect, out: &
         out,
         plot.left - 8.0,
         plot.bottom() + 4.0,
-        &ui::format_si(y_bounds[0]),
+        &panel.display.format_number(y_bounds[0]),
         &text,
         "end",
         SMALL_FONT_SIZE,
@@ -509,7 +509,7 @@ fn render_graph_panel(app: &AppState, panel: &PanelState, rect: PlotRect, out: &
         out,
         plot.left - 8.0,
         plot.top + 4.0,
-        &ui::format_si(y_bounds[1]),
+        &panel.display.format_number(y_bounds[1]),
         &text,
         "end",
         SMALL_FONT_SIZE,
@@ -553,7 +553,7 @@ fn render_graph_panel(app: &AppState, panel: &PanelState, rect: PlotRect, out: &
             out,
             plot.left - 8.0,
             y + 4.0,
-            &ui::format_si(value),
+            &panel.display.format_number(value),
             &color,
             "end",
             SMALL_FONT_SIZE,
@@ -602,18 +602,21 @@ fn render_graph_panel(app: &AppState, panel: &PanelState, rect: PlotRect, out: &
 }
 
 fn render_stat_panel(app: &AppState, panel: &PanelState, rect: PlotRect, out: &mut String) {
-    let Some((series, value)) = first_visible_value(panel) else {
+    let Some(series) = panel.series.iter().find(|series| series.visible) else {
         render_no_data(app, rect, out);
         return;
     };
 
-    let color = value_color(app, panel, value);
+    let color = series
+        .value
+        .map(|value| value_color(app, panel, value))
+        .unwrap_or_else(|| color_hex(app.theme.text, "#e6e6e6"));
     let text = color_hex(app.theme.text, "#e6e6e6");
     write_text(
         out,
         rect.left + rect.width / 2.0,
         rect.top + 34.0,
-        &ui::format_si(value),
+        &panel.display.format_value(series.value),
         &color,
         "middle",
         28.0,
@@ -677,7 +680,11 @@ fn render_gauge_panel(app: &AppState, panel: &PanelState, rect: PlotRect, out: &
         out,
         rect.left + rect.width / 2.0,
         gauge.top + 18.0,
-        &format!("{} ({:.0}%)", ui::format_si(value), ratio * 100.0),
+        &format!(
+            "{} ({:.0}%)",
+            panel.display.format_number(value),
+            ratio * 100.0
+        ),
         "#ffffff",
         "middle",
         FONT_SIZE,
@@ -686,7 +693,7 @@ fn render_gauge_panel(app: &AppState, panel: &PanelState, rect: PlotRect, out: &
         out,
         gauge.left,
         gauge.bottom() + 17.0,
-        &ui::format_si(min),
+        &panel.display.format_number(min),
         &text,
         "start",
         SMALL_FONT_SIZE,
@@ -695,7 +702,7 @@ fn render_gauge_panel(app: &AppState, panel: &PanelState, rect: PlotRect, out: &
         out,
         gauge.right(),
         gauge.bottom() + 17.0,
-        &ui::format_si(max),
+        &panel.display.format_number(max),
         &text,
         "end",
         SMALL_FONT_SIZE,
@@ -762,7 +769,7 @@ fn render_bar_gauge_panel(app: &AppState, panel: &PanelState, rect: PlotRect, ou
             out,
             track_rect.right() + 8.0,
             y,
-            &ui::format_si(value),
+            &panel.display.format_number(value),
             &color,
             "start",
             SMALL_FONT_SIZE,
@@ -821,8 +828,8 @@ fn render_table_panel(app: &AppState, panel: &PanelState, rect: PlotRect, out: &
         let y = rect.top + row_height * (row as f64 + 2.0) - 5.0;
         let value = series
             .value
-            .map(ui::format_si)
-            .unwrap_or_else(|| "-".to_string());
+            .map(|value| panel.display.format_number(value))
+            .unwrap_or_else(|| panel.display.format_value(None));
         let value_color = series
             .value
             .map(|value| value_color(app, panel, value))
@@ -1015,7 +1022,7 @@ fn render_legend(
             .get(&series.name)
             .copied()
             .or(series.value)
-            .map(ui::format_si);
+            .map(|value| panel.display.format_number(value));
         let label = value
             .map(|value| format!("{} ({value})", series.name))
             .unwrap_or_else(|| series.name.clone());
@@ -1357,6 +1364,7 @@ mod tests {
             min: None,
             max: None,
             autogrid: None,
+            display: crate::ui::DisplayFormat::default(),
         }
     }
 
@@ -1486,6 +1494,43 @@ mod tests {
             assert!(svg.contains(second), "{panel_type:?} missing {second}");
             assert!(!svg.contains("No data"));
         }
+    }
+
+    #[test]
+    fn test_export_uses_panel_display_format_for_stat_and_table_values() {
+        let mut stat_app = test_app_with_panel_type(PanelType::Stat);
+        stat_app.panels[0].display = ui::DisplayFormat {
+            unit: Some("bytes".to_string()),
+            decimals: Some(1),
+            no_value: None,
+        };
+        stat_app.panels[0].series[0].value = Some(1536.0);
+
+        let stat_svg = render_svg(&stat_app, Rect::new(0, 0, 100, 40));
+        assert!(stat_svg.contains("1.5KB"));
+
+        stat_app.panels[0].display.no_value = Some("n/a".to_string());
+        stat_app.panels[0].series[0].value = None;
+        let stat_no_value_svg = render_svg(&stat_app, Rect::new(0, 0, 100, 40));
+        assert!(stat_no_value_svg.contains("n/a"));
+
+        let mut table_app = test_app_with_panel_type(PanelType::Table);
+        table_app.panels[0].display = ui::DisplayFormat {
+            unit: Some("percentunit".to_string()),
+            decimals: Some(0),
+            no_value: Some("n/a".to_string()),
+        };
+        table_app.panels[0].series[0].value = Some(0.42);
+        table_app.panels[0].series.push(SeriesView {
+            name: "missing".to_string(),
+            value: None,
+            points: vec![],
+            visible: true,
+        });
+
+        let table_svg = render_svg(&table_app, Rect::new(0, 0, 100, 40));
+        assert!(table_svg.contains("42%"));
+        assert!(table_svg.contains("n/a"));
     }
 
     #[test]

--- a/src/grafana.rs
+++ b/src/grafana.rs
@@ -56,6 +56,7 @@ pub(crate) struct QueryPanel {
     pub(crate) min: Option<f64>,
     pub(crate) max: Option<f64>,
     pub(crate) autogrid: Option<bool>,
+    pub(crate) display: crate::ui::DisplayFormat,
 }
 
 /// Grid position extracted from Grafana.
@@ -126,6 +127,10 @@ struct RawFieldConfig {
 
 #[derive(Debug, Deserialize)]
 struct RawFieldConfigDefaults {
+    unit: Option<String>,
+    decimals: Option<usize>,
+    #[serde(rename = "noValue")]
+    no_value: Option<String>,
     min: Option<f64>,
     max: Option<f64>,
     thresholds: Option<RawThresholds>,
@@ -314,9 +319,15 @@ fn collect_panels(out: &mut DashboardImport, panels: Vec<RawPanel>) -> Result<()
             let mut min = None;
             let mut max = None;
             let mut autogrid = None;
+            let mut display = crate::ui::DisplayFormat::default();
 
             if let Some(fc) = p.field_config {
                 if let Some(defaults) = fc.defaults {
+                    display = crate::ui::DisplayFormat {
+                        unit: defaults.unit,
+                        decimals: defaults.decimals,
+                        no_value: defaults.no_value,
+                    };
                     min = defaults.min;
                     max = defaults.max;
                     autogrid = defaults
@@ -383,6 +394,7 @@ fn collect_panels(out: &mut DashboardImport, panels: Vec<RawPanel>) -> Result<()
                     min,
                     max,
                     autogrid,
+                    display,
                 });
             }
         } else if !kind.is_empty() && kind != "row" {
@@ -467,6 +479,49 @@ mod tests {
 
         assert_eq!(dashboard.queries[0].autogrid, Some(false));
         assert_eq!(dashboard.queries[1].autogrid, None);
+    }
+
+    #[test]
+    fn test_parse_field_display_format() {
+        let json = r#"
+        {
+            "title": "Display Format Test",
+            "panels": [
+                {
+                    "type": "stat",
+                    "title": "Memory",
+                    "targets": [{ "expr": "process_resident_memory_bytes" }],
+                    "fieldConfig": {
+                        "defaults": {
+                            "unit": "bytes",
+                            "decimals": 1,
+                            "noValue": "n/a"
+                        }
+                    }
+                },
+                {
+                    "type": "stat",
+                    "title": "Default",
+                    "targets": [{ "expr": "up" }]
+                }
+            ]
+        }
+        "#;
+        let path = std::env::temp_dir().join("grafatui-display-format-test.json");
+        std::fs::write(&path, json).unwrap();
+
+        let dashboard = load_grafana_dashboard(&path).unwrap();
+        std::fs::remove_file(path).unwrap();
+
+        assert_eq!(dashboard.queries[0].display.unit.as_deref(), Some("bytes"));
+        assert_eq!(dashboard.queries[0].display.decimals, Some(1));
+        assert_eq!(
+            dashboard.queries[0].display.no_value.as_deref(),
+            Some("n/a")
+        );
+        assert_eq!(dashboard.queries[1].display.unit, None);
+        assert_eq!(dashboard.queries[1].display.decimals, None);
+        assert_eq!(dashboard.queries[1].display.no_value, None);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -152,6 +152,7 @@ async fn main() -> Result<()> {
                 min: q.min,
                 max: q.max,
                 autogrid: q.autogrid,
+                display: q.display,
             })
             .collect();
         (format!("{} (imported)", d.title), ps, d.skipped_panels)

--- a/src/ui/format.rs
+++ b/src/ui/format.rs
@@ -31,6 +31,9 @@ impl DisplayFormat {
     }
 
     pub(crate) fn format_number(&self, value: f64) -> String {
+        // Keep this first pass intentionally small: these common Grafana units
+        // unlock most imported dashboard readability while unknown units retain
+        // Grafatui's previous compact SI behavior instead of rendering worse.
         match self.unit_key().as_deref() {
             Some("bytes" | "decbytes") => format_scaled(
                 value,
@@ -47,6 +50,8 @@ impl DisplayFormat {
             Some("s" | "seconds") => format_duration_seconds(value, self.decimals),
             Some("ms") => format_suffix(value, self.decimals, "ms"),
             Some("percent") => format_suffix(value, self.decimals, "%"),
+            // Grafana's percentunit stores ratios as 0.0-1.0, so scale to the
+            // user-facing percent text dashboards expect.
             Some("percentunit") => format_suffix(value * 100.0, self.decimals, "%"),
             Some("ops") => format_rate(value, self.decimals, " ops/s"),
             Some("reqps" | "rps") => format_rate(value, self.decimals, " req/s"),

--- a/src/ui/format.rs
+++ b/src/ui/format.rs
@@ -16,6 +16,60 @@
 
 use ratatui::style::Color;
 
+#[derive(Debug, Clone, Default, PartialEq)]
+pub(crate) struct DisplayFormat {
+    pub(crate) unit: Option<String>,
+    pub(crate) decimals: Option<usize>,
+    pub(crate) no_value: Option<String>,
+}
+
+impl DisplayFormat {
+    pub(crate) fn format_value(&self, value: Option<f64>) -> String {
+        value
+            .map(|value| self.format_number(value))
+            .unwrap_or_else(|| self.no_value.clone().unwrap_or_else(|| "-".to_string()))
+    }
+
+    pub(crate) fn format_number(&self, value: f64) -> String {
+        match self.unit_key().as_deref() {
+            Some("bytes" | "decbytes") => format_scaled(
+                value,
+                &["B", "KB", "MB", "GB", "TB", "PB"],
+                self.decimals,
+                "",
+            ),
+            Some("bits" | "decbits") => format_scaled(
+                value,
+                &["b", "Kb", "Mb", "Gb", "Tb", "Pb"],
+                self.decimals,
+                "",
+            ),
+            Some("s" | "seconds") => format_duration_seconds(value, self.decimals),
+            Some("ms") => format_suffix(value, self.decimals, "ms"),
+            Some("percent") => format_suffix(value, self.decimals, "%"),
+            Some("percentunit") => format_suffix(value * 100.0, self.decimals, "%"),
+            Some("ops") => format_rate(value, self.decimals, " ops/s"),
+            Some("reqps" | "rps") => format_rate(value, self.decimals, " req/s"),
+            Some("bps" | "bytes/sec" | "bytes/s") => format_scaled(
+                value,
+                &["B/s", "KB/s", "MB/s", "GB/s", "TB/s", "PB/s"],
+                self.decimals,
+                "",
+            ),
+            Some("short" | "none") | None => format_si_with_decimals(value, self.decimals),
+            Some(_) => format_si_with_decimals(value, self.decimals),
+        }
+    }
+
+    fn unit_key(&self) -> Option<String> {
+        self.unit
+            .as_deref()
+            .map(str::trim)
+            .filter(|unit| !unit.is_empty())
+            .map(|unit| unit.to_ascii_lowercase())
+    }
+}
+
 /// Maps a normalized value (0.0-1.0) to a heatmap color (blue -> green -> yellow -> red)
 pub(crate) fn value_to_heatmap_color(normalized: f64) -> Color {
     // Use a simple color gradient for heatmap
@@ -32,16 +86,60 @@ pub(crate) fn value_to_heatmap_color(normalized: f64) -> Color {
     }
 }
 
-pub(crate) fn format_si(val: f64) -> String {
+fn format_si_with_decimals(val: f64, decimals: Option<usize>) -> String {
     let abs = val.abs();
+    let decimals = decimals.unwrap_or(2);
     if abs >= 1e9 {
-        format!("{:.2}G", val / 1e9)
+        format!("{:.*}G", decimals, val / 1e9)
     } else if abs >= 1e6 {
-        format!("{:.2}M", val / 1e6)
+        format!("{:.*}M", decimals, val / 1e6)
     } else if abs >= 1e3 {
-        format!("{:.2}k", val / 1e3)
+        format!("{:.*}k", decimals, val / 1e3)
     } else {
-        format!("{:.2}", val)
+        format!("{:.*}", decimals, val)
+    }
+}
+
+fn format_suffix(value: f64, decimals: Option<usize>, suffix: &str) -> String {
+    format!("{:.*}{suffix}", decimals.unwrap_or(2), value)
+}
+
+fn format_rate(value: f64, decimals: Option<usize>, suffix: &str) -> String {
+    format!("{}{suffix}", format_si_with_decimals(value, decimals))
+}
+
+fn format_scaled(
+    value: f64,
+    suffixes: &[&str],
+    decimals: Option<usize>,
+    separator: &str,
+) -> String {
+    let mut scaled = value;
+    let mut suffix_index = 0;
+
+    while scaled.abs() >= 1000.0 && suffix_index + 1 < suffixes.len() {
+        scaled /= 1000.0;
+        suffix_index += 1;
+    }
+
+    format!(
+        "{:.*}{separator}{}",
+        decimals.unwrap_or(2),
+        scaled,
+        suffixes[suffix_index]
+    )
+}
+
+fn format_duration_seconds(value: f64, decimals: Option<usize>) -> String {
+    let abs = value.abs();
+    if abs >= 86_400.0 {
+        format_suffix(value / 86_400.0, decimals, "d")
+    } else if abs >= 3_600.0 {
+        format_suffix(value / 3_600.0, decimals, "h")
+    } else if abs >= 60.0 {
+        format_suffix(value / 60.0, decimals, "m")
+    } else {
+        format_suffix(value, decimals, "s")
     }
 }
 
@@ -137,6 +235,67 @@ fn hsl_to_rgb(h: f32, s: f32, l: f32) -> Color {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_display_format_uses_si_for_missing_and_unknown_units() {
+        let default = DisplayFormat::default();
+        assert_eq!(default.format_number(1_500.0), "1.50k");
+
+        let unknown = DisplayFormat {
+            unit: Some("widgets".to_string()),
+            decimals: None,
+            no_value: None,
+        };
+        assert_eq!(unknown.format_number(1_500.0), "1.50k");
+    }
+
+    #[test]
+    fn test_display_format_scales_bytes_and_bits() {
+        let bytes = DisplayFormat {
+            unit: Some("bytes".to_string()),
+            decimals: None,
+            no_value: None,
+        };
+        assert_eq!(bytes.format_number(1_536.0), "1.54KB");
+
+        let bits = DisplayFormat {
+            unit: Some("bits".to_string()),
+            decimals: Some(1),
+            no_value: None,
+        };
+        assert_eq!(bits.format_number(1_536.0), "1.5Kb");
+    }
+
+    #[test]
+    fn test_display_format_percent_and_percentunit() {
+        let percent = DisplayFormat {
+            unit: Some("percent".to_string()),
+            decimals: Some(1),
+            no_value: None,
+        };
+        assert_eq!(percent.format_number(42.42), "42.4%");
+
+        let percent_unit = DisplayFormat {
+            unit: Some("percentunit".to_string()),
+            decimals: Some(0),
+            no_value: None,
+        };
+        assert_eq!(percent_unit.format_number(0.4242), "42%");
+    }
+
+    #[test]
+    fn test_display_format_decimals_no_value_and_rates() {
+        let rate = DisplayFormat {
+            unit: Some("reqps".to_string()),
+            decimals: Some(0),
+            no_value: Some("n/a".to_string()),
+        };
+        assert_eq!(rate.format_number(1234.56), "1k req/s");
+        assert_eq!(rate.format_value(None), "n/a");
+
+        let default = DisplayFormat::default();
+        assert_eq!(default.format_value(None), "-");
+    }
 
     #[test]
     fn test_format_axis_time_uses_time_for_short_ranges() {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -20,6 +20,6 @@ mod layout;
 mod panels;
 
 pub(crate) use draw::draw_ui;
-pub(crate) use format::{format_si, format_time, get_hash_color, value_to_heatmap_color};
+pub(crate) use format::{DisplayFormat, format_time, get_hash_color, value_to_heatmap_color};
 pub(crate) use layout::{hit_test, visible_panel_rects};
 pub(crate) use panels::calculate_y_bounds;

--- a/src/ui/panels/bar_gauge.rs
+++ b/src/ui/panels/bar_gauge.rs
@@ -15,7 +15,6 @@
  */
 
 use crate::app::{AppState, PanelState};
-use crate::ui::format::format_si;
 use ratatui::{
     prelude::*,
     widgets::{Bar, BarChart, BarGroup, Block, Borders, Paragraph},
@@ -54,7 +53,7 @@ pub(super) fn render_bar_gauge(frame: &mut Frame, area: Rect, p: &PanelState, ap
         let color = p.get_color_for_value(v).unwrap_or(theme.palette[0]);
         let bar = Bar::default()
             .value((v * scale) as u64)
-            .text_value(format_si(v))
+            .text_value(p.display.format_number(v))
             .label(Line::from(s.name.as_str()))
             .style(Style::default().fg(color))
             .value_style(Style::default().fg(theme.text).bg(color));

--- a/src/ui/panels/gauge.rs
+++ b/src/ui/panels/gauge.rs
@@ -15,7 +15,6 @@
  */
 
 use crate::app::{AppState, PanelState};
-use crate::ui::format::format_si;
 use ratatui::{
     prelude::*,
     widgets::{Block, Borders, Gauge},
@@ -49,7 +48,7 @@ pub(super) fn render_gauge(frame: &mut Frame, area: Rect, p: &PanelState, app: &
         .block(Block::default().borders(Borders::NONE))
         .gauge_style(Style::default().fg(color).bg(Color::DarkGray))
         .ratio(ratio)
-        .label(format!("{} ({})", format_si(value), name));
+        .label(format!("{} ({})", p.display.format_number(value), name));
 
     frame.render_widget(gauge, area);
 }

--- a/src/ui/panels/graph/bounds.rs
+++ b/src/ui/panels/graph/bounds.rs
@@ -82,6 +82,7 @@ mod tests {
             min: None,
             max: None,
             autogrid: None,
+            display: crate::ui::DisplayFormat::default(),
         }
     }
 

--- a/src/ui/panels/graph/labels.rs
+++ b/src/ui/panels/graph/labels.rs
@@ -46,6 +46,8 @@ pub(super) fn y_label_width(
     threshold_labels: &[(f64, Color)],
     display: &DisplayFormat,
 ) -> u16 {
+    // Reserve space using the same unit formatter that will draw the labels;
+    // otherwise bytes/percent suffixes can clip or push into the plot area.
     let axis_width = axis_labels
         .iter()
         .map(|label| label.width() as u16)

--- a/src/ui/panels/graph/labels.rs
+++ b/src/ui/panels/graph/labels.rs
@@ -15,7 +15,7 @@
  */
 
 use super::overlay::is_blank_cell;
-use crate::ui::format::{format_axis_time, format_si};
+use crate::ui::format::{DisplayFormat, format_axis_time};
 use ratatui::prelude::*;
 
 #[derive(Debug, Clone, Copy)]
@@ -32,10 +32,19 @@ pub(super) struct YLabelArea {
     pub(super) width: u16,
 }
 
+pub(super) struct YLabelContext<'a> {
+    pub(super) y_bounds: [f64; 2],
+    pub(super) autogrid_ticks: &'a [f64],
+    pub(super) threshold_labels: &'a [(f64, Color)],
+    pub(super) display: &'a DisplayFormat,
+    pub(super) color: Color,
+}
+
 pub(super) fn y_label_width(
     axis_labels: &[Span<'_>],
     autogrid_ticks: &[f64],
     threshold_labels: &[(f64, Color)],
+    display: &DisplayFormat,
 ) -> u16 {
     let axis_width = axis_labels
         .iter()
@@ -44,12 +53,12 @@ pub(super) fn y_label_width(
         .unwrap_or(0);
     let grid_width = autogrid_ticks
         .iter()
-        .map(|tick| format_si(*tick).len() as u16)
+        .map(|tick| display.format_number(*tick).len() as u16)
         .max()
         .unwrap_or(0);
     let threshold_width = threshold_labels
         .iter()
-        .map(|(tick, _)| format_si(*tick).len() as u16)
+        .map(|(tick, _)| display.format_number(*tick).len() as u16)
         .max()
         .unwrap_or(0);
 
@@ -60,36 +69,33 @@ pub(super) fn render_intermediate_y_labels(
     frame: &mut Frame,
     label_area: YLabelArea,
     plot: PlotBounds,
-    y_bounds: [f64; 2],
-    autogrid_ticks: &[f64],
-    threshold_labels: &[(f64, Color)],
-    grid_color: Color,
+    labels: YLabelContext<'_>,
 ) {
     if label_area.width == 0 {
         return;
     }
 
-    for tick in autogrid_ticks {
-        if let Some(y) = value_to_y_label_row(*tick, y_bounds, plot) {
+    for tick in labels.autogrid_ticks {
+        if let Some(y) = value_to_y_label_row(*tick, labels.y_bounds, plot) {
             write_right_aligned_label(
                 frame,
                 label_area.left,
                 y,
                 label_area.width,
-                &format_si(*tick),
-                grid_color,
+                &labels.display.format_number(*tick),
+                labels.color,
             );
         }
     }
 
-    for (tick, color) in threshold_labels {
-        if let Some(y) = value_to_y_label_row(*tick, y_bounds, plot) {
+    for (tick, color) in labels.threshold_labels {
+        if let Some(y) = value_to_y_label_row(*tick, labels.y_bounds, plot) {
             write_right_aligned_label(
                 frame,
                 label_area.left,
                 y,
                 label_area.width,
-                &format_si(*tick),
+                &labels.display.format_number(*tick),
                 *color,
             );
         }

--- a/src/ui/panels/graph/mod.rs
+++ b/src/ui/panels/graph/mod.rs
@@ -22,14 +22,14 @@ mod thresholds;
 
 use autogrid::{build_autogrid_datasets, calculate_time_grid_ticks, calculate_value_grid_ticks};
 use labels::{
-    PlotBounds, YLabelArea, render_autogrid_time_labels, render_intermediate_y_labels,
-    y_label_width,
+    PlotBounds, YLabelArea, YLabelContext, render_autogrid_time_labels,
+    render_intermediate_y_labels, y_label_width,
 };
 use overlay::merge_overlay_buffer;
 use thresholds::{prepare_thresholds, render_raw_threshold_lines, threshold_marker};
 
 use crate::app::{AppState, PanelState};
-use crate::ui::format::{format_axis_time, format_si, get_hash_color};
+use crate::ui::format::{format_axis_time, get_hash_color};
 use ratatui::{
     prelude::*,
     widgets::{Axis, Chart, Dataset, GraphType, Paragraph, Wrap},
@@ -134,9 +134,9 @@ pub(super) fn render_graph_panel(
         // For legend display
         let mut name = s.name.clone();
         if let Some(val) = cursor_values.get(&s.name) {
-            name.push_str(&format!(" ({})", format_si(*val)));
+            name.push_str(&format!(" ({})", p.display.format_number(*val)));
         } else if let Some(val) = s.value {
-            name.push_str(&format!(" ({})", format_si(val)));
+            name.push_str(&format!(" ({})", p.display.format_number(val)));
         }
         if name.is_empty() {
             name = format!("Series {}", i);
@@ -197,12 +197,22 @@ pub(super) fn render_graph_panel(
         Vec::new()
     };
 
-    y_labels[0] = Span::styled(format_si(y_bounds[0]), Style::default().fg(theme.text));
-    y_labels[y_axis_height - 1] =
-        Span::styled(format_si(y_bounds[1]), Style::default().fg(theme.text));
+    y_labels[0] = Span::styled(
+        p.display.format_number(y_bounds[0]),
+        Style::default().fg(theme.text),
+    );
+    y_labels[y_axis_height - 1] = Span::styled(
+        p.display.format_number(y_bounds[1]),
+        Style::default().fg(theme.text),
+    );
 
     // Evaluate y_max_width before moving y_labels into Chart block
-    let y_max_width = y_label_width(&y_labels, &autogrid_value_ticks, &threshold_data.labels);
+    let y_max_width = y_label_width(
+        &y_labels,
+        &autogrid_value_ticks,
+        &threshold_data.labels,
+        &p.display,
+    );
 
     let chart = Chart::new(chart_datasets)
         // No block, as we rendered it outside
@@ -320,10 +330,13 @@ pub(super) fn render_graph_panel(
             width: y_max_width,
         },
         plot_bounds,
-        y_bounds,
-        &autogrid_value_ticks,
-        &threshold_data.labels,
-        app.autogrid_color,
+        YLabelContext {
+            y_bounds,
+            autogrid_ticks: &autogrid_value_ticks,
+            threshold_labels: &threshold_data.labels,
+            display: &p.display,
+            color: app.autogrid_color,
+        },
     );
 
     // Render custom legend

--- a/src/ui/panels/stat.rs
+++ b/src/ui/panels/stat.rs
@@ -35,7 +35,8 @@ pub(super) fn render_stat(frame: &mut Frame, area: Rect, p: &PanelState, app: &A
         .constraints([Constraint::Percentage(60), Constraint::Percentage(40)])
         .split(area);
 
-    // Render Big Value
+    // A visible series with a null value should use Grafana's noValue text,
+    // while no visible series at all remains Grafatui's existing "No data" state.
     let val_str = visible_series
         .map(|_| p.display.format_value(value))
         .unwrap_or_else(|| "No data".to_string());

--- a/src/ui/panels/stat.rs
+++ b/src/ui/panels/stat.rs
@@ -15,7 +15,6 @@
  */
 
 use crate::app::{AppState, PanelState};
-use crate::ui::format::format_si;
 use ratatui::{
     prelude::*,
     widgets::{Block, Borders, Paragraph, Sparkline},
@@ -24,15 +23,11 @@ use ratatui::{
 pub(super) fn render_stat(frame: &mut Frame, area: Rect, p: &PanelState, app: &AppState) {
     let theme = &app.theme;
 
-    // Find the latest value from the first visible series
-    let (value, name) = p
-        .series
-        .iter()
-        .filter(|s| s.visible)
-        .find_map(|s| s.value.map(|v| (v, s.name.clone())))
-        .unwrap_or((0.0, "No data".to_string()));
-
-    let color = p.get_color_for_value(value).unwrap_or(theme.palette[0]);
+    let visible_series = p.series.iter().find(|s| s.visible);
+    let value = visible_series.and_then(|s| s.value);
+    let color = value
+        .and_then(|value| p.get_color_for_value(value))
+        .unwrap_or(theme.palette[0]);
 
     // Split area into value (top) and sparkline (bottom)
     let chunks = Layout::default()
@@ -41,7 +36,9 @@ pub(super) fn render_stat(frame: &mut Frame, area: Rect, p: &PanelState, app: &A
         .split(area);
 
     // Render Big Value
-    let val_str = format_si(value);
+    let val_str = visible_series
+        .map(|_| p.display.format_value(value))
+        .unwrap_or_else(|| "No data".to_string());
     let big_value = Paragraph::new(val_str)
         .style(Style::default().fg(color).add_modifier(Modifier::BOLD))
         .alignment(Alignment::Center)
@@ -50,7 +47,7 @@ pub(super) fn render_stat(frame: &mut Frame, area: Rect, p: &PanelState, app: &A
     frame.render_widget(big_value, chunks[0]);
 
     // Render Sparkline
-    if let Some(s) = p.series.iter().find(|s| s.visible && s.name == name) {
+    if let Some(s) = visible_series {
         let data: Vec<u64> = s.points.iter().map(|(_, v)| *v as u64).collect();
         let sparkline = Sparkline::default()
             .block(Block::default().borders(Borders::NONE))

--- a/src/ui/panels/table.rs
+++ b/src/ui/panels/table.rs
@@ -15,7 +15,6 @@
  */
 
 use crate::app::{AppState, PanelState};
-use crate::ui::format::format_si;
 use ratatui::{
     prelude::*,
     widgets::{Block, Borders, Paragraph, Row, Table},
@@ -30,7 +29,7 @@ pub(super) fn render_table(frame: &mut Frame, area: Rect, p: &PanelState, app: &
         .iter()
         .filter(|s| s.visible)
         .map(|s| {
-            let val_str = s.value.map(format_si).unwrap_or_else(|| "-".to_string());
+            let val_str = p.display.format_value(s.value);
             let color = s
                 .value
                 .and_then(|v| p.get_color_for_value(v))


### PR DESCRIPTION
## Description

Adds Grafana display formatting support for imported dashboards. Panels now parse and apply `fieldConfig.defaults.unit`, `decimals`, and `noValue` across live TUI rendering and SVG/PNG exports.

This improves dashboard readability for common Grafana units such as bytes, bits, durations, percentages, SI-style values, and common rate suffixes, while preserving the existing SI fallback for unsupported units.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have used Conventional Commits for my commit messages