### PR TITLE
feat: Dashboard refresh interval

### DIFF
--- a/GRAFANA_COMPATIBILITY.md
+++ b/GRAFANA_COMPATIBILITY.md
@@ -27,7 +27,7 @@ This document provides a comprehensive feature-parity table between the [Grafana
 | `editable` | ⛔ Not Applicable | Grafatui is read-only |
 | `style` | ⛔ Not Applicable | TUI has its own theme system |
 | `schemaVersion` | ❌ Not Implemented | Not validated |
-| `refresh` | ❌ Not Implemented | Uses `--refresh-rate` CLI option instead |
+| `refresh` | ✅ Supported | Used as the default data refresh interval; overridden by config or `--refresh-rate` |
 | `time` | ❌ Not Implemented | Uses `--range` CLI option instead |
 | `time.from` / `time.to` | ❌ Not Implemented | Uses `--range` CLI option instead |
 | `fiscalYearStartMonth` | ⛔ Not Applicable | |

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ This demo showcases all 7 visualization types (graph, stat, gauge, bar gauge, ta
 - **Import existing dashboards** from JSON files
 - **Supported panels**: graph, timeseries, gauge, bargauge, table, stat, heatmap
 - **Template variables** with built-in PromQL time variables, dynamic Prometheus query variables, and CLI overrides
+- **Dashboard refresh interval** from Grafana JSON, with CLI/config overrides
 - **Legend formatting** (`{{label}}` syntax)
 - **Grid layouts** using `gridPos`
 - **Thresholds** dynamically applied to metrics and graph limits

--- a/src/grafana.rs
+++ b/src/grafana.rs
@@ -31,6 +31,8 @@ pub(crate) struct DashboardImport {
     pub(crate) query_vars: Vec<TemplateQueryVar>,
     /// Number of panels that were skipped (unsupported types).
     pub(crate) skipped_panels: usize,
+    /// Dashboard-level refresh interval in milliseconds, if provided.
+    pub(crate) refresh_rate_ms: Option<u64>,
 }
 
 /// A Prometheus-backed Grafana template variable.
@@ -70,6 +72,7 @@ pub(crate) struct GridPos {
 #[derive(Debug, Deserialize)]
 struct RawDashboard {
     title: Option<String>,
+    refresh: Option<serde_json::Value>,
     panels: Option<Vec<RawPanel>>,
     templating: Option<RawTemplating>,
 }
@@ -236,6 +239,7 @@ pub(crate) fn load_grafana_dashboard(path: &std::path::Path) -> Result<Dashboard
 
     let mut out = DashboardImport {
         title: raw.title.unwrap_or_default(),
+        refresh_rate_ms: raw.refresh.as_ref().and_then(parse_refresh_rate_ms),
         queries: vec![],
         vars,
         query_vars,
@@ -393,6 +397,19 @@ fn collect_panels(out: &mut DashboardImport, panels: Vec<RawPanel>) -> Result<()
     Ok(())
 }
 
+fn parse_refresh_rate_ms(value: &serde_json::Value) -> Option<u64> {
+    let refresh = value.as_str()?.trim();
+    if refresh.is_empty()
+        || refresh.eq_ignore_ascii_case("false")
+        || refresh.eq_ignore_ascii_case("off")
+    {
+        return None;
+    }
+
+    let duration = humantime::parse_duration(refresh).ok()?;
+    u64::try_from(duration.as_millis()).ok()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -512,5 +529,29 @@ mod tests {
         assert_eq!(dashboard.query_vars[0].regex.as_deref(), Some("/(.+)/"));
         assert_eq!(dashboard.query_vars[1].query, "label_values(model_name)");
         assert_eq!(dashboard.vars.get("all_instance"), Some(&".*".to_string()));
+    }
+
+    #[test]
+    fn test_parse_dashboard_refresh_duration() {
+        let json = r#"
+        {
+            "title": "Refresh Dash",
+            "refresh": "5s",
+            "panels": [
+                {
+                    "type": "timeseries",
+                    "title": "Up",
+                    "targets": [{ "expr": "up" }]
+                }
+            ]
+        }
+        "#;
+        let path = std::env::temp_dir().join("grafatui-refresh-test.json");
+        std::fs::write(&path, json).unwrap();
+
+        let dashboard = load_grafana_dashboard(&path).unwrap();
+        std::fs::remove_file(path).unwrap();
+
+        assert_eq!(dashboard.refresh_rate_ms, Some(5000));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,8 +88,6 @@ async fn main() -> Result<()> {
         .unwrap_or_else(|| "5s".to_string());
     let step = app::parse_duration(&step_str).context("--step")?;
 
-    let refresh_rate = args.refresh_rate.or(config.refresh_rate).unwrap_or(1000);
-    let refresh_every = Duration::from_millis(refresh_rate);
     let export_dir = args
         .export_dir
         .or(config.export_dir)
@@ -113,6 +111,7 @@ async fn main() -> Result<()> {
 
     let mut vars: HashMap<String, String> = HashMap::new();
     let mut query_vars = Vec::new();
+    let mut dashboard_refresh_rate_ms = None;
 
     let prom = prom::PromClient::new(prometheus_url);
 
@@ -123,6 +122,7 @@ async fn main() -> Result<()> {
         .map(|p| config::expand_path(&p))
     {
         let d = grafana::load_grafana_dashboard(&path)?;
+        dashboard_refresh_rate_ms = d.refresh_rate_ms;
         // Seed vars from dashboard defaults
         for (k, v) in d.vars {
             vars.insert(k, v);
@@ -187,6 +187,12 @@ async fn main() -> Result<()> {
         .threshold_marker
         .or(config.threshold_marker)
         .unwrap_or_else(|| "dashed-line".to_string());
+    let refresh_rate = resolve_refresh_rate_ms(
+        args.refresh_rate,
+        config.refresh_rate,
+        dashboard_refresh_rate_ms,
+    );
+    let refresh_every = Duration::from_millis(refresh_rate);
 
     let mut state = app::AppState::new(
         prom,
@@ -239,4 +245,31 @@ async fn main() -> Result<()> {
     terminal.show_cursor()?;
 
     res
+}
+
+fn resolve_refresh_rate_ms(
+    cli_refresh_rate: Option<u64>,
+    config_refresh_rate: Option<u64>,
+    dashboard_refresh_rate: Option<u64>,
+) -> u64 {
+    cli_refresh_rate
+        .or(config_refresh_rate)
+        .or(dashboard_refresh_rate)
+        .unwrap_or(1000)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_resolve_refresh_rate_precedence() {
+        assert_eq!(
+            resolve_refresh_rate_ms(Some(2000), Some(3000), Some(4000)),
+            2000
+        );
+        assert_eq!(resolve_refresh_rate_ms(None, Some(3000), Some(4000)), 3000);
+        assert_eq!(resolve_refresh_rate_ms(None, None, Some(4000)), 4000);
+        assert_eq!(resolve_refresh_rate_ms(None, None, None), 1000);
+    }
 }


### PR DESCRIPTION
## Summary

- Parse the top-level Grafana dashboard `refresh` field during JSON import.
- Use dashboard refresh as the default data refresh interval when no CLI or config refresh rate is set.
- Document `refresh` compatibility and the import feature in the README.

## Behavior

Refresh precedence is now:

1. `--refresh-rate`
2. config `refresh_rate`
3. dashboard JSON `refresh`
4. built-in `1000ms` default

Disabled or empty dashboard refresh values such as `false`, `off`, or an empty string are ignored.

## Validation

- `cargo test` - 66 passed