### PR TITLE
Point users to live documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,6 +7,8 @@ assignees: ''
 
 ---
 
+Before filing, please check the [user guide](https://fedexist.github.io/grafatui/), especially [Troubleshooting](https://fedexist.github.io/grafatui/troubleshooting.html) and the [Grafana compatibility matrix](https://fedexist.github.io/grafatui/grafana-compatibility.html).
+
 **Describe the bug**
 A clear and concise description of what the bug is.
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,6 +7,8 @@ assignees: ''
 
 ---
 
+Before filing, please check the [user guide](https://fedexist.github.io/grafatui/) and the [Grafana compatibility matrix](https://fedexist.github.io/grafatui/grafana-compatibility.html) in case the feature is already documented or partially supported.
+
 **Is your feature request related to a problem? Please describe.**
 A clear and concise description of what the problem is. Ex: I'm always frustrated when [...]
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,6 +17,7 @@ Fixes # (issue)
 - [ ] I have performed a self-review of my own code
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation
+- [ ] I have checked whether the [user guide](https://fedexist.github.io/grafatui/) needs an update
 - [ ] My changes generate no new warnings
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 📚 Documentation
 
+- Publish the user guide at [fedexist.github.io/grafatui](https://fedexist.github.io/grafatui/).
 - Align roadmap with Grafana parity priorities ([b0e128d](https://github.com/fedexist/grafatui/commit/b0e128de94fa91da94c6a9b6c723ba44d21e8e41))
 - Add instant query dashboard example ([2b38ded](https://github.com/fedexist/grafatui/commit/2b38ded40532fb13de39c4d09e9f6705d6cf8271))
 - Add mdBook user guide ([a0feba1](https://github.com/fedexist/grafatui/commit/a0feba1e6cbe97e0d19aaab8183b3209d28e5b09))

--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ cargo run -- --grafana-json examples/dashboards/prometheus_demo.json --prometheu
 ## Documentation
 
 - [User guide](https://fedexist.github.io/grafatui/)
-- [Installation](docs/installation.md)
-- [Quick start](docs/quick-start.md)
-- [Configuration](docs/configuration.md)
-- [Grafana dashboard import](docs/grafana-dashboard-import.md)
-- [Grafana compatibility matrix](GRAFANA_COMPATIBILITY.md)
+- [Installation](https://fedexist.github.io/grafatui/installation.html)
+- [Quick start](https://fedexist.github.io/grafatui/quick-start.html)
+- [Configuration](https://fedexist.github.io/grafatui/configuration.html)
+- [Grafana dashboard import](https://fedexist.github.io/grafatui/grafana-dashboard-import.html)
+- [Grafana compatibility matrix](https://fedexist.github.io/grafatui/grafana-compatibility.html)
 - [Examples](examples/README.md)
 
 Rust API documentation is available on [docs.rs](https://docs.rs/grafatui).


### PR DESCRIPTION
## Summary

Closes #59.

- Point README documentation links at the live GitHub Pages guide.
- Add the live guide URL to the 0.1.8 changelog entry.
- Nudge issue and PR templates toward the user guide and compatibility matrix.

## Validation

- `mdbook build`
- `git diff --check HEAD`
- `cargo publish --dry-run`
- `cargo test --all` passed: 77 tests
- PR checks passed: CI build and Docs build; Docs deploy skipped as intended on PRs