### PR TITLE
Support instant panel queries

### DIFF
--- a/GRAFANA_COMPATIBILITY.md
+++ b/GRAFANA_COMPATIBILITY.md
@@ -104,7 +104,7 @@ This document provides a comprehensive feature-parity table between the [Grafana
 | `targets[].datasource` | ❌ Not Implemented | Only Prometheus datasource is supported |
 | `targets[].interval` | ❌ Not Implemented | Uses global `--step` instead |
 | `targets[].intervalFactor` | ❌ Not Implemented | |
-| `targets[].instant` | ❌ Not Implemented | All queries use `query_range` |
+| `targets[].instant` | ✅ Supported | Uses Prometheus instant `query` when true; Gauge, BarGauge, and Table default to instant |
 | `targets[].format` | ❌ Not Implemented | Always treated as time_series |
 | `targets[].hide` | ❌ Not Implemented | All targets are visible |
 | `targets[].exemplar` | ❌ Not Implemented | |
@@ -264,7 +264,7 @@ tooltips.
 | Feature | Status | Notes |
 |---|---|---|
 | Prometheus (`query_range`) | ✅ Supported | Primary and only supported datasource |
-| Prometheus (`query` instant) | 🔶 Partial | Used for dynamic template variable `query_result(...)`; panel targets still use `query_range` |
+| Prometheus (`query` instant) | ✅ Supported | Used for dynamic template variables and instant panel targets |
 | Prometheus labels API | ✅ Supported | Used for dynamic variable `label_values(...)` |
 | Mixed datasource | ❌ Not Implemented | |
 | InfluxDB | ❌ Not Implemented | |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,6 +29,7 @@ These features are shipped and available today:
 | Variables | **Dynamic Prometheus variables** | Query-backed variables using `label_values(...)` and `query_result(...)` |
 | Variables | **PromQL built-ins** | `$__interval`, `$__interval_ms`, `$__range`, `$__range_s`, `$__range_ms`, `$__rate_interval` |
 | Queries | **Multiple targets per panel** | Multiple PromQL expressions render as separate series |
+| Queries | **Instant target queries** | Honors `targets[].instant` and defaults summary table/gauge panels to Prometheus instant queries |
 | Queries | **Legend formatting** | `{{label}}` syntax from Grafana |
 | UI | **8 color themes** | default, dracula, monokai, solarized dark/light, gruvbox, tokyo-night, catppuccin |
 | UI | **Time controls** | Zoom in/out, pan left/right, live mode toggle |
@@ -119,7 +120,7 @@ This is the main backlog, ordered by Grafana parity domain.
 | Feature | Grafana field / behavior | User value | Complexity | Status |
 |---|---|---|---|---|
 | **Hidden targets** | `targets[].hide` | Helper queries do not clutter imported panels | 🟢 | 🔜 |
-| **Instant queries** | `targets[].instant` / Prometheus `query` | Stat/table panels can use point-in-time queries | 🟡 | 🔜 |
+| **Instant queries** | `targets[].instant` / Prometheus `query` | Stat/table panels can use point-in-time queries | 🟡 | ✅ |
 | **Target interval** | `targets[].interval` / `intervalFactor` | Panel-specific resolution is respected | 🟡 | 📋 |
 | **Target ref IDs** | `targets[].refId` | Better diagnostics and future transformation support | 🟢 | 📋 |
 | **Format handling** | `targets[].format` | Tables and heatmaps can choose more appropriate handling | 🟡 | 📋 |
@@ -197,7 +198,7 @@ expectations.
 | Item | Why it belongs here | Complexity | Status |
 |---|---|---|---|
 | Reduce options | Summary panels need more than "last" | 🟡 | 📋 |
-| Instant query support | Many summary/table panels are intended as instant queries | 🟡 | 📋 |
+| Instant query support | Many summary/table panels are intended as instant queries | 🟡 | ✅ |
 | Display names | Imported labels become clearer without changing queries | 🟢 | 📋 |
 | Legend display modes and placement | Dense dashboards need predictable legend behavior | 🟡 | 📋 |
 | Legend calculations | Adds useful table-like summaries without a new panel type | 🟡 | 📋 |

--- a/examples/dashboards/instant_queries.json
+++ b/examples/dashboards/instant_queries.json
@@ -1,0 +1,185 @@
+{
+  "title": "Prometheus Self-Monitoring - Instant Queries",
+  "refresh": "5s",
+  "templating": {
+    "list": [
+      {
+        "name": "job",
+        "current": {
+          "text": "prometheus",
+          "value": "prometheus"
+        }
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "graph",
+      "title": "Range Query Baseline - HTTP Request Rate",
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum by (code) (rate(prometheus_http_requests_total{job=\"$job\"}[1m]))",
+          "legendFormat": "{{code}}"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Stat Default - Range Query With Sparkline",
+      "gridPos": {
+        "x": 12,
+        "y": 0,
+        "w": 6,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "time() - process_start_time_seconds{job=\"$job\"}",
+          "legendFormat": "Uptime range"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "decimals": 0
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Stat Explicit Instant",
+      "gridPos": {
+        "x": 18,
+        "y": 0,
+        "w": 6,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "time() - process_start_time_seconds{job=\"$job\"}",
+          "legendFormat": "Uptime instant",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "decimals": 0
+        }
+      }
+    },
+    {
+      "type": "gauge",
+      "title": "Gauge Default - Instant Memory",
+      "gridPos": {
+        "x": 0,
+        "y": 8,
+        "w": 8,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "process_resident_memory_bytes{job=\"$job\"}",
+          "legendFormat": "Memory"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "decimals": 1,
+          "min": 0
+        }
+      }
+    },
+    {
+      "type": "bargauge",
+      "title": "Bar Gauge Default - Instant Targets",
+      "gridPos": {
+        "x": 8,
+        "y": 8,
+        "w": 8,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "count by (job) (up == 1)",
+          "legendFormat": "{{job}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "min": 0
+        }
+      }
+    },
+    {
+      "type": "table",
+      "title": "Table Default - Instant Target Status",
+      "gridPos": {
+        "x": 16,
+        "y": 8,
+        "w": 8,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "up",
+          "legendFormat": "{{job}} - {{instance}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0
+        }
+      }
+    },
+    {
+      "type": "gauge",
+      "title": "Gauge Explicit Range Override",
+      "gridPos": {
+        "x": 0,
+        "y": 16,
+        "w": 8,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "process_resident_memory_bytes{job=\"$job\"}",
+          "legendFormat": "Memory range",
+          "instant": false
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "decimals": 1,
+          "min": 0
+        }
+      }
+    },
+    {
+      "type": "graph",
+      "title": "Graph Explicit Instant Snapshot",
+      "gridPos": {
+        "x": 8,
+        "y": 16,
+        "w": 16,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "up",
+          "legendFormat": "{{job}} - {{instance}}",
+          "instant": true
+        }
+      ]
+    }
+  ]
+}

--- a/src/app/data.rs
+++ b/src/app/data.rs
@@ -130,6 +130,7 @@ pub(crate) fn default_queries(mut provided: Vec<String>) -> Vec<PanelState> {
             title: q.clone(),
             exprs: vec![q],
             legends: vec![None],
+            query_modes: vec![crate::app::QueryMode::Range],
             series: vec![],
             last_error: None,
             last_url: None,

--- a/src/app/event_loop.rs
+++ b/src/app/event_loop.rs
@@ -144,6 +144,7 @@ mod tests {
                 title: "CPU".to_string(),
                 exprs: vec![],
                 legends: vec![],
+                query_modes: vec![],
                 series: vec![SeriesView {
                     name: "usage".to_string(),
                     value: Some(1.0),

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -383,6 +383,7 @@ mod tests {
             title: title.to_string(),
             exprs: vec![],
             legends: vec![],
+            query_modes: vec![],
             series: vec![
                 SeriesView {
                     name: "a".to_string(),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -24,6 +24,6 @@ pub(crate) use data::{default_queries, parse_duration};
 pub(crate) use event_loop::run_app;
 #[allow(unused_imports)]
 pub(crate) use state::{
-    AppMode, AppState, GridUnit, PanelState, PanelType, SeriesView, ThresholdMode, ThresholdStep,
-    Thresholds, YAxisMode,
+    AppMode, AppState, GridUnit, PanelState, PanelType, QueryMode, SeriesView, ThresholdMode,
+    ThresholdStep, Thresholds, YAxisMode,
 };

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -36,6 +36,8 @@ pub(crate) struct PanelState {
     pub(crate) exprs: Vec<String>,
     /// Optional legend formats (e.g. "{{instance}}"). Parallel to exprs.
     pub(crate) legends: Vec<Option<String>>,
+    /// Query mode for each expression. Parallel to exprs.
+    pub(crate) query_modes: Vec<QueryMode>,
     /// Current time-series data for this panel.
     pub(crate) series: Vec<SeriesView>,
     /// Last error message, if any.
@@ -72,6 +74,13 @@ pub(crate) enum PanelType {
     Stat,
     Heatmap,
     Unknown,
+}
+
+/// Prometheus endpoint mode for a target query.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum QueryMode {
+    Range,
+    Instant,
 }
 
 /// Modes for Y-axis scaling.
@@ -125,6 +134,13 @@ pub(crate) struct Thresholds {
 }
 
 impl PanelState {
+    pub(crate) fn query_mode(&self, index: usize) -> QueryMode {
+        self.query_modes
+            .get(index)
+            .copied()
+            .unwrap_or(QueryMode::Range)
+    }
+
     pub(crate) fn get_color_for_value(&self, val: f64) -> Option<Color> {
         let thresholds = self.thresholds.as_ref()?;
 
@@ -456,17 +472,33 @@ impl AppState {
         for (i, expr) in p.exprs.iter().enumerate() {
             let expr_expanded = expand_expr(expr, range, step, vars);
             let legend_fmt = p.legends.get(i).and_then(|x| x.as_ref());
+            let query_mode = p.query_mode(i);
 
             // Calculate start/end for URL display purposes
             let start_ts = end_ts - (range.as_secs() as i64);
 
-            let url = prometheus.build_query_range_url(&expr_expanded, start_ts, end_ts, step);
+            let url = match query_mode {
+                QueryMode::Range => {
+                    prometheus.build_query_range_url(&expr_expanded, start_ts, end_ts, step)
+                }
+                QueryMode::Instant => prometheus.build_query_url(&expr_expanded, end_ts),
+            };
             last_url = Some(url);
 
-            match prometheus
-                .query_range(&expr_expanded, start_ts, end_ts, step)
-                .await
-            {
+            let query_result = match query_mode {
+                QueryMode::Range => {
+                    prometheus
+                        .query_range(&expr_expanded, start_ts, end_ts, step)
+                        .await
+                }
+                QueryMode::Instant => {
+                    prometheus
+                        .query_instant_series(&expr_expanded, end_ts)
+                        .await
+                }
+            };
+
+            match query_result {
                 Ok(res) => {
                     for s in res {
                         let latest_val = s.values.last().and_then(|(_, v)| v.parse::<f64>().ok());
@@ -501,7 +533,14 @@ impl AppState {
                     }
                 }
                 Err(e) => {
-                    error = Some(format!("query_range failed for `{}`: {}", expr_expanded, e));
+                    let query_name = match query_mode {
+                        QueryMode::Range => "query_range",
+                        QueryMode::Instant => "query",
+                    };
+                    error = Some(format!(
+                        "{} failed for `{}`: {}",
+                        query_name, expr_expanded, e
+                    ));
                 }
             }
         }
@@ -598,5 +637,30 @@ mod tests {
 
         app.select_previous_panel();
         assert_eq!(app.selected_panel, 0);
+    }
+
+    #[test]
+    fn test_panel_query_mode_defaults_to_range_when_missing() {
+        let panel = PanelState {
+            title: "Modes".to_string(),
+            exprs: vec!["up".to_string(), "rate(up[5m])".to_string()],
+            legends: vec![None, None],
+            query_modes: vec![QueryMode::Instant],
+            series: vec![],
+            last_error: None,
+            last_url: None,
+            last_samples: 0,
+            grid: None,
+            y_axis_mode: YAxisMode::Auto,
+            panel_type: PanelType::Graph,
+            thresholds: None,
+            min: None,
+            max: None,
+            autogrid: None,
+            display: crate::ui::DisplayFormat::default(),
+        };
+
+        assert_eq!(panel.query_mode(0), QueryMode::Instant);
+        assert_eq!(panel.query_mode(1), QueryMode::Range);
     }
 }

--- a/src/export.rs
+++ b/src/export.rs
@@ -1350,6 +1350,7 @@ mod tests {
             title: "CPU <main>".to_string(),
             exprs: vec![],
             legends: vec![],
+            query_modes: vec![],
             series: vec![SeriesView {
                 name: "usage & total".to_string(),
                 value: Some(10.0),

--- a/src/grafana.rs
+++ b/src/grafana.rs
@@ -52,6 +52,7 @@ pub(crate) struct QueryPanel {
     pub(crate) title: String,
     pub(crate) exprs: Vec<String>,
     pub(crate) legends: Vec<Option<String>>, // Parallel to exprs
+    pub(crate) query_modes: Vec<crate::app::QueryMode>, // Parallel to exprs
     pub(crate) grid: Option<GridPos>,
     pub(crate) panel_type: crate::app::PanelType,
     pub(crate) thresholds: Option<crate::app::Thresholds>,
@@ -170,6 +171,7 @@ struct RawTarget {
     expr: Option<String>,
     #[serde(rename = "legendFormat")]
     legend_format: Option<String>,
+    instant: Option<bool>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -291,6 +293,26 @@ fn value_is_all(value: Option<&serde_json::Value>) -> bool {
     }
 }
 
+fn query_mode_for_target(
+    instant: Option<bool>,
+    panel_type: crate::app::PanelType,
+) -> crate::app::QueryMode {
+    match instant {
+        Some(true) => crate::app::QueryMode::Instant,
+        Some(false) => crate::app::QueryMode::Range,
+        None => default_query_mode_for_panel(panel_type),
+    }
+}
+
+fn default_query_mode_for_panel(panel_type: crate::app::PanelType) -> crate::app::QueryMode {
+    match panel_type {
+        crate::app::PanelType::Gauge
+        | crate::app::PanelType::BarGauge
+        | crate::app::PanelType::Table => crate::app::QueryMode::Instant,
+        _ => crate::app::QueryMode::Range,
+    }
+}
+
 fn collect_panels(out: &mut DashboardImport, panels: Vec<RawPanel>) -> Result<()> {
     for p in panels.into_iter() {
         if let Some(children) = p.panels {
@@ -311,11 +333,13 @@ fn collect_panels(out: &mut DashboardImport, panels: Vec<RawPanel>) -> Result<()
         if panel_type != crate::app::PanelType::Unknown {
             let mut exprs = Vec::new();
             let mut legends = Vec::new();
+            let mut query_modes = Vec::new();
 
             for t in p.targets.unwrap_or_default() {
                 if let Some(e) = t.expr {
                     exprs.push(e);
                     legends.push(t.legend_format);
+                    query_modes.push(query_mode_for_target(t.instant, panel_type));
                 }
             }
 
@@ -392,6 +416,7 @@ fn collect_panels(out: &mut DashboardImport, panels: Vec<RawPanel>) -> Result<()
                     title: p.title.unwrap_or_default(),
                     exprs,
                     legends,
+                    query_modes,
                     grid: gp,
                     panel_type,
                     thresholds,
@@ -539,6 +564,80 @@ mod tests {
         assert_eq!(dashboard.queries[1].display.unit, None);
         assert_eq!(dashboard.queries[1].display.decimals, None);
         assert_eq!(dashboard.queries[1].display.no_value, None);
+    }
+
+    #[test]
+    fn test_parse_target_instant_query_modes() {
+        let json = r#"
+        {
+            "title": "Instant Mode Test",
+            "panels": [
+                {
+                    "type": "timeseries",
+                    "title": "Explicit Instant",
+                    "targets": [
+                        { "expr": "up", "instant": true },
+                        { "expr": "rate(http_requests_total[5m])", "instant": false }
+                    ]
+                },
+                {
+                    "type": "gauge",
+                    "title": "Gauge Default",
+                    "targets": [{ "expr": "up" }]
+                },
+                {
+                    "type": "bargauge",
+                    "title": "Bar Gauge Default",
+                    "targets": [{ "expr": "up" }]
+                },
+                {
+                    "type": "table",
+                    "title": "Table Default",
+                    "targets": [{ "expr": "up" }]
+                },
+                {
+                    "type": "stat",
+                    "title": "Stat Default",
+                    "targets": [{ "expr": "up" }]
+                },
+                {
+                    "type": "gauge",
+                    "title": "Gauge Range Override",
+                    "targets": [{ "expr": "up", "instant": false }]
+                }
+            ]
+        }
+        "#;
+        let path = std::env::temp_dir().join("grafatui-instant-mode-test.json");
+        std::fs::write(&path, json).unwrap();
+
+        let dashboard = load_grafana_dashboard(&path).unwrap();
+        std::fs::remove_file(path).unwrap();
+
+        assert_eq!(
+            dashboard.queries[0].query_modes,
+            vec![crate::app::QueryMode::Instant, crate::app::QueryMode::Range]
+        );
+        assert_eq!(
+            dashboard.queries[1].query_modes,
+            vec![crate::app::QueryMode::Instant]
+        );
+        assert_eq!(
+            dashboard.queries[2].query_modes,
+            vec![crate::app::QueryMode::Instant]
+        );
+        assert_eq!(
+            dashboard.queries[3].query_modes,
+            vec![crate::app::QueryMode::Instant]
+        );
+        assert_eq!(
+            dashboard.queries[4].query_modes,
+            vec![crate::app::QueryMode::Range]
+        );
+        assert_eq!(
+            dashboard.queries[5].query_modes,
+            vec![crate::app::QueryMode::Range]
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,6 +136,7 @@ async fn main() -> Result<()> {
                 title: q.title,
                 exprs: q.exprs,
                 legends: q.legends,
+                query_modes: q.query_modes,
                 series: vec![],
                 last_error: None,
                 last_url: None,

--- a/src/prom.rs
+++ b/src/prom.rs
@@ -81,6 +81,15 @@ impl PromClient {
         )
     }
 
+    pub(crate) fn build_query_url(&self, expr: &str, time: i64) -> String {
+        format!(
+            "{}/api/v1/query?query={}&time={}",
+            self.base.trim_end_matches('/'),
+            urlencoding::encode(expr),
+            time
+        )
+    }
+
     pub(crate) async fn query_range(
         &self,
         expr: &str,
@@ -219,15 +228,17 @@ impl PromClient {
         expr: &str,
         time: i64,
     ) -> Result<Vec<String>> {
-        let url = format!(
-            "{}/api/v1/query?query={}&time={}",
-            self.base.trim_end_matches('/'),
-            urlencoding::encode(expr),
-            time
-        );
+        let url = self.build_query_url(expr, time);
         let body: PromResponse<QueryInstantData> = self.get_json(&url).await?;
         ensure_success(&body.status)?;
         Ok(body.data.result_strings())
+    }
+
+    pub(crate) async fn query_instant_series(&self, expr: &str, time: i64) -> Result<Vec<Series>> {
+        let url = self.build_query_url(expr, time);
+        let body: PromResponse<QueryInstantData> = self.get_json(&url).await?;
+        ensure_success(&body.status)?;
+        Ok(body.data.into_series(time))
     }
 
     async fn get_json<T: DeserializeOwned>(&self, url: &str) -> Result<T> {
@@ -299,6 +310,56 @@ impl QueryInstantData {
             _ => Vec::new(),
         }
     }
+
+    fn into_series(self, time: i64) -> Vec<Series> {
+        match self.result_type.as_str() {
+            "vector" => vector_result_series(&self.result, time),
+            "scalar" => scalar_result_series(&self.result, time)
+                .into_iter()
+                .collect(),
+            _ => Vec::new(),
+        }
+    }
+}
+
+fn vector_result_series(result: &serde_json::Value, time: i64) -> Vec<Series> {
+    result
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(|sample| {
+            let metric = sample.get("metric")?.as_object()?;
+            let value = sample
+                .get("value")
+                .and_then(|value| value.as_array())
+                .and_then(|value| value.get(1))
+                .and_then(|value| value.as_str())?;
+
+            Some(Series {
+                metric: metric
+                    .iter()
+                    .filter_map(|(label, value)| {
+                        value
+                            .as_str()
+                            .map(|value| (label.clone(), value.to_string()))
+                    })
+                    .collect(),
+                values: vec![(time as f64, value.to_string())],
+            })
+        })
+        .collect()
+}
+
+fn scalar_result_series(result: &serde_json::Value, time: i64) -> Option<Series> {
+    let value = result
+        .as_array()
+        .and_then(|value| value.get(1))
+        .and_then(|value| value.as_str())?;
+
+    Some(Series {
+        metric: HashMap::new(),
+        values: vec![(time as f64, value.to_string())],
+    })
 }
 
 fn vector_result_strings(result: &serde_json::Value) -> Vec<String> {
@@ -362,6 +423,17 @@ mod tests {
     }
 
     #[test]
+    fn test_build_query_url_preserves_path_prefix() {
+        let client = PromClient::new("http://localhost:9090/prometheus/".to_string());
+        let url = client.build_query_url("up{job=\"node\"}", 1600003600);
+
+        assert_eq!(
+            url,
+            "http://localhost:9090/prometheus/api/v1/query?query=up%7Bjob%3D%22node%22%7D&time=1600003600"
+        );
+    }
+
+    #[test]
     fn test_deserialize_query_range_response() {
         let json = r#"
         {
@@ -412,5 +484,50 @@ mod tests {
             data.result_strings(),
             vec![r#"{instance="node-1", job="node"} 1"#]
         );
+    }
+
+    #[test]
+    fn test_query_instant_vector_converts_to_series() {
+        let json = r#"
+        {
+            "resultType": "vector",
+            "result": [
+                {
+                    "metric": { "instance": "node-1", "job": "node" },
+                    "value": [1435781451.781, "1"]
+                },
+                {
+                    "metric": { "instance": "node-2", "job": "node" },
+                    "value": [1435781451.781, "2.5"]
+                }
+            ]
+        }
+        "#;
+
+        let data: QueryInstantData = serde_json::from_str(json).unwrap();
+        let series = data.into_series(1_435_781_451);
+
+        assert_eq!(series.len(), 2);
+        assert_eq!(series[0].metric.get("instance").unwrap(), "node-1");
+        assert_eq!(series[0].values, vec![(1_435_781_451.0, "1".to_string())]);
+        assert_eq!(series[1].metric.get("instance").unwrap(), "node-2");
+        assert_eq!(series[1].values, vec![(1_435_781_451.0, "2.5".to_string())]);
+    }
+
+    #[test]
+    fn test_query_instant_scalar_converts_to_unlabeled_series() {
+        let json = r#"
+        {
+            "resultType": "scalar",
+            "result": [1435781451.781, "42"]
+        }
+        "#;
+
+        let data: QueryInstantData = serde_json::from_str(json).unwrap();
+        let series = data.into_series(1_435_781_451);
+
+        assert_eq!(series.len(), 1);
+        assert!(series[0].metric.is_empty());
+        assert_eq!(series[0].values, vec![(1_435_781_451.0, "42".to_string())]);
     }
 }

--- a/src/ui/panels/graph/bounds.rs
+++ b/src/ui/panels/graph/bounds.rs
@@ -71,6 +71,7 @@ mod tests {
             title: "test".to_string(),
             exprs: vec![],
             legends: vec![],
+            query_modes: vec![],
             series: vec![],
             last_error: None,
             last_url: None,


### PR DESCRIPTION
## Description

Adds Prometheus instant-query support for imported Grafana panel targets. Grafatui now honors `targets[].instant`, defaults Gauge/BarGauge/Table panels to instant queries when omitted, preserves range-query behavior for Stat sparklines and chart-style panels by default, and includes an example dashboard demonstrating the behavior.

Fixes #54

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have used Conventional Commits for my commit messages