### PR TITLE
Update docs and license headers

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -14,7 +14,7 @@ The `examples/dashboards/all_visualizations.json` file demonstrates all supporte
 cargo run -- --grafana-json examples/dashboards/all_visualizations.json
 
 # Or connect to a remote Prometheus
-cargo run -- --grafana-json examples/dashboards/all_visualizations.json --prometheus http://your-prometheus:9090
+cargo run -- --grafana-json examples/dashboards/all_visualizations.json --prometheus-url http://your-prometheus:9090
 ```
 
 **Option 2: Quick Local Test with Prometheus**
@@ -48,18 +48,39 @@ When creating test dashboards for new features:
 
 ```
 grafatui/
-├── src/               # Source code
-│   ├── main.rs       # CLI entry point
-│   ├── app.rs        # Application state & logic
-│   ├── ui.rs         # UI rendering & visualizations
-│   ├── prom.rs       # Prometheus client
-│   ├── grafana.rs    # Grafana JSON parser
-│   ├── config.rs     # Configuration
-│   └── theme.rs      # Color themes
-├── examples/         # Example dashboards & demos
-│   ├── dashboards/   # Grafana JSON files
-│   └── README.md     # Examples documentation
-└── target/           # Build artifacts (gitignored)
+├── src/                         # Rust source code
+│   ├── main.rs                  # Program entry point and app wiring
+│   ├── cli.rs                   # clap CLI argument and subcommand definitions
+│   ├── config.rs                # TOML configuration loading and path expansion
+│   ├── export.rs                # SVG/PNG export and changed-frame recordings
+│   ├── grafana.rs               # Grafana dashboard JSON import
+│   ├── prom.rs                  # Prometheus HTTP client
+│   ├── theme.rs                 # Color themes and Grafana color parsing
+│   ├── app/                     # Runtime state, input, refresh loop, and variables
+│   │   ├── data.rs              # Query expansion, legend formatting, downsampling
+│   │   ├── event_loop.rs        # Terminal event loop and export/recording actions
+│   │   ├── input.rs             # Keyboard and mouse input handling
+│   │   ├── state.rs             # App, panel, series, thresholds, and query state
+│   │   └── variables.rs         # Dynamic Grafana template variable resolution
+│   └── ui/                      # Ratatui rendering and formatting
+│       ├── draw.rs              # Top-level UI composition
+│       ├── format.rs            # Value, unit, and time formatting
+│       ├── layout.rs            # Grid layout and panel hit-testing
+│       └── panels/              # Panel renderers
+│           ├── graph/           # Graph bounds, labels, overlays, thresholds, autogrid
+│           ├── bar_gauge.rs     # Bar gauge renderer
+│           ├── gauge.rs         # Gauge renderer
+│           ├── heatmap.rs       # Heatmap renderer
+│           ├── stat.rs          # Stat renderer
+│           └── table.rs         # Table renderer
+├── docs/                        # mdBook user guide source
+│   ├── SUMMARY.md               # mdBook table of contents
+│   └── grafana-compatibility.md # Grafana JSON compatibility matrix
+├── examples/                    # Example dashboards and local demo stack
+│   ├── dashboards/              # Grafana dashboard JSON fixtures
+│   └── demo/                    # Docker Compose Prometheus/node-exporter/vLLM demo
+├── book.toml                    # mdBook configuration
+└── Cargo.toml                   # Crate metadata and dependencies
 ```
 
 ## Running Tests

--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2025 Federico D'Ambrosio
+   Copyright 2026 Federico D'Ambrosio
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,7 +8,7 @@ oriented around two priorities:
 2. **User-visible product value** - parity work should make real dashboards
    easier to read, debug, and share.
 
-> **Current version**: 0.1.7 · **Status**: Active development, pre-1.0
+> **Current version**: 0.1.9 · **Status**: Active development, pre-1.0
 
 **Legend**:
 - 🟢 Low complexity · 🟡 Medium complexity · 🔴 High complexity
@@ -44,7 +44,7 @@ These features are shipped and available today:
 | Rendering | **Autogrid** | Global and per-panel guide lines, including configurable color |
 | Field config | **Thresholds** | `fieldConfig.defaults.thresholds` for graph limit lines and Stat/Gauge/BarGauge coloring |
 | Field config | **Threshold marker styles** | Dashed line, dot, braille, block, quadrant, sextant, octant, and related modes |
-| Field config | **Field min/max bounds** | `fieldConfig.defaults.min` / `max` for gauge scaling and percentage thresholds |
+| Field config | **Field min/max bounds** | `fieldConfig.defaults.min` / `max` for graph y-axis bounds, gauge scaling, and percentage thresholds |
 | Field config | **Display formatting subset** | Common `unit` values, `decimals`, and `noValue` for supported panel values, axes, legends, and exports |
 | Export | **SVG/PNG snapshots** | Export the visible dashboard to SVG, PNG, or both |
 | Export | **Recording frame bundles** | Changed-frame recordings with manifest metadata and frame caps |
@@ -53,10 +53,9 @@ These features are shipped and available today:
 | Distribution | **Cross-platform binaries** | Linux, macOS, and Windows release assets |
 | Distribution | **Package formats** | `.deb`, `.rpm`, Homebrew formula support |
 
-For a field-by-field breakdown of Grafana JSON compatibility, see
-[GRAFANA_COMPATIBILITY.md](GRAFANA_COMPATIBILITY.md). That document should be
-refreshed alongside roadmap work because several v0.1.x parity features have
-landed since its original snapshot.
+For a field-by-field breakdown of Grafana JSON compatibility, see the
+[compatibility matrix](docs/grafana-compatibility.md). Keep that document
+refreshed alongside parity work so it stays aligned with the current release.
 
 ---
 
@@ -87,7 +86,7 @@ This is the main backlog, ordered by Grafana parity domain.
 
 | Feature | Grafana field / behavior | User value | Complexity | Status |
 |---|---|---|---|---|
-| **Compatibility matrix refresh** | Documentation generated from current code | Keeps users and contributors aligned with reality | 🟢 | 🔜 |
+| **Compatibility matrix automation** | Documentation generated or checked against current code | Keeps users and contributors aligned with reality | 🟢 | 📋 |
 | **Unsupported panel warnings** | Unsupported `panels[].type` and skipped targets | Makes import degradation visible instead of silent | 🟢 | 🔜 |
 | **Import validation** | `schemaVersion`, panel shape, target shape, required fields | Lets users check dashboards before launching the TUI | 🟢 | 🔜 |
 | **Better JSON/import errors** | Parse errors with path/context where possible | Faster debugging for broken exports | 🟢 | 📋 |
@@ -120,7 +119,7 @@ This is the main backlog, ordered by Grafana parity domain.
 | Feature | Grafana field / behavior | User value | Complexity | Status |
 |---|---|---|---|---|
 | **Hidden targets** | `targets[].hide` | Helper queries do not clutter imported panels | 🟢 | 🔜 |
-| **Instant queries** | `targets[].instant` / Prometheus `query` | Stat/table panels can use point-in-time queries | 🟡 | ✅ |
+| **Instant query defaults** | Panel-specific fallback behavior when `targets[].instant` is omitted | Keeps summary panels fast while preserving range queries for charts | 🟢 | ✅ |
 | **Target interval** | `targets[].interval` / `intervalFactor` | Panel-specific resolution is respected | 🟡 | 📋 |
 | **Target ref IDs** | `targets[].refId` | Better diagnostics and future transformation support | 🟢 | 📋 |
 | **Format handling** | `targets[].format` | Tables and heatmaps can choose more appropriate handling | 🟡 | 📋 |
@@ -182,7 +181,6 @@ Goal: imported dashboards should be more readable and less silently degraded.
 
 | Item | Why it belongs here | Complexity | Status |
 |---|---|---|---|
-| Compatibility matrix refresh | Establish the current truth before adding more parity | 🟢 | 🔜 |
 | Value mappings | Makes status/stat panels useful instead of numeric-only | 🟡 | 🔜 |
 | Broader unit formatting | Expands the shipped common-unit subset to more Grafana dashboards | 🟡 | 📋 |
 | Additional no-value coverage | Completes the shipped fallback behavior where terminal rendering can use it | 🟢 | 📋 |
@@ -198,7 +196,6 @@ expectations.
 | Item | Why it belongs here | Complexity | Status |
 |---|---|---|---|
 | Reduce options | Summary panels need more than "last" | 🟡 | 📋 |
-| Instant query support | Many summary/table panels are intended as instant queries | 🟡 | ✅ |
 | Display names | Imported labels become clearer without changing queries | 🟢 | 📋 |
 | Legend display modes and placement | Dense dashboards need predictable legend behavior | 🟡 | 📋 |
 | Legend calculations | Adds useful table-like summaries without a new panel type | 🟡 | 📋 |
@@ -261,10 +258,10 @@ These are valuable, but they should not outrank core Grafana import fidelity.
 
 Recommended order for the next focused development cycle:
 
-1. **Refresh compatibility truth**
-   - Update `GRAFANA_COMPATIBILITY.md` to match v0.1.7.
-   - Add tests or fixtures for fields already supported but documented as
-     missing.
+1. **Automate compatibility truth**
+   - Add tests or fixtures for fields already supported by v0.1.9 so the
+     compatibility matrix is easier to keep current.
+   - Prefer small checks that compare parser behavior with documented support.
 
 2. **Extend the field display layer**
    - Add value mappings and broaden unit coverage beyond the shipped common
@@ -290,9 +287,9 @@ Roadmap items are especially useful when PRs include:
 
 - A small Grafana JSON fixture that demonstrates the supported field.
 - Unit tests for parsing and display behavior.
-- A short note in `GRAFANA_COMPATIBILITY.md` explaining the TUI mapping or
+- A short note in `docs/grafana-compatibility.md` explaining the TUI mapping or
   limitation.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines, and
-[GRAFANA_COMPATIBILITY.md](GRAFANA_COMPATIBILITY.md) for the full Grafana JSON
+[docs/grafana-compatibility.md](docs/grafana-compatibility.md) for the full Grafana JSON
 feature-parity breakdown.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -28,6 +28,8 @@ docker-compose down -v
 
 - `examples/dashboards/prometheus_demo.json`: recommended first demo for the bundled Prometheus stack.
 - `examples/dashboards/all_visualizations.json`: compact dashboard showing the supported visualization types.
+- `examples/dashboards/instant_queries.json`: demonstrates explicit instant targets and the default instant behavior for summary panels.
+- `examples/dashboards/thresholds_demo.json`: demonstrates thresholds, field bounds, and threshold marker rendering.
 - `examples/demo/vllm/grafana.json`: vLLM-oriented dashboard for the mock demo services.
 
 ## More Detail

--- a/docs/grafana-compatibility.md
+++ b/docs/grafana-compatibility.md
@@ -2,7 +2,7 @@
 
 This document provides a comprehensive feature-parity table between the [Grafana Dashboard JSON Model](https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/json-model/) and what Grafatui currently supports.
 
-> **Snapshot**: Grafatui v0.1.7. The roadmap prioritizes Grafana parity first,
+> **Snapshot**: Grafatui v0.1.9. The roadmap prioritizes Grafana parity first,
 > then user-visible product value. See the [roadmap](https://github.com/fedexist/grafatui/blob/main/ROADMAP.md) for milestone
 > slices built from this compatibility ladder.
 
@@ -164,17 +164,18 @@ This document provides a comprehensive feature-parity table between the [Grafana
 
 ## Field Configuration (`fieldConfig`)
 
-`fieldConfig` is partially implemented. Thresholds, min/max bounds, selected
-display formatting fields, threshold style, and per-panel autogrid settings are
-parsed; value mappings, display names, and field overrides remain major gaps.
+`fieldConfig` is partially implemented. Thresholds, explicit min/max bounds,
+selected display formatting fields, threshold style, and per-panel autogrid
+settings are parsed; value mappings, display names, and field overrides remain
+major gaps.
 
 | JSON Field | Status | Notes |
 |---|---|---|
 | `fieldConfig` | 🔶 Partial | Parsed for supported defaults/custom fields below |
 | `fieldConfig.defaults` | 🔶 Partial | Parsed for min/max, thresholds, and selected custom fields |
 | `fieldConfig.defaults.unit` | 🔶 Partial | Common units such as bytes, bits, seconds, milliseconds, percent, percentunit, ops, request rate, and byte rate are formatted; unknown units fall back to Grafatui's compact SI formatter |
-| `fieldConfig.defaults.min` | ✅ Supported | Used for interpolating percentage thresholds and Gauge limits |
-| `fieldConfig.defaults.max` | ✅ Supported | Used for scaling gauges and threshold boundaries |
+| `fieldConfig.defaults.min` | ✅ Supported | Used for Graph y-axis lower bounds, percentage thresholds, and Gauge limits |
+| `fieldConfig.defaults.max` | ✅ Supported | Used for Graph y-axis upper bounds, gauge scaling, and threshold boundaries |
 | `fieldConfig.defaults.decimals` | ✅ Supported | Controls numeric precision in panel values, graph axes, legends, and exports |
 | `fieldConfig.defaults.color` | ❌ Not Implemented | Uses theme palette instead |
 | `fieldConfig.defaults.mappings` | ❌ Not Implemented | Value mappings not supported |
@@ -291,8 +292,8 @@ tooltips.
 | Annotations | 0 | 0 | 2 | 0 |
 | Data Links / Transforms | 0 | 0 | 2 | 1 |
 | Alert Rules | 0 | 0 | 3 | 0 |
-| Datasources | 2 | 1 | 5 | 0 |
-| **Total** | **46** | **14** | **85** | **15** |
+| Datasources | 3 | 0 | 5 | 0 |
+| **Total** | **47** | **13** | **85** | **15** |
 
 ---
 
@@ -304,7 +305,7 @@ Based on user feedback, the following missing features are most commonly expecte
 2. **Broader unit formatting** (`fieldConfig.defaults.unit`) — Extend the current common-unit subset to more Grafana unit families
 3. **Reduce options** (`options.reduceOptions`) — Use min/max/mean/total instead of always using the latest value
 4. **Import diagnostics** — Warn clearly about skipped panel types and ignored high-impact fields
-5. **Instant query panel targets** (`targets[].instant`) — Support point-in-time queries for stat/table-style panels
+5. **Hidden targets** (`targets[].hide`) — Hide helper queries that should not render as visible series
 6. **Additional panel types** — `text`, `piechart`, `histogram`, `logs`
 
 ---
@@ -331,4 +332,4 @@ Grafatui provides several TUI-native capabilities that don't map directly to Gra
 
 ---
 
-*This document was reviewed against the Grafatui source code at v0.1.7. If you notice any inaccuracies, please open an issue or PR.*
+*This document was reviewed against the Grafatui source code at v0.1.9. If you notice any inaccuracies, please open an issue or PR.*

--- a/docs/grafana-dashboard-import.md
+++ b/docs/grafana-dashboard-import.md
@@ -40,6 +40,28 @@ grafatui --grafana-json ./dash.json --var job=node --var instance=server-01
 
 Prometheus query variables such as `label_values(up, instance)` and `query_result(...)` are resolved before panel queries run.
 
+## Query Modes
+
+Grafatui honors `targets[].instant` from Grafana dashboard JSON. Targets marked
+as instant use the Prometheus instant `query` endpoint, while range targets use
+`query_range`.
+
+If a target does not specify `instant`, Gauge, Bar Gauge, and Table panels
+default to instant queries. Graph, Timeseries, Stat, and Heatmap panels default
+to range queries.
+
+## Field Configuration
+
+Grafatui applies selected `fieldConfig.defaults` values where they map cleanly
+to terminal rendering:
+
+- `min` and `max` set explicit Graph y-axis bounds and Gauge limits.
+- `thresholds` render graph threshold lines and drive dynamic coloring for Stat,
+  Gauge, and Bar Gauge panels.
+- `unit`, `decimals`, and `noValue` affect supported panel values, axes,
+  legends, and exports.
+- `custom.axisGridShow` controls per-panel graph guide lines.
+
 ## Built-In PromQL Variables
 
 Grafatui expands the following Grafana-style variables:

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,7 +8,7 @@ Want to try grafatui instantly? Use the pre-configured demo environment:
 
 ```bash
 cd demo
-docker-compose up -d && sleep 5 && cd ../.. && cargo run -- --grafana-json examples/dashboards/prometheus_demo.json --prometheus http://localhost:19090
+docker-compose up -d && sleep 5 && cd ../.. && cargo run -- --grafana-json examples/dashboards/prometheus_demo.json --prometheus-url http://localhost:19090
 ```
 
 See [`demo/README.md`](demo/README.md) for details.
@@ -31,6 +31,14 @@ Demonstrates all supported panel types in a single dashboard:
 - **Table**: Tabular view of series
 - **Heatmap**: Color-coded time-series intensity
 
+### `instant_queries.json`
+Demonstrates explicit `targets[].instant` support and the default instant query
+behavior used by Gauge, Bar Gauge, and Table panels.
+
+### `thresholds_demo.json`
+Demonstrates threshold rendering, threshold marker styles, and explicit field
+min/max bounds.
+
 ### Usage
 
 ```bash
@@ -38,7 +46,7 @@ Demonstrates all supported panel types in a single dashboard:
 cargo run -- --grafana-json examples/dashboards/all_visualizations.json
 
 # Or with custom Prometheus URL
-cargo run -- --grafana-json examples/dashboards/all_visualizations.json --prometheus http://prometheus.example.com:9090
+cargo run -- --grafana-json examples/dashboards/all_visualizations.json --prometheus-url http://prometheus.example.com:9090
 
 # Override variables
 cargo run -- --grafana-json examples/dashboards/all_visualizations.json --var instance=localhost:9090

--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -11,7 +11,7 @@ docker-compose up -d && sleep 5 && cargo run -- --grafana-json ../dashboards/pro
 > **Note**: The docker-compose is configured to use port **19090** to avoid conflicts with development tools and other services.
 
 This will:
-1. Start Prometheus (port **10001**) and node-exporter (port 9100)
+1. Start Prometheus (port **19090**) and node-exporter (port 9100)
 2. Wait 5 seconds for metrics to populate
 3. Launch grafatui with the demo dashboard
 
@@ -46,7 +46,7 @@ curl http://localhost:19090/-/healthy
 
 # Run grafatui (from repo root)
 cd ../..
-cargo run -- --grafana-json examples/dashboards/prometheus_demo.json --prometheus http://localhost:19090
+cargo run -- --grafana-json examples/dashboards/prometheus_demo.json --prometheus-url http://localhost:19090
 
 # Run vLLM Dashboard (using config file)
 # This uses grafatui.toml to set Prometheus URL and dashboard automatically
@@ -54,7 +54,7 @@ cd examples/demo
 cargo run -- --config grafatui.toml
 
 # Optional: customize time range and step
-cargo run -- --grafana-json examples/dashboards/prometheus_demo.json --prometheus http://localhost:19090 --range 5m --step 2s
+cargo run -- --grafana-json examples/dashboards/prometheus_demo.json --prometheus-url http://localhost:19090 --range 5m --step 2s
 ```
 
 ## Cleanup
@@ -77,4 +77,4 @@ docker-compose down -v  # -v removes volumes (data)
 
 **Port already in use:**
 - Change port in `docker-compose.yml`: `"9091:9090"` (use 9091 instead)
-- Then run grafatui with: `--prometheus http://localhost:9091`
+- Then run grafatui with: `--prometheus-url http://localhost:9091`

--- a/src/app/data.rs
+++ b/src/app/data.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Federico D'Ambrosio
+ * Copyright 2026 Federico D'Ambrosio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/app/event_loop.rs
+++ b/src/app/event_loop.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Federico D'Ambrosio
+ * Copyright 2026 Federico D'Ambrosio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Federico D'Ambrosio
+ * Copyright 2026 Federico D'Ambrosio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Federico D'Ambrosio
+ * Copyright 2026 Federico D'Ambrosio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Federico D'Ambrosio
+ * Copyright 2026 Federico D'Ambrosio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/app/variables.rs
+++ b/src/app/variables.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Federico D'Ambrosio
+ * Copyright 2026 Federico D'Ambrosio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Federico D'Ambrosio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 use clap::Parser;
 use std::path::PathBuf;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Federico D'Ambrosio
+ * Copyright 2026 Federico D'Ambrosio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/export.rs
+++ b/src/export.rs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 Federico D'Ambrosio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 use crate::app::{AppMode, AppState, PanelState, PanelType, SeriesView, ThresholdMode};
 use crate::theme::Theme;
 use crate::ui;

--- a/src/grafana.rs
+++ b/src/grafana.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Federico D'Ambrosio
+ * Copyright 2026 Federico D'Ambrosio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Federico D'Ambrosio
+ * Copyright 2026 Federico D'Ambrosio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/prom.rs
+++ b/src/prom.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Federico D'Ambrosio
+ * Copyright 2026 Federico D'Ambrosio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Federico D'Ambrosio
+ * Copyright 2026 Federico D'Ambrosio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/ui/draw.rs
+++ b/src/ui/draw.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Federico D'Ambrosio
+ * Copyright 2026 Federico D'Ambrosio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/ui/format.rs
+++ b/src/ui/format.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Federico D'Ambrosio
+ * Copyright 2026 Federico D'Ambrosio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Federico D'Ambrosio
+ * Copyright 2026 Federico D'Ambrosio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Federico D'Ambrosio
+ * Copyright 2026 Federico D'Ambrosio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/ui/panels/bar_gauge.rs
+++ b/src/ui/panels/bar_gauge.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Federico D'Ambrosio
+ * Copyright 2026 Federico D'Ambrosio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/ui/panels/gauge.rs
+++ b/src/ui/panels/gauge.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Federico D'Ambrosio
+ * Copyright 2026 Federico D'Ambrosio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/ui/panels/graph/autogrid.rs
+++ b/src/ui/panels/graph/autogrid.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Federico D'Ambrosio
+ * Copyright 2026 Federico D'Ambrosio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/ui/panels/graph/bounds.rs
+++ b/src/ui/panels/graph/bounds.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Federico D'Ambrosio
+ * Copyright 2026 Federico D'Ambrosio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/ui/panels/graph/labels.rs
+++ b/src/ui/panels/graph/labels.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Federico D'Ambrosio
+ * Copyright 2026 Federico D'Ambrosio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/ui/panels/graph/mod.rs
+++ b/src/ui/panels/graph/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Federico D'Ambrosio
+ * Copyright 2026 Federico D'Ambrosio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/ui/panels/graph/overlay.rs
+++ b/src/ui/panels/graph/overlay.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Federico D'Ambrosio
+ * Copyright 2026 Federico D'Ambrosio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/ui/panels/graph/thresholds.rs
+++ b/src/ui/panels/graph/thresholds.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Federico D'Ambrosio
+ * Copyright 2026 Federico D'Ambrosio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/ui/panels/heatmap.rs
+++ b/src/ui/panels/heatmap.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Federico D'Ambrosio
+ * Copyright 2026 Federico D'Ambrosio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/ui/panels/mod.rs
+++ b/src/ui/panels/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Federico D'Ambrosio
+ * Copyright 2026 Federico D'Ambrosio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/ui/panels/stat.rs
+++ b/src/ui/panels/stat.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Federico D'Ambrosio
+ * Copyright 2026 Federico D'Ambrosio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/ui/panels/table.rs
+++ b/src/ui/panels/table.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Federico D'Ambrosio
+ * Copyright 2026 Federico D'Ambrosio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description

Updates project documentation and licensing metadata to match the current v0.1.9 codebase and 2026 copyright year.

This includes:
- Refreshing docs for current Grafana compatibility, roadmap status, examples, and development project structure.
- Correcting stale CLI flag examples and demo port documentation.
- Updating the root LICENSE copyright year.
- Updating Rust source headers to 2026 and adding the existing Apache 2.0 header style to modules that were missing it.

Fixes # N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have checked whether the [user guide](https://fedexist.github.io/grafatui/) needs an update
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have used Conventional Commits for my commit messages

Validation performed:
- `mdbook build`
- `cargo test` (79 passed)
- `git diff --check origin/main...HEAD`
