### PR TITLE
Support Grafana timeseries graph styles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /assets
 /book
 .DS_Store
+docs/superpowers/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -178,9 +187,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "block-buffer"
@@ -217,6 +226,12 @@ name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
 name = "bytemuck"
@@ -430,12 +445,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "crossterm_winapi",
  "derive_more",
  "document-features",
@@ -644,6 +665,12 @@ dependencies = [
  "bit-set",
  "regex",
 ]
+
+[[package]]
+name = "fast-srgb8"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 
 [[package]]
 name = "fdeflate"
@@ -937,6 +964,17 @@ name = "hashbrown"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -1366,7 +1404,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "libc",
 ]
 
@@ -1376,7 +1414,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f4de44e98ddbf09375cbf4d17714d18f39195f4f4894e8524501726fd9a8a4a"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -1414,11 +1452,11 @@ checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "lru"
-version = "0.16.4"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
 dependencies = [
- "hashbrown 0.16.0",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -1501,7 +1539,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -1578,6 +1616,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "palette"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
+dependencies = [
+ "approx",
+ "fast-srgb8",
+ "libm",
+ "palette_derive",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -1918,9 +1980,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
-version = "0.30.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
+checksum = "1695748e3a735b34968c887ceea5a380b43545903868ae8f5b666593100f6b68"
 dependencies = [
  "instability",
  "ratatui-core",
@@ -1928,21 +1990,25 @@ dependencies = [
  "ratatui-macros",
  "ratatui-termwiz",
  "ratatui-widgets",
+ "serde",
 ]
 
 [[package]]
 name = "ratatui-core"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
+checksum = "42d3603f354bba8c595fa47860e60142d7372b7210c27044c6a7d0e1a4336b44"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "compact_str",
- "hashbrown 0.16.0",
+ "critical-section",
+ "hashbrown 0.17.1",
  "indoc",
  "itertools",
  "kasuari",
  "lru",
+ "palette",
+ "serde",
  "strum",
  "thiserror 2.0.17",
  "unicode-segmentation",
@@ -1952,9 +2018,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-crossterm"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
+checksum = "2b2867bedcbd6a690ca4f8672a687b730ec07660c79844517b084311b529980c"
 dependencies = [
  "cfg-if",
  "crossterm",
@@ -1964,9 +2030,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-macros"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f1342a13e83e4bb9d0b793d0ea762be633f9582048c892ae9041ef39c936f4"
+checksum = "80fac59720679490d89d200df411faa249be728681adcabed3d047ae72c48f1d"
 dependencies = [
  "ratatui-core",
  "ratatui-widgets",
@@ -1974,9 +2040,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-termwiz"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f76fe0bd0ed4295f0321b1676732e2454024c15a35d01904ddb315afd3d545c"
+checksum = "386b8ff8f74ed749509391c56d549761a2fcdb408e1f42e467286bcb7dac8967"
 dependencies = [
  "ratatui-core",
  "termwiz",
@@ -1984,17 +2050,18 @@ dependencies = [
 
 [[package]]
 name = "ratatui-widgets"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
+checksum = "7ef4f17dd7ac3abf5adc2b920a03c61eee4bfe6a88fa5191936895525371d79c"
 dependencies = [
- "bitflags 2.10.0",
- "hashbrown 0.16.0",
+ "bitflags 2.13.0",
+ "hashbrown 0.17.1",
  "indoc",
  "instability",
  "itertools",
  "line-clipping",
  "ratatui-core",
+ "serde",
  "strum",
  "time",
  "unicode-segmentation",
@@ -2007,7 +2074,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -2155,7 +2222,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2209,7 +2276,7 @@ version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "bytemuck",
  "core_maths",
  "log",
@@ -2431,18 +2498,18 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2537,7 +2604,7 @@ checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
  "base64",
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "fancy-regex",
  "filedescriptor",
  "finl_unicode",
@@ -2796,7 +2863,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "bytes",
  "futures-util",
  "http",
@@ -3146,7 +3213,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -3635,7 +3702,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "grafatui"
 version = "0.1.9"
 authors = ["Federico D'Ambrosio <fedexist@gmail.com>"]
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.88"
 description = "A Grafana-like TUI for Prometheus"
 license = "Apache-2.0"
 repository = "https://github.com/fedexist/grafatui"
@@ -23,7 +23,7 @@ clap_mangen = "0.2.26"
 crossterm = "0.29.0"
 futures = "0.3.31"
 humantime = "2.3.0"
-ratatui = { version = "0.30.0", features = ["crossterm"] }
+ratatui = { version = "0.30.1", features = ["crossterm"] }
 reqwest = { version = "0.12.24", default-features = false, features = ["json", "gzip", "brotli", "zstd", "rustls-tls"] }
 resvg = "0.45.1"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ cargo run -- --grafana-json examples/dashboards/prometheus_demo.json --prometheu
 - Prometheus range and instant queries with async fetching.
 - Grafana dashboard JSON import for graph, timeseries, stat, gauge, bar gauge, table, and heatmap panels.
 - Template variables, Grafana built-in PromQL variables, legend formatting, thresholds, and grid layout support.
+- Grafana timeseries draw styles for lines, points, bars, area fill, hidden axes, and per-panel grid visibility.
 - Keyboard-first navigation, panel search, fullscreen mode, mouse selection, and value inspection.
 - SVG/PNG export and changed-frame recording bundles.
 - TOML configuration and built-in themes.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/fedexist/grafatui/workflows/CI/badge.svg)](https://github.com/fedexist/grafatui/actions/workflows/ci.yml)
 [![Crates.io](https://img.shields.io/crates/v/grafatui.svg)](https://crates.io/crates/grafatui)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Rust Version](https://img.shields.io/badge/rust-1.85%2B-orange.svg)](https://www.rust-lang.org)
+[![Rust Version](https://img.shields.io/badge/rust-1.88%2B-orange.svg)](https://www.rust-lang.org)
 [![docs.rs](https://img.shields.io/docsrs/grafatui)](https://docs.rs/grafatui)
 
 **Grafatui** is a terminal user interface for Prometheus, inspired by Grafana. It lets you inspect time-series dashboards from a fast, keyboard-driven TUI that works well over SSH and in minimal environments.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -27,7 +27,7 @@ docker-compose down -v
 ## Included Dashboards
 
 - `examples/dashboards/prometheus_demo.json`: recommended first demo for the bundled Prometheus stack.
-- `examples/dashboards/all_visualizations.json`: compact dashboard showing the supported visualization types.
+- `examples/dashboards/all_visualizations.json`: compact dashboard showing the supported visualization types, including timeseries bars, area fill, point mode, and hidden-axis examples.
 - `examples/demo/vllm/grafana.json`: vLLM-oriented dashboard for the mock demo services.
 
 ## More Detail

--- a/docs/grafana-compatibility.md
+++ b/docs/grafana-compatibility.md
@@ -75,8 +75,12 @@ This document provides a comprehensive feature-parity table between the [Grafana
 | Feature | JSON Field | Behavior | Grafana | Grafatui |
 |---|---|---|---|---|
 | **Draw styles** | `fieldConfig.defaults.custom.drawStyle` | Line, points, and bars map to terminal graph styles | 🟡 | ✅ |
+| **Point display** | `fieldConfig.defaults.custom.showPoints` | `always` overlays visible point markers; `never` suppresses area/line point markers | 🟡 | 🔶 |
+| **Area fill** | `fieldConfig.defaults.custom.fillOpacity` | Nonzero fill opacity renders terminal/SVG area fill behind the line | 🟡 | 🔶 |
 | **Stacking** | `fieldConfig.defaults.custom.stacking` | Parsed and retained; non-off modes render non-stacked in this slice | 🟡 | 🔶 |
 | **Axis placement** | `fieldConfig.defaults.custom.axisPlacement` | `hidden` suppresses y-axis labels; left/right map to the terminal y-axis | 🟡 | 🔶 |
+| **Axis grid** | `fieldConfig.defaults.custom.axisGridShow` | Controls per-panel autogrid guide lines | 🟡 | ✅ |
+| **Threshold style** | `fieldConfig.defaults.custom.thresholdsStyle` | Dashed/line style is parsed for graph threshold rendering | 🟡 | 🔶 |
 
 ### Panel Common Fields
 
@@ -191,7 +195,7 @@ parsed; value mappings, display names, and field overrides remain major gaps.
 | `fieldConfig.defaults.custom` | 🔶 Partial | Used for graph draw style, fill/points, axis placement, stacking metadata, threshold style, and axis grid visibility |
 | `fieldConfig.defaults.custom.lineWidth` | ❌ Not Implemented | TUI limitation |
 | `fieldConfig.defaults.custom.fillOpacity` | 🔶 Partial | Nonzero values enable terminal/SVG area fill; exact browser opacity is approximated |
-| `fieldConfig.defaults.custom.pointSize` | ⛔ Not Applicable | TUI limitation |
+| `fieldConfig.defaults.custom.pointSize` | ⛔ Not Applicable | TUI points use fixed terminal-cell markers |
 | `fieldConfig.defaults.custom.axisLabel` | ❌ Not Implemented | |
 | `fieldConfig.defaults.custom.axisGridShow` | ✅ Supported | Controls per-panel autogrid guide lines for graph/time-series panels |
 | `fieldConfig.defaults.custom.thresholdsStyle` | 🔶 Partial | `mode` is parsed for threshold rendering; glyph style is also controlled by Grafatui's marker setting |

--- a/docs/grafana-compatibility.md
+++ b/docs/grafana-compatibility.md
@@ -70,6 +70,14 @@ This document provides a comprehensive feature-parity table between the [Grafana
 | `trend` | ❌ Not Implemented | |
 | `xychart` | ❌ Not Implemented | |
 
+### Graph & Timeseries Parity
+
+| Feature | JSON Field | Behavior | Grafana | Grafatui |
+|---|---|---|---|---|
+| **Draw styles** | `fieldConfig.defaults.custom.drawStyle` | Line, points, and bars map to terminal graph styles | 🟡 | ✅ |
+| **Stacking** | `fieldConfig.defaults.custom.stacking` | Parsed and retained; non-off modes render non-stacked in this slice | 🟡 | 🔶 |
+| **Axis placement** | `fieldConfig.defaults.custom.axisPlacement` | `hidden` suppresses y-axis labels; left/right map to the terminal y-axis | 🟡 | 🔶 |
+
 ### Panel Common Fields
 
 | JSON Field | Status | Notes |
@@ -181,12 +189,9 @@ parsed; value mappings, display names, and field overrides remain major gaps.
 | `fieldConfig.defaults.noValue` | 🔶 Partial | Used for null Stat/Table values and exports; empty panels still show Grafatui's `No data` state |
 | `fieldConfig.defaults.displayName` | ❌ Not Implemented | |
 | `fieldConfig.defaults.custom` | 🔶 Partial | Used for threshold style and axis grid visibility |
-| `fieldConfig.defaults.custom.drawStyle` | ❌ Not Implemented | Always drawn as lines |
 | `fieldConfig.defaults.custom.lineWidth` | ❌ Not Implemented | TUI limitation |
 | `fieldConfig.defaults.custom.fillOpacity` | ⛔ Not Applicable | TUI limitation |
 | `fieldConfig.defaults.custom.pointSize` | ⛔ Not Applicable | TUI limitation |
-| `fieldConfig.defaults.custom.stacking` | ❌ Not Implemented | No stacked charts |
-| `fieldConfig.defaults.custom.axisPlacement` | ❌ Not Implemented | |
 | `fieldConfig.defaults.custom.axisLabel` | ❌ Not Implemented | |
 | `fieldConfig.defaults.custom.axisGridShow` | ✅ Supported | Controls per-panel autogrid guide lines for graph/time-series panels |
 | `fieldConfig.defaults.custom.thresholdsStyle` | 🔶 Partial | `mode` is parsed for threshold rendering; glyph style is also controlled by Grafatui's marker setting |

--- a/docs/grafana-compatibility.md
+++ b/docs/grafana-compatibility.md
@@ -188,9 +188,9 @@ parsed; value mappings, display names, and field overrides remain major gaps.
 | `fieldConfig.defaults.mappings` | ❌ Not Implemented | Value mappings not supported |
 | `fieldConfig.defaults.noValue` | 🔶 Partial | Used for null Stat/Table values and exports; empty panels still show Grafatui's `No data` state |
 | `fieldConfig.defaults.displayName` | ❌ Not Implemented | |
-| `fieldConfig.defaults.custom` | 🔶 Partial | Used for threshold style and axis grid visibility |
+| `fieldConfig.defaults.custom` | 🔶 Partial | Used for graph draw style, fill/points, axis placement, stacking metadata, threshold style, and axis grid visibility |
 | `fieldConfig.defaults.custom.lineWidth` | ❌ Not Implemented | TUI limitation |
-| `fieldConfig.defaults.custom.fillOpacity` | ⛔ Not Applicable | TUI limitation |
+| `fieldConfig.defaults.custom.fillOpacity` | 🔶 Partial | Nonzero values enable terminal/SVG area fill; exact browser opacity is approximated |
 | `fieldConfig.defaults.custom.pointSize` | ⛔ Not Applicable | TUI limitation |
 | `fieldConfig.defaults.custom.axisLabel` | ❌ Not Implemented | |
 | `fieldConfig.defaults.custom.axisGridShow` | ✅ Supported | Controls per-panel autogrid guide lines for graph/time-series panels |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -8,7 +8,7 @@ Install the latest published release with Cargo:
 cargo install grafatui
 ```
 
-Grafatui currently requires Rust 1.85 or newer.
+Grafatui currently requires Rust 1.88 or newer.
 
 ## From Source
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -25,6 +25,7 @@ Shows all 6 visualization types with real metrics from Prometheus monitoring its
 ### `all_visualizations.json`
 Demonstrates all supported panel types in a single dashboard:
 - **Graph**: Line chart showing CPU usage over time
+- **Timeseries styles**: Bars with hidden axis, area fill, and points-only rendering
 - **Gauge**: Progress bar for memory usage
 - **Stat**: Big value display with sparkline for uptime
 - **Bar Gauge**: Vertical bars comparing request rates
@@ -54,7 +55,7 @@ You can export any Grafana dashboard as JSON and use it with grafatui:
 
 ## Supported Panel Types
 
-- ✅ `graph` / `timeseries` - Line charts
+- ✅ `graph` / `timeseries` - Line, point, bar, and area-style charts
 - ✅ `gauge` - Progress bars
 - ✅ `bargauge` - Bar charts
 - ✅ `table` - Data tables

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,7 +8,7 @@ Want to try grafatui instantly? Use the pre-configured demo environment:
 
 ```bash
 cd demo
-docker-compose up -d && sleep 5 && cd ../.. && cargo run -- --grafana-json examples/dashboards/prometheus_demo.json --prometheus http://localhost:19090
+docker-compose up -d && sleep 5 && cd ../.. && cargo run -- --grafana-json examples/dashboards/prometheus_demo.json --prometheus-url http://localhost:19090
 ```
 
 See [`demo/README.md`](demo/README.md) for details.
@@ -38,10 +38,10 @@ Demonstrates all supported panel types in a single dashboard:
 cargo run -- --grafana-json examples/dashboards/all_visualizations.json
 
 # Or with custom Prometheus URL
-cargo run -- --grafana-json examples/dashboards/all_visualizations.json --prometheus http://prometheus.example.com:9090
+cargo run -- --grafana-json examples/dashboards/all_visualizations.json --prometheus-url http://prometheus.example.com:9090
 
 # Override variables
-cargo run -- --grafana-json examples/dashboards/all_visualizations.json --var instance=localhost:9090
+cargo run -- --grafana-json examples/dashboards/all_visualizations.json --var instance=prometheus:9090
 ```
 
 ## Creating Your Own

--- a/examples/dashboards/all_visualizations.json
+++ b/examples/dashboards/all_visualizations.json
@@ -107,6 +107,79 @@
                     "legendFormat": "{{handler}}"
                 }
             ]
+        },
+        {
+            "type": "timeseries",
+            "title": "Graph - Bars Hidden Axis",
+            "gridPos": {
+                "x": 0,
+                "y": 16,
+                "w": 8,
+                "h": 8
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {
+                        "drawStyle": "bars",
+                        "axisPlacement": "hidden"
+                    }
+                }
+            },
+            "targets": [
+                {
+                    "expr": "rate(prometheus_http_requests_total{instance=\"$instance\"}[1m])",
+                    "legendFormat": "{{code}}"
+                }
+            ]
+        },
+        {
+            "type": "timeseries",
+            "title": "Graph - Area Fill",
+            "gridPos": {
+                "x": 8,
+                "y": 16,
+                "w": 8,
+                "h": 8
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {
+                        "drawStyle": "line",
+                        "fillOpacity": 30,
+                        "showPoints": "never"
+                    }
+                }
+            },
+            "targets": [
+                {
+                    "expr": "rate(prometheus_http_requests_total{instance=\"$instance\"}[1m])",
+                    "legendFormat": "{{handler}}"
+                }
+            ]
+        },
+        {
+            "type": "timeseries",
+            "title": "Graph - Points",
+            "gridPos": {
+                "x": 16,
+                "y": 16,
+                "w": 8,
+                "h": 8
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {
+                        "drawStyle": "points",
+                        "showPoints": "always"
+                    }
+                }
+            },
+            "targets": [
+                {
+                    "expr": "up{instance=\"$instance\"}",
+                    "legendFormat": "{{job}}"
+                }
+            ]
         }
     ]
 }

--- a/examples/dashboards/all_visualizations.json
+++ b/examples/dashboards/all_visualizations.json
@@ -5,8 +5,8 @@
             {
                 "name": "instance",
                 "current": {
-                    "text": "localhost:9090",
-                    "value": "localhost:9090"
+                    "text": "prometheus:9090",
+                    "value": "prometheus:9090"
                 }
             }
         ]

--- a/src/app/data.rs
+++ b/src/app/data.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use super::state::{PanelState, PanelType, YAxisMode};
+use super::state::{GraphOptions, PanelOptions, PanelState, PanelType, YAxisMode};
 use anyhow::Result;
 use std::collections::HashMap;
 use std::time::Duration;
@@ -143,6 +143,7 @@ pub(crate) fn default_queries(mut provided: Vec<String>) -> Vec<PanelState> {
             max: None,
             autogrid: None,
             display: crate::ui::DisplayFormat::default(),
+            options: PanelOptions::Graph(GraphOptions::default()),
         })
         .collect()
 }

--- a/src/app/event_loop.rs
+++ b/src/app/event_loop.rs
@@ -117,7 +117,7 @@ fn finalize_recording_before_quit(app: &mut AppState) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::app::{PanelState, PanelType, SeriesView, YAxisMode};
+    use crate::app::{GraphOptions, PanelOptions, PanelState, PanelType, SeriesView, YAxisMode};
     use crate::export::{ExportFormat, ExportOptions};
     use crate::prom::PromClient;
     use crate::theme::Theme;
@@ -162,6 +162,7 @@ mod tests {
                 max: None,
                 autogrid: None,
                 display: crate::ui::DisplayFormat::default(),
+                options: PanelOptions::Graph(GraphOptions::default()),
             }],
             0,
             Theme::default(),

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -349,7 +349,7 @@ fn toggle_series_visibility(app: &mut AppState, c: char) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::app::{PanelState, PanelType, SeriesView};
+    use crate::app::{GraphOptions, PanelOptions, PanelState, PanelType, SeriesView};
     use crate::export::ExportOptions;
     use crate::prom;
     use crate::theme::Theme;
@@ -409,6 +409,7 @@ mod tests {
             max: None,
             autogrid: None,
             display: crate::ui::DisplayFormat::default(),
+            options: PanelOptions::Graph(GraphOptions::default()),
         }
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -24,6 +24,6 @@ pub(crate) use data::{default_queries, parse_duration};
 pub(crate) use event_loop::run_app;
 #[allow(unused_imports)]
 pub(crate) use state::{
-    AppMode, AppState, GridUnit, PanelState, PanelType, QueryMode, SeriesView, ThresholdMode,
-    ThresholdStep, Thresholds, YAxisMode,
+    AppMode, AppState, GraphOptions, GridUnit, PanelOptions, PanelState, PanelType, QueryMode,
+    SeriesView, ThresholdMode, ThresholdStep, Thresholds, YAxisMode,
 };

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -24,6 +24,7 @@ pub(crate) use data::{default_queries, parse_duration};
 pub(crate) use event_loop::run_app;
 #[allow(unused_imports)]
 pub(crate) use state::{
-    AppMode, AppState, GraphOptions, GridUnit, PanelOptions, PanelState, PanelType, QueryMode,
-    SeriesView, ThresholdMode, ThresholdStep, Thresholds, YAxisMode,
+    AppMode, AppState, GraphAxisPlacement, GraphDrawStyle, GraphOptions, GraphPointMode,
+    GraphStackingMode, GridUnit, PanelOptions, PanelState, PanelType, QueryMode, SeriesView,
+    ThresholdMode, ThresholdStep, Thresholds, YAxisMode,
 };

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -62,6 +62,8 @@ pub(crate) struct PanelState {
     pub(crate) autogrid: Option<bool>,
     /// Display formatting imported from Grafana field configuration.
     pub(crate) display: DisplayFormat,
+    /// Renderer-specific presentation options.
+    pub(crate) options: PanelOptions,
 }
 
 /// Visualization types supported by Grafatui.
@@ -74,6 +76,70 @@ pub(crate) enum PanelType {
     Stat,
     Heatmap,
     Unknown,
+}
+
+/// Renderer-specific options carried by a generic panel.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum PanelOptions {
+    None,
+    Graph(GraphOptions),
+}
+
+impl Default for PanelOptions {
+    fn default() -> Self {
+        Self::None
+    }
+}
+
+/// Graph/timeseries rendering options imported from Grafana.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct GraphOptions {
+    pub(crate) draw_style: GraphDrawStyle,
+    pub(crate) show_points: GraphPointMode,
+    pub(crate) fill_opacity: Option<u8>,
+    pub(crate) axis_placement: GraphAxisPlacement,
+    pub(crate) line_interpolation: Option<String>,
+    pub(crate) stacking: GraphStackingMode,
+}
+
+impl Default for GraphOptions {
+    fn default() -> Self {
+        Self {
+            draw_style: GraphDrawStyle::Line,
+            show_points: GraphPointMode::Auto,
+            fill_opacity: None,
+            axis_placement: GraphAxisPlacement::Visible,
+            line_interpolation: None,
+            stacking: GraphStackingMode::Off,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum GraphDrawStyle {
+    Line,
+    Points,
+    Bars,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum GraphPointMode {
+    Auto,
+    Always,
+    Never,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum GraphAxisPlacement {
+    Visible,
+    Hidden,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum GraphStackingMode {
+    Off,
+    Normal,
+    Percent,
 }
 
 /// Prometheus endpoint mode for a target query.
@@ -134,6 +200,13 @@ pub(crate) struct Thresholds {
 }
 
 impl PanelState {
+    pub(crate) fn graph_options(&self) -> GraphOptions {
+        match &self.options {
+            PanelOptions::Graph(options) => options.clone(),
+            PanelOptions::None => GraphOptions::default(),
+        }
+    }
+
     pub(crate) fn query_mode(&self, index: usize) -> QueryMode {
         self.query_modes
             .get(index)
@@ -658,9 +731,47 @@ mod tests {
             max: None,
             autogrid: None,
             display: crate::ui::DisplayFormat::default(),
+            options: PanelOptions::None,
         };
 
         assert_eq!(panel.query_mode(0), QueryMode::Instant);
         assert_eq!(panel.query_mode(1), QueryMode::Range);
+    }
+
+    #[test]
+    fn test_default_graph_options_match_current_line_rendering() {
+        let options = GraphOptions::default();
+
+        assert_eq!(options.draw_style, GraphDrawStyle::Line);
+        assert_eq!(options.show_points, GraphPointMode::Auto);
+        assert_eq!(options.fill_opacity, None);
+        assert_eq!(options.axis_placement, GraphAxisPlacement::Visible);
+        assert_eq!(options.line_interpolation, None);
+        assert_eq!(options.stacking, GraphStackingMode::Off);
+    }
+
+    #[test]
+    fn test_panel_graph_options_fall_back_to_defaults() {
+        let panel = PanelState {
+            title: "not graph".to_string(),
+            exprs: vec![],
+            legends: vec![],
+            query_modes: vec![],
+            series: vec![],
+            last_error: None,
+            last_url: None,
+            last_samples: 0,
+            grid: None,
+            y_axis_mode: YAxisMode::Auto,
+            panel_type: PanelType::Stat,
+            thresholds: None,
+            min: None,
+            max: None,
+            autogrid: None,
+            display: crate::ui::DisplayFormat::default(),
+            options: PanelOptions::None,
+        };
+
+        assert_eq!(panel.graph_options(), GraphOptions::default());
     }
 }

--- a/src/export.rs
+++ b/src/export.rs
@@ -1100,6 +1100,10 @@ fn graph_area_baseline(y_bounds: [f64; 2]) -> f64 {
     }
 }
 
+fn graph_point_in_range(x: f64, y: f64, x_bounds: [f64; 2]) -> bool {
+    x.is_finite() && y.is_finite() && x >= x_bounds[0] && x <= x_bounds[1]
+}
+
 fn render_graph_points(
     series: &SeriesView,
     rect: PlotRect,
@@ -1109,14 +1113,14 @@ fn render_graph_points(
     out: &mut String,
 ) {
     for (x, y) in &series.points {
-        if *x < x_bounds[0] || *x > x_bounds[1] {
+        if !graph_point_in_range(*x, *y, x_bounds) {
             continue;
         }
         let px = map_x(*x, x_bounds, rect);
         let py = map_y(*y, y_bounds, rect);
         write!(
             out,
-            r#"<circle cx="{:.2}" cy="{:.2}" r="2.2" fill="{}" />"#,
+            r#"<circle data-role="graph-point" cx="{:.2}" cy="{:.2}" r="2.2" fill="{}" />"#,
             px, py, color
         )
         .unwrap();
@@ -1134,7 +1138,7 @@ fn render_graph_bars(
     let visible_points: Vec<_> = series
         .points
         .iter()
-        .filter(|(x, _)| *x >= x_bounds[0] && *x <= x_bounds[1])
+        .filter(|(x, y)| graph_point_in_range(*x, *y, x_bounds))
         .collect();
     if visible_points.is_empty() {
         return;
@@ -1149,7 +1153,7 @@ fn render_graph_bars(
         let height = (baseline_y - map_y(*y, y_bounds, rect)).abs().max(1.0);
         write!(
             out,
-            r#"<rect x="{:.2}" y="{:.2}" width="{:.2}" height="{:.2}" fill="{}" />"#,
+            r#"<rect data-role="graph-bar" x="{:.2}" y="{:.2}" width="{:.2}" height="{:.2}" fill="{}" />"#,
             px, py, bar_width, height, color
         )
         .unwrap();
@@ -1168,7 +1172,7 @@ fn render_graph_area(
     let points: Vec<_> = series
         .points
         .iter()
-        .filter(|(x, _)| *x >= x_bounds[0] && *x <= x_bounds[1])
+        .filter(|(x, y)| graph_point_in_range(*x, *y, x_bounds))
         .collect();
     if points.len() < 2 {
         return;
@@ -1191,7 +1195,7 @@ fn render_graph_area(
 
     write!(
         out,
-        r#"<path d="{}" fill="{}" fill-opacity="{:.2}" stroke="none" />"#,
+        r#"<path data-role="graph-area" d="{}" fill="{}" fill-opacity="{:.2}" stroke="none" />"#,
         path, color, opacity
     )
     .unwrap();
@@ -1625,7 +1629,7 @@ mod tests {
             stacking: GraphStackingMode::Off,
         });
         let points_svg = render_svg(&points_app, Rect::new(0, 0, 120, 50));
-        assert!(points_svg.contains("<circle "));
+        assert!(points_svg.contains(r#"data-role="graph-point""#));
 
         let mut area_app = test_app_with_panel_type(PanelType::Graph);
         area_app.panels[0].options = PanelOptions::Graph(GraphOptions {
@@ -1637,6 +1641,7 @@ mod tests {
             stacking: GraphStackingMode::Off,
         });
         let area_svg = render_svg(&area_app, Rect::new(0, 0, 120, 50));
+        assert!(area_svg.contains(r#"data-role="graph-area""#));
         assert!(area_svg.contains("fill-opacity=\"0.30\""));
 
         let mut bars_app = test_app_with_panel_type(PanelType::Graph);
@@ -1649,7 +1654,67 @@ mod tests {
             stacking: GraphStackingMode::Off,
         });
         let bars_svg = render_svg(&bars_app, Rect::new(0, 0, 120, 50));
-        assert!(bars_svg.contains("<rect "));
+        assert!(bars_svg.contains(r#"data-role="graph-bar""#));
+    }
+
+    #[test]
+    fn test_graph_export_skips_non_finite_style_points() {
+        let mut points_app = test_app_with_panel_type(PanelType::Graph);
+        points_app.panels[0].options = PanelOptions::Graph(GraphOptions {
+            draw_style: GraphDrawStyle::Points,
+            show_points: GraphPointMode::Auto,
+            fill_opacity: None,
+            axis_placement: GraphAxisPlacement::Visible,
+            line_interpolation: None,
+            stacking: GraphStackingMode::Off,
+        });
+        let points_start = points_app.panels[0].series[0].points[0].0;
+        points_app.panels[0].series[0].points = vec![
+            (points_start, 0.0),
+            (f64::NAN, 50.0),
+            (points_start + 50.0, f64::NAN),
+            (points_start + 100.0, 100.0),
+        ];
+        let points_svg = render_svg(&points_app, Rect::new(0, 0, 120, 50));
+        assert!(!points_svg.contains("NaN"));
+
+        let mut area_app = test_app_with_panel_type(PanelType::Graph);
+        area_app.panels[0].options = PanelOptions::Graph(GraphOptions {
+            draw_style: GraphDrawStyle::Line,
+            show_points: GraphPointMode::Never,
+            fill_opacity: Some(30),
+            axis_placement: GraphAxisPlacement::Visible,
+            line_interpolation: None,
+            stacking: GraphStackingMode::Off,
+        });
+        let area_start = area_app.panels[0].series[0].points[0].0;
+        area_app.panels[0].series[0].points = vec![
+            (area_start, 0.0),
+            (f64::NAN, 50.0),
+            (area_start + 50.0, f64::NAN),
+            (area_start + 100.0, 100.0),
+        ];
+        let area_svg = render_svg(&area_app, Rect::new(0, 0, 120, 50));
+        assert!(!area_svg.contains("NaN"));
+
+        let mut bars_app = test_app_with_panel_type(PanelType::Graph);
+        bars_app.panels[0].options = PanelOptions::Graph(GraphOptions {
+            draw_style: GraphDrawStyle::Bars,
+            show_points: GraphPointMode::Auto,
+            fill_opacity: None,
+            axis_placement: GraphAxisPlacement::Visible,
+            line_interpolation: None,
+            stacking: GraphStackingMode::Off,
+        });
+        let bars_start = bars_app.panels[0].series[0].points[0].0;
+        bars_app.panels[0].series[0].points = vec![
+            (bars_start, 0.0),
+            (f64::NAN, 50.0),
+            (bars_start + 50.0, f64::NAN),
+            (bars_start + 100.0, 100.0),
+        ];
+        let bars_svg = render_svg(&bars_app, Rect::new(0, 0, 120, 50));
+        assert!(!bars_svg.contains("NaN"));
     }
 
     #[test]

--- a/src/export.rs
+++ b/src/export.rs
@@ -1343,7 +1343,7 @@ fn display_paths(paths: &[PathBuf]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::app::{PanelState, SeriesView, YAxisMode};
+    use crate::app::{GraphOptions, PanelOptions, PanelState, SeriesView, YAxisMode};
 
     fn test_panel(start: f64) -> PanelState {
         PanelState {
@@ -1368,6 +1368,7 @@ mod tests {
             max: None,
             autogrid: None,
             display: crate::ui::DisplayFormat::default(),
+            options: PanelOptions::Graph(GraphOptions::default()),
         }
     }
 

--- a/src/export.rs
+++ b/src/export.rs
@@ -430,6 +430,7 @@ fn render_graph_panel(app: &AppState, panel: &PanelState, rect: PlotRect, out: &
     let text = color_hex(app.theme.text, "#e6e6e6");
     let axis = color_hex(Color::Gray, "#777777");
     let grid = "#6d6d6d";
+    let graph_options = panel.graph_options();
 
     write!(
         out,
@@ -582,12 +583,30 @@ fn render_graph_panel(app: &AppState, panel: &PanelState, rect: PlotRect, out: &
         }
         let color = series_color(panel, &app.theme, index);
         let color = color_hex(color, "#00ff88");
-        if let Some(path) = series_path(series, [x_min, x_max], y_bounds, plot) {
-            write!(
-                out,
-                r#"<path d="{path}" fill="none" stroke="{color}" stroke-width="1.6" stroke-linejoin="round" stroke-linecap="round"/>"#
-            )
-            .unwrap();
+        let x_bounds = [x_min, x_max];
+
+        match graph_options.draw_style {
+            crate::app::GraphDrawStyle::Points => {
+                render_graph_points(series, plot, y_bounds, x_bounds, &color, out);
+            }
+            crate::app::GraphDrawStyle::Bars => {
+                render_graph_bars(series, plot, y_bounds, x_bounds, &color, out);
+            }
+            crate::app::GraphDrawStyle::Line => {
+                if let Some(opacity) = graph_area_opacity(&graph_options) {
+                    render_graph_area(series, plot, y_bounds, x_bounds, &color, opacity, out);
+                }
+                if let Some(path) = series_path(series, x_bounds, y_bounds, plot) {
+                    write!(
+                        out,
+                        r#"<path d="{path}" fill="none" stroke="{color}" stroke-width="1.6" stroke-linejoin="round" stroke-linecap="round"/>"#
+                    )
+                    .unwrap();
+                }
+                if graph_options.show_points == crate::app::GraphPointMode::Always {
+                    render_graph_points(series, plot, y_bounds, x_bounds, &color, out);
+                }
+            }
         }
     }
 
@@ -1066,6 +1085,118 @@ fn cursor_values(panel: &PanelState, app: &AppState) -> std::collections::HashMa
     values
 }
 
+fn graph_area_opacity(options: &crate::app::GraphOptions) -> Option<f64> {
+    options
+        .fill_opacity
+        .filter(|value| *value > 0)
+        .map(|value| f64::from(value.min(100)) / 100.0)
+}
+
+fn graph_area_baseline(y_bounds: [f64; 2]) -> f64 {
+    if y_bounds[0] <= 0.0 && y_bounds[1] >= 0.0 {
+        0.0
+    } else {
+        y_bounds[0]
+    }
+}
+
+fn render_graph_points(
+    series: &SeriesView,
+    rect: PlotRect,
+    y_bounds: [f64; 2],
+    x_bounds: [f64; 2],
+    color: &str,
+    out: &mut String,
+) {
+    for (x, y) in &series.points {
+        if *x < x_bounds[0] || *x > x_bounds[1] {
+            continue;
+        }
+        let px = map_x(*x, x_bounds, rect);
+        let py = map_y(*y, y_bounds, rect);
+        write!(
+            out,
+            r#"<circle cx="{:.2}" cy="{:.2}" r="2.2" fill="{}" />"#,
+            px, py, color
+        )
+        .unwrap();
+    }
+}
+
+fn render_graph_bars(
+    series: &SeriesView,
+    rect: PlotRect,
+    y_bounds: [f64; 2],
+    x_bounds: [f64; 2],
+    color: &str,
+    out: &mut String,
+) {
+    let visible_points: Vec<_> = series
+        .points
+        .iter()
+        .filter(|(x, _)| *x >= x_bounds[0] && *x <= x_bounds[1])
+        .collect();
+    if visible_points.is_empty() {
+        return;
+    }
+    let bar_width = (rect.width / visible_points.len() as f64).max(1.0) * 0.7;
+    let baseline = graph_area_baseline(y_bounds);
+    let baseline_y = map_y(baseline, y_bounds, rect);
+
+    for (x, y) in visible_points {
+        let px = map_x(*x, x_bounds, rect) - bar_width / 2.0;
+        let py = map_y(*y, y_bounds, rect).min(baseline_y);
+        let height = (baseline_y - map_y(*y, y_bounds, rect)).abs().max(1.0);
+        write!(
+            out,
+            r#"<rect x="{:.2}" y="{:.2}" width="{:.2}" height="{:.2}" fill="{}" />"#,
+            px, py, bar_width, height, color
+        )
+        .unwrap();
+    }
+}
+
+fn render_graph_area(
+    series: &SeriesView,
+    rect: PlotRect,
+    y_bounds: [f64; 2],
+    x_bounds: [f64; 2],
+    color: &str,
+    opacity: f64,
+    out: &mut String,
+) {
+    let points: Vec<_> = series
+        .points
+        .iter()
+        .filter(|(x, _)| *x >= x_bounds[0] && *x <= x_bounds[1])
+        .collect();
+    if points.len() < 2 {
+        return;
+    }
+
+    let baseline = graph_area_baseline(y_bounds);
+    let baseline_y = map_y(baseline, y_bounds, rect);
+    let first_x = map_x(points[0].0, x_bounds, rect);
+    let last_x = map_x(points[points.len() - 1].0, x_bounds, rect);
+
+    let mut path = format!("M {:.2} {:.2}", first_x, baseline_y);
+    for (x, y) in points {
+        path.push_str(&format!(
+            " L {:.2} {:.2}",
+            map_x(*x, x_bounds, rect),
+            map_y(*y, y_bounds, rect)
+        ));
+    }
+    path.push_str(&format!(" L {:.2} {:.2} Z", last_x, baseline_y));
+
+    write!(
+        out,
+        r#"<path d="{}" fill="{}" fill-opacity="{:.2}" stroke="none" />"#,
+        path, color, opacity
+    )
+    .unwrap();
+}
+
 fn series_path(
     series: &SeriesView,
     x_bounds: [f64; 2],
@@ -1343,7 +1474,10 @@ fn display_paths(paths: &[PathBuf]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::app::{GraphOptions, PanelOptions, PanelState, SeriesView, YAxisMode};
+    use crate::app::{
+        GraphAxisPlacement, GraphDrawStyle, GraphOptions, GraphPointMode, GraphStackingMode,
+        PanelOptions, PanelState, SeriesView, YAxisMode,
+    };
 
     fn test_panel(start: f64) -> PanelState {
         PanelState {
@@ -1477,6 +1611,45 @@ mod tests {
 
         assert!(svg.contains(&ui::format_time(1_699_999_900.0)));
         assert!(svg.contains(&ui::format_time(1_700_000_000.0)));
+    }
+
+    #[test]
+    fn test_graph_export_renders_points_area_and_bars() {
+        let mut points_app = test_app_with_panel_type(PanelType::Graph);
+        points_app.panels[0].options = PanelOptions::Graph(GraphOptions {
+            draw_style: GraphDrawStyle::Points,
+            show_points: GraphPointMode::Auto,
+            fill_opacity: None,
+            axis_placement: GraphAxisPlacement::Visible,
+            line_interpolation: None,
+            stacking: GraphStackingMode::Off,
+        });
+        let points_svg = render_svg(&points_app, Rect::new(0, 0, 120, 50));
+        assert!(points_svg.contains("<circle "));
+
+        let mut area_app = test_app_with_panel_type(PanelType::Graph);
+        area_app.panels[0].options = PanelOptions::Graph(GraphOptions {
+            draw_style: GraphDrawStyle::Line,
+            show_points: GraphPointMode::Never,
+            fill_opacity: Some(30),
+            axis_placement: GraphAxisPlacement::Visible,
+            line_interpolation: None,
+            stacking: GraphStackingMode::Off,
+        });
+        let area_svg = render_svg(&area_app, Rect::new(0, 0, 120, 50));
+        assert!(area_svg.contains("fill-opacity=\"0.30\""));
+
+        let mut bars_app = test_app_with_panel_type(PanelType::Graph);
+        bars_app.panels[0].options = PanelOptions::Graph(GraphOptions {
+            draw_style: GraphDrawStyle::Bars,
+            show_points: GraphPointMode::Auto,
+            fill_opacity: None,
+            axis_placement: GraphAxisPlacement::Visible,
+            line_interpolation: None,
+            stacking: GraphStackingMode::Off,
+        });
+        let bars_svg = render_svg(&bars_app, Rect::new(0, 0, 120, 50));
+        assert!(bars_svg.contains("<rect "));
     }
 
     #[test]

--- a/src/grafana.rs
+++ b/src/grafana.rs
@@ -60,6 +60,7 @@ pub(crate) struct QueryPanel {
     pub(crate) max: Option<f64>,
     pub(crate) autogrid: Option<bool>,
     pub(crate) display: crate::ui::DisplayFormat,
+    pub(crate) options: crate::app::PanelOptions,
 }
 
 /// Grid position extracted from Grafana.
@@ -412,6 +413,12 @@ fn collect_panels(out: &mut DashboardImport, panels: Vec<RawPanel>) -> Result<()
                     w: g.w,
                     h: g.h,
                 });
+                let options = match panel_type {
+                    crate::app::PanelType::Graph => {
+                        crate::app::PanelOptions::Graph(crate::app::GraphOptions::default())
+                    }
+                    _ => crate::app::PanelOptions::None,
+                };
                 out.queries.push(QueryPanel {
                     title: p.title.unwrap_or_default(),
                     exprs,
@@ -424,6 +431,7 @@ fn collect_panels(out: &mut DashboardImport, panels: Vec<RawPanel>) -> Result<()
                     max,
                     autogrid,
                     display,
+                    options,
                 });
             }
         } else if !kind.is_empty() && kind != "row" {

--- a/src/grafana.rs
+++ b/src/grafana.rs
@@ -144,6 +144,17 @@ struct RawFieldConfigDefaults {
 
 #[derive(Debug, Deserialize)]
 struct RawCustom {
+    #[serde(rename = "drawStyle")]
+    draw_style: Option<String>,
+    #[serde(rename = "showPoints")]
+    show_points: Option<String>,
+    #[serde(rename = "fillOpacity")]
+    fill_opacity: Option<u16>,
+    #[serde(rename = "axisPlacement")]
+    axis_placement: Option<String>,
+    #[serde(rename = "lineInterpolation")]
+    line_interpolation: Option<String>,
+    stacking: Option<RawStacking>,
     #[serde(rename = "axisGridShow")]
     axis_grid_show: Option<bool>,
     #[serde(rename = "thresholdsStyle")]
@@ -152,6 +163,11 @@ struct RawCustom {
 
 #[derive(Debug, Deserialize)]
 struct RawThresholdsStyle {
+    mode: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawStacking {
     mode: Option<String>,
 }
 
@@ -314,6 +330,61 @@ fn default_query_mode_for_panel(panel_type: crate::app::PanelType) -> crate::app
     }
 }
 
+fn graph_options_from_custom(custom: Option<&RawCustom>) -> crate::app::GraphOptions {
+    let Some(custom) = custom else {
+        return crate::app::GraphOptions::default();
+    };
+
+    crate::app::GraphOptions {
+        draw_style: parse_graph_draw_style(custom.draw_style.as_deref()),
+        show_points: parse_graph_point_mode(custom.show_points.as_deref()),
+        fill_opacity: custom.fill_opacity.map(|value| value.min(100) as u8),
+        axis_placement: parse_graph_axis_placement(custom.axis_placement.as_deref()),
+        line_interpolation: custom
+            .line_interpolation
+            .as_ref()
+            .filter(|value| !value.trim().is_empty())
+            .cloned(),
+        stacking: parse_graph_stacking_mode(
+            custom
+                .stacking
+                .as_ref()
+                .and_then(|stacking| stacking.mode.as_deref()),
+        ),
+    }
+}
+
+fn parse_graph_draw_style(value: Option<&str>) -> crate::app::GraphDrawStyle {
+    match value {
+        Some("points") => crate::app::GraphDrawStyle::Points,
+        Some("bars") => crate::app::GraphDrawStyle::Bars,
+        _ => crate::app::GraphDrawStyle::Line,
+    }
+}
+
+fn parse_graph_point_mode(value: Option<&str>) -> crate::app::GraphPointMode {
+    match value {
+        Some("always") => crate::app::GraphPointMode::Always,
+        Some("never") => crate::app::GraphPointMode::Never,
+        _ => crate::app::GraphPointMode::Auto,
+    }
+}
+
+fn parse_graph_axis_placement(value: Option<&str>) -> crate::app::GraphAxisPlacement {
+    match value {
+        Some("hidden") => crate::app::GraphAxisPlacement::Hidden,
+        _ => crate::app::GraphAxisPlacement::Visible,
+    }
+}
+
+fn parse_graph_stacking_mode(value: Option<&str>) -> crate::app::GraphStackingMode {
+    match value {
+        Some("normal") => crate::app::GraphStackingMode::Normal,
+        Some("percent") => crate::app::GraphStackingMode::Percent,
+        _ => crate::app::GraphStackingMode::Off,
+    }
+}
+
 fn collect_panels(out: &mut DashboardImport, panels: Vec<RawPanel>) -> Result<()> {
     for p in panels.into_iter() {
         if let Some(children) = p.panels {
@@ -349,9 +420,11 @@ fn collect_panels(out: &mut DashboardImport, panels: Vec<RawPanel>) -> Result<()
             let mut max = None;
             let mut autogrid = None;
             let mut display = crate::ui::DisplayFormat::default();
+            let mut graph_options = crate::app::GraphOptions::default();
 
             if let Some(fc) = p.field_config {
                 if let Some(defaults) = fc.defaults {
+                    graph_options = graph_options_from_custom(defaults.custom.as_ref());
                     display = crate::ui::DisplayFormat {
                         unit: defaults.unit,
                         decimals: defaults.decimals,
@@ -392,8 +465,9 @@ fn collect_panels(out: &mut DashboardImport, panels: Vec<RawPanel>) -> Result<()
                         if !steps.is_empty() {
                             let style = defaults
                                 .custom
-                                .and_then(|c| c.thresholds_style)
-                                .and_then(|t| t.mode)
+                                .as_ref()
+                                .and_then(|c| c.thresholds_style.as_ref())
+                                .and_then(|t| t.mode.clone())
                                 .unwrap_or_else(|| "line".to_string());
 
                             thresholds = Some(crate::app::Thresholds {
@@ -414,9 +488,7 @@ fn collect_panels(out: &mut DashboardImport, panels: Vec<RawPanel>) -> Result<()
                     h: g.h,
                 });
                 let options = match panel_type {
-                    crate::app::PanelType::Graph => {
-                        crate::app::PanelOptions::Graph(crate::app::GraphOptions::default())
-                    }
+                    crate::app::PanelType::Graph => crate::app::PanelOptions::Graph(graph_options),
                     _ => crate::app::PanelOptions::None,
                 };
                 out.queries.push(QueryPanel {
@@ -715,5 +787,114 @@ mod tests {
         std::fs::remove_file(path).unwrap();
 
         assert_eq!(dashboard.refresh_rate_ms, Some(5000));
+    }
+
+    #[test]
+    fn test_import_timeseries_graph_options() {
+        let json = r#"{
+            "title": "Graph options",
+            "panels": [{
+                "type": "timeseries",
+                "title": "Area points",
+                "targets": [{ "expr": "up" }],
+                "fieldConfig": {
+                    "defaults": {
+                        "custom": {
+                            "drawStyle": "line",
+                            "showPoints": "always",
+                            "fillOpacity": 20,
+                            "axisPlacement": "hidden",
+                            "lineInterpolation": "smooth",
+                            "stacking": { "mode": "normal" }
+                        }
+                    }
+                }
+            }]
+        }"#;
+
+        let raw: RawDashboard = serde_json::from_str(json).unwrap();
+        let mut out = DashboardImport {
+            title: raw.title.unwrap_or_default(),
+            refresh_rate_ms: None,
+            queries: vec![],
+            vars: HashMap::new(),
+            query_vars: vec![],
+            skipped_panels: 0,
+        };
+
+        collect_panels(&mut out, raw.panels.unwrap()).unwrap();
+
+        let options = match &out.queries[0].options {
+            crate::app::PanelOptions::Graph(options) => options,
+            other => panic!("expected graph options, got {other:?}"),
+        };
+        assert_eq!(options.draw_style, crate::app::GraphDrawStyle::Line);
+        assert_eq!(options.show_points, crate::app::GraphPointMode::Always);
+        assert_eq!(options.fill_opacity, Some(20));
+        assert_eq!(
+            options.axis_placement,
+            crate::app::GraphAxisPlacement::Hidden
+        );
+        assert_eq!(options.line_interpolation.as_deref(), Some("smooth"));
+        assert_eq!(options.stacking, crate::app::GraphStackingMode::Normal);
+    }
+
+    #[test]
+    fn test_import_graph_options_fallbacks_and_non_graph_none() {
+        let json = r#"{
+            "title": "Fallbacks",
+            "panels": [
+                {
+                    "type": "timeseries",
+                    "title": "Unknown values",
+                    "targets": [{ "expr": "up" }],
+                    "fieldConfig": {
+                        "defaults": {
+                            "custom": {
+                                "drawStyle": "candles",
+                                "showPoints": "sometimes",
+                                "fillOpacity": 999,
+                                "axisPlacement": "right",
+                                "stacking": { "mode": "percent" }
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "stat",
+                    "title": "Stat",
+                    "targets": [{ "expr": "up" }]
+                }
+            ]
+        }"#;
+
+        let raw: RawDashboard = serde_json::from_str(json).unwrap();
+        let mut out = DashboardImport {
+            title: raw.title.unwrap_or_default(),
+            refresh_rate_ms: None,
+            queries: vec![],
+            vars: HashMap::new(),
+            query_vars: vec![],
+            skipped_panels: 0,
+        };
+
+        collect_panels(&mut out, raw.panels.unwrap()).unwrap();
+
+        let graph_options = match &out.queries[0].options {
+            crate::app::PanelOptions::Graph(options) => options,
+            other => panic!("expected graph options, got {other:?}"),
+        };
+        assert_eq!(graph_options.draw_style, crate::app::GraphDrawStyle::Line);
+        assert_eq!(graph_options.show_points, crate::app::GraphPointMode::Auto);
+        assert_eq!(graph_options.fill_opacity, Some(100));
+        assert_eq!(
+            graph_options.axis_placement,
+            crate::app::GraphAxisPlacement::Visible
+        );
+        assert_eq!(
+            graph_options.stacking,
+            crate::app::GraphStackingMode::Percent
+        );
+        assert_eq!(out.queries[1].options, crate::app::PanelOptions::None);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -154,6 +154,7 @@ async fn main() -> Result<()> {
                 max: q.max,
                 autogrid: q.autogrid,
                 display: q.display,
+                options: q.options,
             })
             .collect();
         (format!("{} (imported)", d.title), ps, d.skipped_panels)

--- a/src/ui/panels/graph/bounds.rs
+++ b/src/ui/panels/graph/bounds.rs
@@ -119,7 +119,9 @@ fn fallback_bounds(explicit_min: Option<f64>, explicit_max: Option<f64>) -> [f64
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::app::{SeriesView, ThresholdMode, ThresholdStep, Thresholds};
+    use crate::app::{
+        GraphOptions, PanelOptions, SeriesView, ThresholdMode, ThresholdStep, Thresholds,
+    };
     use ratatui::style::Color;
 
     fn create_test_panel() -> PanelState {
@@ -140,6 +142,7 @@ mod tests {
             max: None,
             autogrid: None,
             display: crate::ui::DisplayFormat::default(),
+            options: PanelOptions::Graph(GraphOptions::default()),
         }
     }
 

--- a/src/ui/panels/graph/mod.rs
+++ b/src/ui/panels/graph/mod.rs
@@ -470,16 +470,9 @@ pub(super) fn render_graph_panel(
         let mut autogrid_buf = ratatui::buffer::Buffer::empty(chart_area);
         autogrid_chart.render(chart_area, &mut autogrid_buf);
 
-        if let Some(strong_data_buf) = strong_data_buf.as_ref() {
-            merge_overlay_buffer_preserving_data(
-                frame,
-                &autogrid_buf,
-                strong_data_buf,
-                plot_bounds,
-            );
-        } else {
-            merge_overlay_buffer(frame, &autogrid_buf, plot_bounds);
-        }
+        // Autogrid is a background layer: it may fill empty plot cells, but it
+        // should not cut through area fills or other rendered data.
+        merge_overlay_buffer(frame, &autogrid_buf, plot_bounds);
         render_autogrid_time_labels(
             frame,
             plot_bounds,
@@ -520,7 +513,12 @@ mod tests {
     use super::*;
     use crate::app::{
         GraphAxisPlacement, GraphDrawStyle, GraphOptions, GraphPointMode, GraphStackingMode,
+        PanelOptions, PanelType, QueryMode, SeriesView, YAxisMode,
     };
+    use crate::export::ExportOptions;
+    use crate::theme::Theme;
+    use ratatui::{Terminal, backend::TestBackend};
+    use std::time::Duration;
 
     #[test]
     fn test_graph_type_for_draw_style() {
@@ -645,5 +643,103 @@ mod tests {
             ),
             13
         );
+    }
+
+    fn area_fill_panel() -> PanelState {
+        PanelState {
+            title: "area".to_string(),
+            exprs: vec![],
+            legends: vec![],
+            query_modes: vec![QueryMode::Range],
+            series: vec![SeriesView {
+                name: "filled".to_string(),
+                value: Some(8.0),
+                points: vec![(0.0, 8.0), (50.0, 8.0), (100.0, 8.0)],
+                visible: true,
+            }],
+            last_error: None,
+            last_url: None,
+            last_samples: 3,
+            grid: None,
+            y_axis_mode: YAxisMode::Auto,
+            panel_type: PanelType::Graph,
+            thresholds: None,
+            min: Some(0.0),
+            max: Some(10.0),
+            autogrid: Some(true),
+            display: crate::ui::DisplayFormat::default(),
+            options: PanelOptions::Graph(GraphOptions {
+                draw_style: GraphDrawStyle::Line,
+                show_points: GraphPointMode::Never,
+                fill_opacity: Some(30),
+                axis_placement: GraphAxisPlacement::Visible,
+                line_interpolation: None,
+                stacking: GraphStackingMode::Off,
+            }),
+        }
+    }
+
+    fn area_fill_app(panel: PanelState) -> AppState {
+        let mut app = AppState::new(
+            crate::prom::PromClient::new("http://localhost:9090".to_string()),
+            Duration::from_secs(100),
+            Duration::from_secs(5),
+            Duration::from_secs(1),
+            "test".to_string(),
+            vec![panel],
+            0,
+            Theme::default(),
+            "dashed-line".to_string(),
+            ExportOptions::default(),
+        );
+        app.view_end_ts = 100;
+        app.autogrid_color = Color::Red;
+        app
+    }
+
+    #[test]
+    fn test_area_fill_keeps_precedence_over_autogrid() {
+        let app = area_fill_app(area_fill_panel());
+        let panel = &app.panels[0];
+        let mut terminal = Terminal::new(TestBackend::new(80, 20)).unwrap();
+
+        terminal
+            .draw(|frame| {
+                render_graph_panel(frame, Rect::new(0, 0, 80, 20), panel, &app, None);
+            })
+            .unwrap();
+
+        let y_bounds = calculate_y_bounds(panel);
+        let chart_area = Rect::new(0, 0, 80, 18);
+        let x_labels = vec![Span::raw("00:00:00"), Span::raw("00:01:40")];
+        let chart_y_labels = vec![Span::raw("0"), Span::raw("10")];
+        let plot = PlotBounds {
+            left: chart_plot_left(
+                chart_area,
+                chart_y_label_width(&chart_y_labels),
+                &x_labels,
+                true,
+            ),
+            right: chart_area.right(),
+            top: chart_area.top(),
+            bottom: chart_area.bottom().saturating_sub(2),
+        };
+        let plot_height = plot.bottom.saturating_sub(plot.top) as f64;
+        let grid_ratio = (5.0 - y_bounds[0]) / (y_bounds[1] - y_bounds[0]);
+        let grid_y = plot
+            .bottom
+            .saturating_sub((grid_ratio * plot_height).round() as u16);
+
+        let grid_colored_cells_inside_fill = (plot.left..plot.right)
+            .filter(|x| {
+                terminal
+                    .backend()
+                    .buffer()
+                    .cell((*x, grid_y))
+                    .is_some_and(|cell| cell.style().fg == Some(Color::Red))
+            })
+            .count();
+
+        assert_eq!(grid_colored_cells_inside_fill, 0);
     }
 }

--- a/src/ui/panels/graph/mod.rs
+++ b/src/ui/panels/graph/mod.rs
@@ -25,7 +25,7 @@ use labels::{
     PlotBounds, YLabelArea, YLabelContext, render_autogrid_time_labels,
     render_intermediate_y_labels, y_label_width,
 };
-use overlay::merge_overlay_buffer;
+use overlay::{merge_overlay_buffer, merge_overlay_buffer_preserving_data};
 use thresholds::{prepare_thresholds, render_raw_threshold_lines, threshold_marker};
 
 use crate::app::{AppState, PanelState};
@@ -61,6 +61,25 @@ fn area_fill_baseline(y_bounds: [f64; 2]) -> f64 {
 
 fn is_y_axis_hidden(options: &crate::app::GraphOptions) -> bool {
     options.axis_placement == crate::app::GraphAxisPlacement::Hidden
+}
+
+fn chart_plot_left(
+    chart_area: Rect,
+    y_label_width: u16,
+    x_labels: &[Span<'_>],
+    has_y_axis_labels: bool,
+) -> u16 {
+    let gutter = if has_y_axis_labels {
+        y_label_width + 1
+    } else {
+        x_labels
+            .first()
+            .map(|label| label.width() as u16)
+            .unwrap_or_default()
+            .min(chart_area.width / 3)
+    };
+
+    chart_area.left() + gutter
 }
 
 pub(super) fn render_graph_panel(
@@ -128,6 +147,7 @@ pub(super) fn render_graph_panel(
 
     // Prepare datasets (without names for the chart itself to avoid built-in legend)
     let mut chart_datasets = Vec::new();
+    let mut strong_data_datasets = Vec::new();
     let mut legend_items = Vec::new();
 
     // Declare helper datasets to extend their lifetimes
@@ -183,9 +203,19 @@ pub(super) fn render_graph_panel(
             .style(Style::default().fg(color))
             .data(data);
 
-        if graph_options.fill_opacity.unwrap_or(0) > 0
-            && graph_options.draw_style == crate::app::GraphDrawStyle::Line
-        {
+        let is_area_filled = graph_options.fill_opacity.unwrap_or(0) > 0
+            && graph_options.draw_style == crate::app::GraphDrawStyle::Line;
+
+        if is_area_filled {
+            strong_data_datasets.push(
+                Dataset::default()
+                    .name("")
+                    .marker(ratatui::symbols::Marker::Braille)
+                    .graph_type(GraphType::Line)
+                    .style(Style::default().fg(color))
+                    .data(data),
+            );
+
             dataset = dataset
                 .graph_type(GraphType::Area)
                 .fill_to_y(area_fill_baseline(y_bounds));
@@ -202,6 +232,17 @@ pub(super) fn render_graph_panel(
                     .style(Style::default().fg(color))
                     .data(data),
             );
+
+            if is_area_filled {
+                strong_data_datasets.push(
+                    Dataset::default()
+                        .name("")
+                        .marker(ratatui::symbols::Marker::Dot)
+                        .graph_type(GraphType::Scatter)
+                        .style(Style::default().fg(color))
+                        .data(data),
+                );
+            }
         }
     }
 
@@ -218,6 +259,17 @@ pub(super) fn render_graph_panel(
                 .style(Style::default().fg(Color::White))
                 .data(&cursor_dataset),
         );
+
+        if !strong_data_datasets.is_empty() {
+            strong_data_datasets.push(
+                Dataset::default()
+                    .name("")
+                    .marker(ratatui::symbols::Marker::Braille)
+                    .graph_type(GraphType::Line)
+                    .style(Style::default().fg(Color::White))
+                    .data(&cursor_dataset),
+            );
+        }
     }
 
     let time_range_secs = now - start;
@@ -265,6 +317,11 @@ pub(super) fn render_graph_panel(
             &p.display,
         )
     };
+    let chart_y_labels = if hide_y_axis {
+        Vec::new()
+    } else {
+        y_labels.clone()
+    };
 
     let chart = Chart::new(chart_datasets)
         // No block, as we rendered it outside
@@ -278,13 +335,39 @@ pub(super) fn render_graph_panel(
             Axis::default()
                 .style(Style::default().fg(Color::Gray))
                 .bounds(y_bounds)
-                .labels(y_labels.clone()),
+                .labels(chart_y_labels.clone()),
         );
     // No legend position needed as we disabled names
 
     frame.render_widget(chart, chart_area);
 
-    let chart_left = chart_area.left() + y_max_width + 1; // +1 for the | axis line
+    let strong_data_buf = if strong_data_datasets.is_empty() {
+        None
+    } else {
+        let strong_data_chart = Chart::new(strong_data_datasets)
+            .x_axis(
+                Axis::default()
+                    .bounds([start, now])
+                    .labels(x_labels.clone())
+                    .style(Style::default().fg(theme.text)),
+            )
+            .y_axis(
+                Axis::default()
+                    .style(Style::default().fg(Color::Gray))
+                    .bounds(y_bounds)
+                    .labels(chart_y_labels.clone()),
+            );
+        let mut buf = ratatui::buffer::Buffer::empty(chart_area);
+        strong_data_chart.render(chart_area, &mut buf);
+        Some(buf)
+    };
+
+    let chart_left = chart_plot_left(
+        chart_area,
+        y_max_width,
+        &x_labels,
+        !chart_y_labels.is_empty(),
+    );
     let chart_right = chart_area.right();
     let plot_bounds = PlotBounds {
         left: chart_left,
@@ -307,13 +390,22 @@ pub(super) fn render_graph_panel(
                 Axis::default()
                     .style(Style::default().fg(Color::Gray))
                     .bounds(y_bounds)
-                    .labels(y_labels.clone()),
+                    .labels(chart_y_labels.clone()),
             );
 
         let mut threshold_buf = ratatui::buffer::Buffer::empty(chart_area);
         threshold_chart.render(chart_area, &mut threshold_buf);
 
-        merge_overlay_buffer(frame, &threshold_buf, plot_bounds);
+        if let Some(strong_data_buf) = strong_data_buf.as_ref() {
+            merge_overlay_buffer_preserving_data(
+                frame,
+                &threshold_buf,
+                strong_data_buf,
+                plot_bounds,
+            );
+        } else {
+            merge_overlay_buffer(frame, &threshold_buf, plot_bounds);
+        }
     }
 
     render_raw_threshold_lines(
@@ -358,13 +450,22 @@ pub(super) fn render_graph_panel(
                 Axis::default()
                     .style(Style::default().fg(Color::Gray))
                     .bounds(y_bounds)
-                    .labels(y_labels),
+                    .labels(chart_y_labels),
             );
 
         let mut autogrid_buf = ratatui::buffer::Buffer::empty(chart_area);
         autogrid_chart.render(chart_area, &mut autogrid_buf);
 
-        merge_overlay_buffer(frame, &autogrid_buf, plot_bounds);
+        if let Some(strong_data_buf) = strong_data_buf.as_ref() {
+            merge_overlay_buffer_preserving_data(
+                frame,
+                &autogrid_buf,
+                strong_data_buf,
+                plot_bounds,
+            );
+        } else {
+            merge_overlay_buffer(frame, &autogrid_buf, plot_bounds);
+        }
         render_autogrid_time_labels(
             frame,
             plot_bounds,
@@ -462,5 +563,29 @@ mod tests {
             stacking: GraphStackingMode::Normal,
         };
         assert!(is_y_axis_hidden(&hidden));
+    }
+
+    #[test]
+    fn test_chart_plot_left_visible_axis_preserves_y_label_gutter() {
+        let chart_area = Rect::new(10, 0, 90, 20);
+        let x_labels = vec![Span::raw("long-start-label")];
+
+        assert_eq!(chart_plot_left(chart_area, 6, &x_labels, true), 17);
+    }
+
+    #[test]
+    fn test_chart_plot_left_hidden_axis_uses_first_x_label_gutter() {
+        let chart_area = Rect::new(10, 0, 90, 20);
+        let x_labels = vec![Span::raw("long-start-label")];
+
+        assert_eq!(chart_plot_left(chart_area, 0, &x_labels, false), 26);
+    }
+
+    #[test]
+    fn test_chart_plot_left_hidden_axis_clamps_first_x_label_gutter() {
+        let chart_area = Rect::new(10, 0, 30, 20);
+        let x_labels = vec![Span::raw("very-long-start-label")];
+
+        assert_eq!(chart_plot_left(chart_area, 0, &x_labels, false), 20);
     }
 }

--- a/src/ui/panels/graph/mod.rs
+++ b/src/ui/panels/graph/mod.rs
@@ -38,6 +38,31 @@ use std::collections::HashMap;
 
 pub(crate) use bounds::calculate_y_bounds;
 
+fn graph_type_for_draw_style(draw_style: crate::app::GraphDrawStyle) -> GraphType {
+    match draw_style {
+        crate::app::GraphDrawStyle::Line => GraphType::Line,
+        crate::app::GraphDrawStyle::Points => GraphType::Scatter,
+        crate::app::GraphDrawStyle::Bars => GraphType::Bar,
+    }
+}
+
+fn should_overlay_points(options: &crate::app::GraphOptions) -> bool {
+    options.show_points == crate::app::GraphPointMode::Always
+        && options.draw_style != crate::app::GraphDrawStyle::Points
+}
+
+fn area_fill_baseline(y_bounds: [f64; 2]) -> f64 {
+    if y_bounds[0] <= 0.0 && y_bounds[1] >= 0.0 {
+        0.0
+    } else {
+        y_bounds[0]
+    }
+}
+
+fn is_y_axis_hidden(options: &crate::app::GraphOptions) -> bool {
+    options.axis_placement == crate::app::GraphAxisPlacement::Hidden
+}
+
 pub(super) fn render_graph_panel(
     frame: &mut Frame,
     area: Rect,
@@ -98,6 +123,8 @@ pub(super) fn render_graph_panel(
     // Calculate y_bounds once
     let y_bounds = calculate_y_bounds(p);
     let show_autogrid = app.autogrid_enabled && p.autogrid.unwrap_or(true);
+    let graph_options = p.graph_options();
+    let hide_y_axis = is_y_axis_hidden(&graph_options);
 
     // Prepare datasets (without names for the chart itself to avoid built-in legend)
     let mut chart_datasets = Vec::new();
@@ -149,14 +176,33 @@ pub(super) fn render_graph_panel(
         ));
 
         // For chart (no name to avoid legend)
-        chart_datasets.push(
-            Dataset::default()
-                .name("")
-                .marker(ratatui::symbols::Marker::Braille)
-                .graph_type(GraphType::Line)
-                .style(Style::default().fg(color))
-                .data(data),
-        );
+        let mut dataset = Dataset::default()
+            .name("")
+            .marker(ratatui::symbols::Marker::Braille)
+            .graph_type(graph_type_for_draw_style(graph_options.draw_style))
+            .style(Style::default().fg(color))
+            .data(data);
+
+        if graph_options.fill_opacity.unwrap_or(0) > 0
+            && graph_options.draw_style == crate::app::GraphDrawStyle::Line
+        {
+            dataset = dataset
+                .graph_type(GraphType::Area)
+                .fill_to_y(area_fill_baseline(y_bounds));
+        }
+
+        chart_datasets.push(dataset);
+
+        if should_overlay_points(&graph_options) {
+            chart_datasets.push(
+                Dataset::default()
+                    .name("")
+                    .marker(ratatui::symbols::Marker::Dot)
+                    .graph_type(GraphType::Scatter)
+                    .style(Style::default().fg(color))
+                    .data(data),
+            );
+        }
     }
 
     // Add cursor line if inspecting
@@ -197,22 +243,28 @@ pub(super) fn render_graph_panel(
         Vec::new()
     };
 
-    y_labels[0] = Span::styled(
-        p.display.format_number(y_bounds[0]),
-        Style::default().fg(theme.text),
-    );
-    y_labels[y_axis_height - 1] = Span::styled(
-        p.display.format_number(y_bounds[1]),
-        Style::default().fg(theme.text),
-    );
+    if !hide_y_axis {
+        y_labels[0] = Span::styled(
+            p.display.format_number(y_bounds[0]),
+            Style::default().fg(theme.text),
+        );
+        y_labels[y_axis_height - 1] = Span::styled(
+            p.display.format_number(y_bounds[1]),
+            Style::default().fg(theme.text),
+        );
+    }
 
     // Evaluate y_max_width before moving y_labels into Chart block
-    let y_max_width = y_label_width(
-        &y_labels,
-        &autogrid_value_ticks,
-        &threshold_data.labels,
-        &p.display,
-    );
+    let y_max_width = if hide_y_axis {
+        0
+    } else {
+        y_label_width(
+            &y_labels,
+            &autogrid_value_ticks,
+            &threshold_data.labels,
+            &p.display,
+        )
+    };
 
     let chart = Chart::new(chart_datasets)
         // No block, as we rendered it outside
@@ -323,25 +375,92 @@ pub(super) fn render_graph_panel(
         );
     }
 
-    render_intermediate_y_labels(
-        frame,
-        YLabelArea {
-            left: chart_area.left(),
-            width: y_max_width,
-        },
-        plot_bounds,
-        YLabelContext {
-            y_bounds,
-            autogrid_ticks: &autogrid_value_ticks,
-            threshold_labels: &threshold_data.labels,
-            display: &p.display,
-            color: app.autogrid_color,
-        },
-    );
+    if !hide_y_axis {
+        render_intermediate_y_labels(
+            frame,
+            YLabelArea {
+                left: chart_area.left(),
+                width: y_max_width,
+            },
+            plot_bounds,
+            YLabelContext {
+                y_bounds,
+                autogrid_ticks: &autogrid_value_ticks,
+                threshold_labels: &threshold_data.labels,
+                display: &p.display,
+                color: app.autogrid_color,
+            },
+        );
+    }
 
     // Render custom legend
     if legend_height > 0 {
         let legend = Paragraph::new(Line::from(legend_items)).wrap(Wrap { trim: true });
         frame.render_widget(legend, legend_area);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::{
+        GraphAxisPlacement, GraphDrawStyle, GraphOptions, GraphPointMode, GraphStackingMode,
+    };
+
+    #[test]
+    fn test_graph_type_for_draw_style() {
+        assert_eq!(
+            graph_type_for_draw_style(GraphDrawStyle::Line),
+            GraphType::Line
+        );
+        assert_eq!(
+            graph_type_for_draw_style(GraphDrawStyle::Points),
+            GraphType::Scatter
+        );
+        assert_eq!(
+            graph_type_for_draw_style(GraphDrawStyle::Bars),
+            GraphType::Bar
+        );
+    }
+
+    #[test]
+    fn test_should_overlay_points() {
+        let mut options = GraphOptions::default();
+        options.draw_style = GraphDrawStyle::Line;
+        options.show_points = GraphPointMode::Auto;
+        assert!(!should_overlay_points(&options));
+
+        options.show_points = GraphPointMode::Always;
+        assert!(should_overlay_points(&options));
+
+        options.draw_style = GraphDrawStyle::Points;
+        assert!(!should_overlay_points(&options));
+
+        options.draw_style = GraphDrawStyle::Bars;
+        options.show_points = GraphPointMode::Always;
+        assert!(should_overlay_points(&options));
+    }
+
+    #[test]
+    fn test_area_fill_baseline_prefers_zero_when_visible() {
+        assert_eq!(area_fill_baseline([-10.0, 20.0]), 0.0);
+        assert_eq!(area_fill_baseline([5.0, 20.0]), 5.0);
+        assert_eq!(area_fill_baseline([-20.0, -5.0]), -20.0);
+    }
+
+    #[test]
+    fn test_hidden_axis_flag() {
+        let visible = GraphOptions::default();
+        assert!(!is_y_axis_hidden(&visible));
+
+        let hidden = GraphOptions {
+            axis_placement: GraphAxisPlacement::Hidden,
+            draw_style: GraphDrawStyle::Line,
+            show_points: GraphPointMode::Auto,
+            fill_opacity: None,
+            line_interpolation: Some("smooth".to_string()),
+            stacking: GraphStackingMode::Normal,
+        };
+        assert!(is_y_axis_hidden(&hidden));
     }
 }

--- a/src/ui/panels/graph/mod.rs
+++ b/src/ui/panels/graph/mod.rs
@@ -239,7 +239,7 @@ pub(super) fn render_graph_panel(
             chart_datasets.push(
                 Dataset::default()
                     .name("")
-                    .marker(ratatui::symbols::Marker::Dot)
+                    .marker(ratatui::symbols::Marker::Braille)
                     .graph_type(GraphType::Scatter)
                     .style(Style::default().fg(color))
                     .data(data),
@@ -249,7 +249,7 @@ pub(super) fn render_graph_panel(
                 strong_data_datasets.push(
                     Dataset::default()
                         .name("")
-                        .marker(ratatui::symbols::Marker::Dot)
+                        .marker(ratatui::symbols::Marker::Braille)
                         .graph_type(GraphType::Scatter)
                         .style(Style::default().fg(color))
                         .data(data),
@@ -741,5 +741,36 @@ mod tests {
             .count();
 
         assert_eq!(grid_colored_cells_inside_fill, 0);
+    }
+
+    #[test]
+    fn test_line_forced_points_use_line_marker_grid() {
+        let mut panel = area_fill_panel();
+        panel.options = PanelOptions::Graph(GraphOptions {
+            draw_style: GraphDrawStyle::Line,
+            show_points: GraphPointMode::Always,
+            fill_opacity: None,
+            axis_placement: GraphAxisPlacement::Visible,
+            line_interpolation: None,
+            stacking: GraphStackingMode::Off,
+        });
+        let app = area_fill_app(panel);
+        let panel = &app.panels[0];
+        let mut terminal = Terminal::new(TestBackend::new(80, 20)).unwrap();
+
+        terminal
+            .draw(|frame| {
+                render_graph_panel(frame, Rect::new(0, 0, 80, 20), panel, &app, None);
+            })
+            .unwrap();
+
+        let has_cell_level_point_marker = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .any(|cell| cell.symbol() == "•");
+
+        assert!(!has_cell_level_point_marker);
     }
 }

--- a/src/ui/panels/graph/mod.rs
+++ b/src/ui/panels/graph/mod.rs
@@ -69,15 +69,19 @@ fn chart_plot_left(
     x_labels: &[Span<'_>],
     has_y_axis_labels: bool,
 ) -> u16 {
-    let gutter = if has_y_axis_labels {
-        y_label_width + 1
+    let first_x_label_width = x_labels
+        .first()
+        .map(|label| label.width() as u16)
+        .unwrap_or_default();
+    let y_axis_offset = u16::from(has_y_axis_labels);
+    let x_label_gutter = first_x_label_width.saturating_sub(y_axis_offset);
+    let labels_left_of_y_axis = if has_y_axis_labels {
+        y_label_width.max(x_label_gutter)
     } else {
-        x_labels
-            .first()
-            .map(|label| label.width() as u16)
-            .unwrap_or_default()
-            .min(chart_area.width / 3)
-    };
+        x_label_gutter
+    }
+    .min(chart_area.width / 3);
+    let gutter = labels_left_of_y_axis + y_axis_offset;
 
     chart_area.left() + gutter
 }
@@ -566,11 +570,27 @@ mod tests {
     }
 
     #[test]
-    fn test_chart_plot_left_visible_axis_preserves_y_label_gutter() {
+    fn test_chart_plot_left_visible_axis_uses_y_label_width_when_dominant() {
+        let chart_area = Rect::new(10, 0, 90, 20);
+        let x_labels = vec![Span::raw("abc")];
+
+        assert_eq!(chart_plot_left(chart_area, 6, &x_labels, true), 17);
+    }
+
+    #[test]
+    fn test_chart_plot_left_visible_axis_uses_first_x_label_when_dominant() {
         let chart_area = Rect::new(10, 0, 90, 20);
         let x_labels = vec![Span::raw("long-start-label")];
 
-        assert_eq!(chart_plot_left(chart_area, 6, &x_labels, true), 17);
+        assert_eq!(chart_plot_left(chart_area, 6, &x_labels, true), 26);
+    }
+
+    #[test]
+    fn test_chart_plot_left_visible_axis_clamps_gutter() {
+        let chart_area = Rect::new(10, 0, 30, 20);
+        let x_labels = vec![Span::raw("very-long-start-label")];
+
+        assert_eq!(chart_plot_left(chart_area, 2, &x_labels, true), 21);
     }
 
     #[test]

--- a/src/ui/panels/graph/mod.rs
+++ b/src/ui/panels/graph/mod.rs
@@ -86,6 +86,14 @@ fn chart_plot_left(
     chart_area.left() + gutter
 }
 
+fn chart_y_label_width(labels: &[Span<'_>]) -> u16 {
+    labels
+        .iter()
+        .map(|label| label.width() as u16)
+        .max()
+        .unwrap_or_default()
+}
+
 pub(super) fn render_graph_panel(
     frame: &mut Frame,
     area: Rect,
@@ -326,6 +334,7 @@ pub(super) fn render_graph_panel(
     } else {
         y_labels.clone()
     };
+    let chart_y_label_width = chart_y_label_width(&chart_y_labels);
 
     let chart = Chart::new(chart_datasets)
         // No block, as we rendered it outside
@@ -368,7 +377,7 @@ pub(super) fn render_graph_panel(
 
     let chart_left = chart_plot_left(
         chart_area,
-        y_max_width,
+        chart_y_label_width,
         &x_labels,
         !chart_y_labels.is_empty(),
     );
@@ -418,6 +427,7 @@ pub(super) fn render_graph_panel(
         &threshold_data.labels,
         y_bounds,
         plot_bounds,
+        strong_data_buf.as_ref(),
     );
 
     if show_autogrid && chart_top <= chart_bottom {
@@ -607,5 +617,33 @@ mod tests {
         let x_labels = vec![Span::raw("very-long-start-label")];
 
         assert_eq!(chart_plot_left(chart_area, 0, &x_labels, false), 20);
+    }
+
+    #[test]
+    fn test_chart_plot_left_ignores_custom_label_width() {
+        let chart_area = Rect::new(10, 0, 90, 20);
+        let x_labels = vec![Span::raw("abc")];
+        let chart_y_labels = vec![Span::raw("0"), Span::raw("9")];
+        let custom_label_width = 30;
+        let chart_y_label_width = chart_y_label_width(&chart_y_labels);
+
+        assert_eq!(
+            chart_plot_left(
+                chart_area,
+                chart_y_label_width,
+                &x_labels,
+                !chart_y_labels.is_empty(),
+            ),
+            13
+        );
+        assert_ne!(
+            chart_plot_left(
+                chart_area,
+                custom_label_width,
+                &x_labels,
+                !chart_y_labels.is_empty(),
+            ),
+            13
+        );
     }
 }

--- a/src/ui/panels/graph/mod.rs
+++ b/src/ui/panels/graph/mod.rs
@@ -94,6 +94,65 @@ fn chart_y_label_width(labels: &[Span<'_>]) -> u16 {
         .unwrap_or_default()
 }
 
+fn point_to_braille_cell(
+    x: f64,
+    y: f64,
+    x_bounds: [f64; 2],
+    y_bounds: [f64; 2],
+    plot: PlotBounds,
+) -> Option<(u16, u16)> {
+    if !x.is_finite()
+        || !y.is_finite()
+        || !x_bounds[0].is_finite()
+        || !x_bounds[1].is_finite()
+        || !y_bounds[0].is_finite()
+        || !y_bounds[1].is_finite()
+        || x < x_bounds[0]
+        || x > x_bounds[1]
+        || y < y_bounds[0]
+        || y > y_bounds[1]
+        || x_bounds[1] <= x_bounds[0]
+        || y_bounds[1] <= y_bounds[0]
+        || plot.right <= plot.left
+        || plot.bottom < plot.top
+    {
+        return None;
+    }
+
+    let plot_width = plot.right.saturating_sub(plot.left);
+    let plot_height = plot.bottom.saturating_sub(plot.top).saturating_add(1);
+    let x_resolution = f64::from(plot_width) * 2.0;
+    let y_resolution = f64::from(plot_height) * 4.0;
+
+    let braille_x =
+        ((x - x_bounds[0]) * (x_resolution - 1.0) / (x_bounds[1] - x_bounds[0])).round() as u16;
+    let braille_y =
+        ((y_bounds[1] - y) * (y_resolution - 1.0) / (y_bounds[1] - y_bounds[0])).round() as u16;
+
+    let cell_x = plot.left.saturating_add(braille_x / 2);
+    let cell_y = plot.top.saturating_add(braille_y / 4);
+    (cell_x < plot.right && cell_y <= plot.bottom).then_some((cell_x, cell_y))
+}
+
+fn render_forced_point_markers(
+    frame: &mut Frame,
+    markers: &[(f64, f64, Color)],
+    x_bounds: [f64; 2],
+    y_bounds: [f64; 2],
+    plot: PlotBounds,
+) {
+    let buf = frame.buffer_mut();
+    for (x, y, color) in markers {
+        let Some((cell_x, cell_y)) = point_to_braille_cell(*x, *y, x_bounds, y_bounds, plot) else {
+            continue;
+        };
+        if let Some(cell) = buf.cell_mut((cell_x, cell_y)) {
+            cell.set_symbol(ratatui::symbols::DOT)
+                .set_style(Style::default().fg(*color));
+        }
+    }
+}
+
 pub(super) fn render_graph_panel(
     frame: &mut Frame,
     area: Rect,
@@ -161,6 +220,7 @@ pub(super) fn render_graph_panel(
     let mut chart_datasets = Vec::new();
     let mut strong_data_datasets = Vec::new();
     let mut legend_items = Vec::new();
+    let mut forced_point_markers = Vec::new();
 
     // Declare helper datasets to extend their lifetimes
     let mut cursor_dataset = vec![];
@@ -236,25 +296,7 @@ pub(super) fn render_graph_panel(
         chart_datasets.push(dataset);
 
         if should_overlay_points(&graph_options) {
-            chart_datasets.push(
-                Dataset::default()
-                    .name("")
-                    .marker(ratatui::symbols::Marker::Braille)
-                    .graph_type(GraphType::Scatter)
-                    .style(Style::default().fg(color))
-                    .data(data),
-            );
-
-            if is_area_filled {
-                strong_data_datasets.push(
-                    Dataset::default()
-                        .name("")
-                        .marker(ratatui::symbols::Marker::Braille)
-                        .graph_type(GraphType::Scatter)
-                        .style(Style::default().fg(color))
-                        .data(data),
-                );
-            }
+            forced_point_markers.extend(data.iter().map(|(x, y)| (*x, *y, color)));
         }
     }
 
@@ -501,6 +543,14 @@ pub(super) fn render_graph_panel(
         );
     }
 
+    render_forced_point_markers(
+        frame,
+        &forced_point_markers,
+        [start, now],
+        y_bounds,
+        plot_bounds,
+    );
+
     // Render custom legend
     if legend_height > 0 {
         let legend = Paragraph::new(Line::from(legend_items)).wrap(Wrap { trim: true });
@@ -744,8 +794,9 @@ mod tests {
     }
 
     #[test]
-    fn test_line_forced_points_use_line_marker_grid() {
+    fn test_line_forced_points_are_visible_and_use_line_marker_cells() {
         let mut panel = area_fill_panel();
+        panel.series[0].points = vec![(25.0, 2.0), (50.0, 8.0), (75.0, 4.0)];
         panel.options = PanelOptions::Graph(GraphOptions {
             draw_style: GraphDrawStyle::Line,
             show_points: GraphPointMode::Always,
@@ -764,13 +815,38 @@ mod tests {
             })
             .unwrap();
 
-        let has_cell_level_point_marker = terminal
+        let y_bounds = calculate_y_bounds(panel);
+        let chart_area = Rect::new(0, 0, 80, 18);
+        let x_labels = vec![Span::raw("00:00:00"), Span::raw("00:01:40")];
+        let chart_y_labels = vec![Span::raw("0"), Span::raw("10")];
+        let plot = PlotBounds {
+            left: chart_plot_left(
+                chart_area,
+                chart_y_label_width(&chart_y_labels),
+                &x_labels,
+                true,
+            ),
+            right: chart_area.right(),
+            top: chart_area.top(),
+            bottom: chart_area.bottom().saturating_sub(2),
+        };
+        let expected_cells: std::collections::HashSet<_> = panel.series[0]
+            .points
+            .iter()
+            .filter_map(|(x, y)| point_to_braille_cell(*x, *y, [0.0, 100.0], y_bounds, plot))
+            .collect();
+        let visible_point_cells: std::collections::HashSet<_> = terminal
             .backend()
             .buffer()
             .content()
             .iter()
-            .any(|cell| cell.symbol() == "•");
+            .enumerate()
+            .filter_map(|(index, cell)| {
+                (cell.symbol() == "•").then_some(((index % 80) as u16, (index / 80) as u16))
+            })
+            .collect();
 
-        assert!(!has_cell_level_point_marker);
+        assert!(!visible_point_cells.is_empty());
+        assert_eq!(visible_point_cells, expected_cells);
     }
 }

--- a/src/ui/panels/graph/overlay.rs
+++ b/src/ui/panels/graph/overlay.rs
@@ -67,7 +67,7 @@ fn overlay_cell_if_blank(dst: &mut ratatui::buffer::Cell, src: &ratatui::buffer:
     }
 }
 
-fn overlay_cell_if_blank_or_weak_area_fill(
+pub(super) fn overlay_cell_if_blank_or_weak_area_fill(
     dst: &mut ratatui::buffer::Cell,
     src: &ratatui::buffer::Cell,
     strong_data_mask: &ratatui::buffer::Cell,

--- a/src/ui/panels/graph/overlay.rs
+++ b/src/ui/panels/graph/overlay.rs
@@ -35,6 +35,28 @@ pub(super) fn merge_overlay_buffer(
     }
 }
 
+pub(super) fn merge_overlay_buffer_preserving_data(
+    frame: &mut Frame,
+    overlay_buf: &ratatui::buffer::Buffer,
+    strong_data_buf: &ratatui::buffer::Buffer,
+    plot: PlotBounds,
+) {
+    let buf = frame.buffer_mut();
+    for y in plot.top..=plot.bottom {
+        for x in plot.left..plot.right {
+            let Some(src_cell) = overlay_buf.cell((x, y)) else {
+                continue;
+            };
+            let Some(mask_cell) = strong_data_buf.cell((x, y)) else {
+                continue;
+            };
+            if let Some(dst_cell) = buf.cell_mut((x, y)) {
+                overlay_cell_if_blank_or_weak_area_fill(dst_cell, src_cell, mask_cell);
+            }
+        }
+    }
+}
+
 pub(super) fn is_blank_cell(cell: &ratatui::buffer::Cell) -> bool {
     cell.symbol().chars().all(char::is_whitespace)
 }
@@ -43,6 +65,26 @@ fn overlay_cell_if_blank(dst: &mut ratatui::buffer::Cell, src: &ratatui::buffer:
     if is_blank_cell(dst) && !is_blank_cell(src) {
         dst.set_symbol(src.symbol()).set_style(src.style());
     }
+}
+
+fn overlay_cell_if_blank_or_weak_area_fill(
+    dst: &mut ratatui::buffer::Cell,
+    src: &ratatui::buffer::Cell,
+    strong_data_mask: &ratatui::buffer::Cell,
+) {
+    if is_blank_cell(src) {
+        return;
+    }
+
+    if is_blank_cell(dst) || (is_braille_cell(dst) && is_blank_cell(strong_data_mask)) {
+        dst.set_symbol(src.symbol()).set_style(src.style());
+    }
+}
+
+fn is_braille_cell(cell: &ratatui::buffer::Cell) -> bool {
+    cell.symbol()
+        .chars()
+        .any(|ch| ('\u{2800}'..='\u{28ff}').contains(&ch))
 }
 
 #[cfg(test)]
@@ -86,6 +128,38 @@ mod tests {
         overlay_cell_if_blank(&mut dst, &src);
 
         assert_eq!(dst.symbol(), "x");
+        assert_eq!(dst.style().fg, Some(Color::LightBlue));
+    }
+
+    #[test]
+    fn test_overlay_cell_if_area_fill_replaces_weak_area_cell() {
+        let mut dst = ratatui::buffer::Cell::default();
+        dst.set_char('⣿')
+            .set_style(Style::default().fg(Color::LightBlue));
+        let mut src = ratatui::buffer::Cell::default();
+        src.set_char('-').set_style(Style::default().fg(Color::Red));
+        let mask = ratatui::buffer::Cell::default();
+
+        overlay_cell_if_blank_or_weak_area_fill(&mut dst, &src, &mask);
+
+        assert_eq!(dst.symbol(), "-");
+        assert_eq!(dst.style().fg, Some(Color::Red));
+    }
+
+    #[test]
+    fn test_overlay_cell_if_area_fill_keeps_strong_data_marker() {
+        let mut dst = ratatui::buffer::Cell::default();
+        dst.set_char('⣿')
+            .set_style(Style::default().fg(Color::LightBlue));
+        let mut src = ratatui::buffer::Cell::default();
+        src.set_char('-').set_style(Style::default().fg(Color::Red));
+        let mut mask = ratatui::buffer::Cell::default();
+        mask.set_char('⠉')
+            .set_style(Style::default().fg(Color::LightBlue));
+
+        overlay_cell_if_blank_or_weak_area_fill(&mut dst, &src, &mask);
+
+        assert_eq!(dst.symbol(), "⣿");
         assert_eq!(dst.style().fg, Some(Color::LightBlue));
     }
 }

--- a/src/ui/panels/graph/thresholds.rs
+++ b/src/ui/panels/graph/thresholds.rs
@@ -15,7 +15,7 @@
  */
 
 use super::labels::PlotBounds;
-use super::overlay::is_blank_cell;
+use super::overlay::{is_blank_cell, overlay_cell_if_blank_or_weak_area_fill};
 use crate::app::{PanelState, ThresholdMode};
 use ratatui::{prelude::*, widgets::GraphType};
 
@@ -86,6 +86,7 @@ pub(super) fn render_raw_threshold_lines(
     threshold_labels: &[(f64, Color)],
     y_bounds: [f64; 2],
     plot: PlotBounds,
+    strong_data_buf: Option<&ratatui::buffer::Buffer>,
 ) {
     if !marker_name.ends_with("line") || y_bounds[1] <= y_bounds[0] {
         return;
@@ -118,9 +119,18 @@ pub(super) fn render_raw_threshold_lines(
                 continue;
             }
             if let Some(cell) = buf.cell_mut((x, y)) {
-                if is_blank_cell(cell) {
-                    cell.set_char(line_char)
-                        .set_style(Style::default().fg(*color));
+                let mut line_cell = ratatui::buffer::Cell::default();
+                line_cell
+                    .set_char(line_char)
+                    .set_style(Style::default().fg(*color));
+
+                if let Some(strong_data_buf) = strong_data_buf {
+                    if let Some(mask_cell) = strong_data_buf.cell((x, y)) {
+                        overlay_cell_if_blank_or_weak_area_fill(cell, &line_cell, mask_cell);
+                    }
+                } else if is_blank_cell(cell) {
+                    cell.set_symbol(line_cell.symbol())
+                        .set_style(line_cell.style());
                 }
             }
         }
@@ -143,4 +153,80 @@ fn threshold_dataset(
     }
 
     vec![(start, threshold_value), (end, threshold_value)]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::{Terminal, backend::TestBackend};
+
+    fn plot_bounds() -> PlotBounds {
+        PlotBounds {
+            left: 0,
+            right: 5,
+            top: 0,
+            bottom: 4,
+        }
+    }
+
+    #[test]
+    fn test_raw_threshold_line_replaces_weak_area_fill_with_mask() {
+        let mut terminal = Terminal::new(TestBackend::new(5, 5)).unwrap();
+        let mask = ratatui::buffer::Buffer::empty(Rect::new(0, 0, 5, 5));
+
+        terminal
+            .draw(|frame| {
+                frame
+                    .buffer_mut()
+                    .cell_mut((1, 2))
+                    .unwrap()
+                    .set_char('⣿')
+                    .set_style(Style::default().fg(Color::Blue));
+
+                render_raw_threshold_lines(
+                    frame,
+                    "dashed-line",
+                    &[(5.0, Color::Red)],
+                    [0.0, 10.0],
+                    plot_bounds(),
+                    Some(&mask),
+                );
+            })
+            .unwrap();
+
+        let cell = terminal.backend().buffer().cell((1, 2)).unwrap();
+        assert_eq!(cell.symbol(), "-");
+        assert_eq!(cell.style().fg, Some(Color::Red));
+    }
+
+    #[test]
+    fn test_raw_threshold_line_preserves_strong_data_with_mask() {
+        let mut terminal = Terminal::new(TestBackend::new(5, 5)).unwrap();
+        let mut mask = ratatui::buffer::Buffer::empty(Rect::new(0, 0, 5, 5));
+        mask.cell_mut((1, 2)).unwrap().set_char('⠉');
+
+        terminal
+            .draw(|frame| {
+                frame
+                    .buffer_mut()
+                    .cell_mut((1, 2))
+                    .unwrap()
+                    .set_char('⣿')
+                    .set_style(Style::default().fg(Color::Blue));
+
+                render_raw_threshold_lines(
+                    frame,
+                    "dashed-line",
+                    &[(5.0, Color::Red)],
+                    [0.0, 10.0],
+                    plot_bounds(),
+                    Some(&mask),
+                );
+            })
+            .unwrap();
+
+        let cell = terminal.backend().buffer().cell((1, 2)).unwrap();
+        assert_eq!(cell.symbol(), "⣿");
+        assert_eq!(cell.style().fg, Some(Color::Blue));
+    }
 }


### PR DESCRIPTION
Closes #65

## Summary
- upgrade ratatui to 0.30.1 and refresh MSRV documentation
- add graph-specific panel options while keeping `PanelState` generic
- import Grafana timeseries custom options for draw style, points, fill opacity, hidden axes, and stacking metadata
- render line, points, bars, and area styles in the TUI and carry the supported styles through SVG export
- update compatibility docs and example dashboard coverage

## Validation
- `cargo fmt --check`
- `cargo check`
- `cargo test`
- example dashboard JSON validation