### PR TITLE
Tighten import validation

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -88,7 +88,7 @@ This is the main backlog, ordered by Grafana parity domain.
 |---|---|---|---|---|
 | **Compatibility matrix automation** | Documentation generated or checked against current code | Keeps users and contributors aligned with reality | 🟢 | 📋 |
 | **Unsupported panel warnings** | Unsupported `panels[].type` and ignored high-impact fields | Makes import degradation visible instead of silent | 🟢 | ✅ |
-| **Import validation** | Non-interactive `--validate --grafana-json` import checks | Lets users check dashboards before launching the TUI | 🟢 | 🔶 |
+| **Import validation** | `--validate`, `--strict`, and JSON import checks | Lets users check dashboards before launching the TUI | 🟢 | 🔶 |
 | **Better JSON/import errors** | Parse errors with path/context where possible | Faster debugging for broken exports | 🟢 | 📋 |
 | **Variable substitution diagnostics** | Missing variables, unsupported format modifiers | Explains empty panels caused by unresolved variables | 🟢 | ✅ |
 
@@ -184,9 +184,9 @@ Goal: imported dashboards should be more readable and less silently degraded.
 | Value mappings | Makes status/stat panels useful instead of numeric-only | 🟡 | 🔜 |
 | Broader unit formatting | Expands the shipped common-unit subset to more Grafana dashboards | 🟡 | 📋 |
 | Additional no-value coverage | Completes the shipped fallback behavior where terminal rendering can use it | 🟢 | 📋 |
-| Hidden targets | Prevents helper queries from appearing as normal series | 🟢 | 🔜 |
+| Hidden targets | Prevents helper queries from appearing as normal series | 🟢 | ✅ |
 | Unsupported panel warnings | Builds trust in imported results | 🟢 | ✅ |
-| `--validate` import diagnostics | Gives users a non-interactive dashboard check | 🟢 | 🔶 |
+| `--validate` import diagnostics | Gives users text, JSON, and strict non-interactive dashboard checks | 🟢 | 🔶 |
 
 ### v0.3 - Panel Semantics
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,6 +9,8 @@ Grafatui can be configured with CLI options, a TOML configuration file, or both.
 | `--prometheus-url <URL>` | Prometheus server URL | `http://localhost:9090` |
 | `--grafana-json <FILE>` | Grafana dashboard JSON file | none |
 | `--validate` | Check the Grafana dashboard import and exit without starting the TUI | `false` |
+| `--strict` | Make `--validate` fail when diagnostics contain warnings | `false` |
+| `--format <FORMAT>` | Output format for `--validate`: `text` or `json` | `text` |
 | `--range <DURATION>` | Time range window, such as `5m`, `1h`, or `24h` | `5m` |
 | `--step <DURATION>` | Query step resolution, such as `5s` or `30s` | `5s` |
 | `--var <KEY=VALUE>` | Override a dashboard variable | none |

--- a/docs/grafana-compatibility.md
+++ b/docs/grafana-compatibility.md
@@ -118,7 +118,7 @@ This document provides a comprehensive feature-parity table between the [Grafana
 | `targets[].intervalFactor` | ❌ Not Implemented | |
 | `targets[].instant` | ✅ Supported | Uses Prometheus instant `query` when true; Gauge, BarGauge, and Table default to instant |
 | `targets[].format` | ❌ Not Implemented | Always treated as time_series |
-| `targets[].hide` | ❌ Not Implemented | All targets are visible; import diagnostics warn when hidden targets are ignored |
+| `targets[].hide` | ✅ Supported | Hidden targets are skipped during import |
 | `targets[].exemplar` | ❌ Not Implemented | |
 | `targets[].editorMode` | ⛔ Not Applicable | UI-only setting |
 
@@ -314,8 +314,7 @@ Based on user feedback, the following missing features are most commonly expecte
 2. **Broader unit formatting** (`fieldConfig.defaults.unit`) — Extend the current common-unit subset to more Grafana unit families
 3. **Reduce options** (`options.reduceOptions`) — Use min/max/mean/total instead of always using the latest value
 4. **Import diagnostics** — Warn clearly about skipped panel types and ignored high-impact fields
-5. **Hidden targets** (`targets[].hide`) — Hide helper queries that should not render as visible series
-6. **Additional panel types** — `text`, `piechart`, `histogram`, `logs`
+5. **Additional panel types** — `text`, `piechart`, `histogram`, `logs`
 
 ---
 

--- a/docs/grafana-dashboard-import.md
+++ b/docs/grafana-dashboard-import.md
@@ -44,9 +44,8 @@ Prometheus query variables such as `label_values(up, instance)` and `query_resul
 
 Grafatui prints import warnings before starting the TUI when a dashboard uses
 important Grafana features that are skipped or ignored. Diagnostics include
-unsupported panel types, hidden targets, value mappings, reduce options,
-unresolved variables, and unsupported variable modifiers such as
-`${var:regex}`.
+unsupported panel types, value mappings, reduce options, unresolved variables,
+and unsupported variable modifiers such as `${var:regex}`.
 
 Run a non-interactive check with:
 
@@ -56,6 +55,20 @@ grafatui --validate --grafana-json ./dash.json
 
 Warnings do not make validation fail. A dashboard that can be parsed and
 imported exits successfully even if diagnostics are printed.
+
+Use `--strict` to make warnings fail validation, or `--format json` to emit a
+machine-readable summary:
+
+```bash
+grafatui --validate --strict --grafana-json ./dash.json
+grafatui --validate --format json --grafana-json ./dash.json
+```
+
+## Hidden Targets
+
+Grafatui honors `targets[].hide` by skipping hidden targets during import.
+Panels with a mix of hidden and visible targets render only the visible target
+queries.
 
 ## Query Modes
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use std::path::PathBuf;
 
 /// Command-line arguments for Grafatui.
@@ -44,6 +44,14 @@ pub(crate) struct Args {
     /// Validate a Grafana dashboard import without starting the TUI
     #[arg(long)]
     pub(crate) validate: bool,
+
+    /// Fail validation when import diagnostics contain warnings
+    #[arg(long, requires = "validate")]
+    pub(crate) strict: bool,
+
+    /// Output format for --validate
+    #[arg(long, value_enum, default_value = "text", requires = "validate")]
+    pub(crate) format: ValidateFormat,
 
     /// Legacy UI tick rate in milliseconds; redraws now happen on input and data refresh
     #[arg(long, default_value = "250")]
@@ -104,6 +112,13 @@ pub(crate) enum Commands {
     Man,
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, ValueEnum)]
+pub(crate) enum ValidateFormat {
+    #[default]
+    Text,
+    Json,
+}
+
 /// Helper to parse key=value pairs for CLI arguments.
 pub(crate) fn parse_key_val<T, U>(
     s: &str,
@@ -131,5 +146,22 @@ mod tests {
 
         assert!(args.validate);
         assert_eq!(args.grafana_json, Some(PathBuf::from("dashboard.json")));
+    }
+
+    #[test]
+    fn test_parse_validate_strict_and_json_format() {
+        let args = Args::parse_from([
+            "grafatui",
+            "--validate",
+            "--strict",
+            "--format",
+            "json",
+            "--grafana-json",
+            "dashboard.json",
+        ]);
+
+        assert!(args.validate);
+        assert!(args.strict);
+        assert_eq!(args.format, crate::cli::ValidateFormat::Json);
     }
 }

--- a/src/grafana.rs
+++ b/src/grafana.rs
@@ -15,7 +15,7 @@
  */
 
 use anyhow::{Context, Result};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 
 /// Result of importing a Grafana dashboard.
@@ -38,7 +38,7 @@ pub(crate) struct DashboardImport {
 }
 
 /// A warning produced while importing a Grafana dashboard.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub(crate) struct ImportDiagnostic {
     /// Stable diagnostic code.
     pub(crate) code: String,
@@ -450,11 +450,7 @@ fn collect_panels(out: &mut DashboardImport, panels: Vec<RawPanel>, path: &str) 
             for (target_idx, t) in p.targets.unwrap_or_default().into_iter().enumerate() {
                 let target_path = format!("{panel_path}.targets[{target_idx}]");
                 if t.hide == Some(true) {
-                    out.diagnostics.push(ImportDiagnostic::new(
-                        "ignored_field",
-                        format!("{target_path}.hide"),
-                        "`targets[].hide` is not supported yet; target will be imported as visible",
-                    ));
+                    continue;
                 }
                 if let Some(e) = t.expr {
                     exprs.push(e);
@@ -1189,7 +1185,7 @@ mod tests {
                     "type": "stat",
                     "title": "CPU",
                     "targets": [
-                        { "expr": "up", "hide": true }
+                        { "expr": "up" }
                     ],
                     "fieldConfig": {
                         "defaults": {
@@ -1218,11 +1214,45 @@ mod tests {
             .map(|diagnostic| (diagnostic.code.as_str(), diagnostic.path.as_str()))
             .collect();
 
-        assert!(diagnostics.contains(&("ignored_field", "panels[0].targets[0].hide")));
         assert!(
             diagnostics.contains(&("ignored_field", "panels[0].fieldConfig.defaults.mappings"))
         );
         assert!(diagnostics.contains(&("ignored_field", "panels[0].options.reduceOptions")));
+    }
+
+    #[test]
+    fn test_hidden_targets_are_not_imported_or_warned() {
+        let json = r#"{
+            "title": "Hidden Targets",
+            "panels": [
+                {
+                    "type": "timeseries",
+                    "title": "CPU",
+                    "targets": [
+                        { "expr": "helper_query", "hide": true },
+                        { "expr": "visible_query" }
+                    ]
+                }
+            ]
+        }"#;
+        let path = std::env::temp_dir().join("grafatui-hidden-targets-test.json");
+        std::fs::write(&path, json).unwrap();
+
+        let dashboard = load_grafana_dashboard(&path).unwrap();
+        std::fs::remove_file(path).unwrap();
+
+        assert_eq!(dashboard.queries.len(), 1);
+        assert_eq!(dashboard.queries[0].exprs, vec!["visible_query"]);
+        assert_eq!(
+            dashboard.queries[0].expr_paths,
+            vec!["panels[0].targets[1].expr"]
+        );
+        assert!(
+            dashboard
+                .diagnostics
+                .iter()
+                .all(|diagnostic| diagnostic.path != "panels[0].targets[0].hide")
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ mod ui;
 use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Context, Result, anyhow, bail};
 use clap::Parser;
 use config::Config;
 use crossterm::{
@@ -34,6 +34,7 @@ use crossterm::{
 };
 use ratatui::Terminal;
 use ratatui::backend::CrosstermBackend;
+use serde::Serialize;
 use theme::Theme;
 
 mod cli;
@@ -82,11 +83,7 @@ async fn main() -> Result<()> {
         })?;
         let dashboard = grafana::load_grafana_dashboard(&path)?;
         let summary = validate_dashboard_import(dashboard, config.vars.clone(), &args.var);
-        print_import_diagnostics(&summary.diagnostics);
-        println!(
-            "Grafana dashboard is importable: {} ({} panel(s))",
-            summary.title, summary.panel_count
-        );
+        print_validation_summary(&summary, args.format, args.strict)?;
         return Ok(());
     }
 
@@ -267,7 +264,7 @@ struct ImportContext {
     diagnostics: Vec<grafana::ImportDiagnostic>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 struct ImportValidationSummary {
     title: String,
     panel_count: usize,
@@ -347,6 +344,39 @@ fn print_import_diagnostics(diagnostics: &[grafana::ImportDiagnostic]) {
             diagnostic.code, diagnostic.path, diagnostic.message
         );
     }
+}
+
+fn print_validation_summary(
+    summary: &ImportValidationSummary,
+    format: cli::ValidateFormat,
+    strict: bool,
+) -> Result<()> {
+    match format {
+        cli::ValidateFormat::Text => {
+            print_import_diagnostics(&summary.diagnostics);
+            if strict && !summary.diagnostics.is_empty() {
+                bail!(
+                    "validation failed with {} warning(s)",
+                    summary.diagnostics.len()
+                );
+            }
+            println!(
+                "Grafana dashboard is importable: {} ({} panel(s))",
+                summary.title, summary.panel_count
+            );
+        }
+        cli::ValidateFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(summary)?);
+            if strict && !summary.diagnostics.is_empty() {
+                bail!(
+                    "validation failed with {} warning(s)",
+                    summary.diagnostics.len()
+                );
+            }
+        }
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/tests/validate_cli.rs
+++ b/tests/validate_cli.rs
@@ -1,0 +1,77 @@
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn write_dashboard(name: &str, json: &str) -> PathBuf {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let path = std::env::temp_dir().join(format!("grafatui-{name}-{stamp}.json"));
+    fs::write(&path, json).unwrap();
+    path
+}
+
+#[test]
+fn validate_strict_exits_nonzero_when_warnings_exist() {
+    let path = write_dashboard(
+        "strict",
+        r#"{
+            "title": "Warnings",
+            "panels": [
+                { "type": "text", "title": "Notes" }
+            ]
+        }"#,
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_grafatui"))
+        .args(["--validate", "--strict", "--grafana-json"])
+        .arg(&path)
+        .output()
+        .unwrap();
+    fs::remove_file(path).unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("warning[grafana.import.skipped_panel]"));
+    assert!(stderr.contains("validation failed with 1 warning(s)"));
+}
+
+#[test]
+fn validate_json_outputs_machine_readable_summary() {
+    let path = write_dashboard(
+        "json",
+        r#"{
+            "title": "JSON Warnings",
+            "panels": [
+                { "type": "text", "title": "Notes" },
+                {
+                    "type": "timeseries",
+                    "title": "CPU",
+                    "targets": [
+                        { "expr": "helper_query", "hide": true },
+                        { "expr": "visible_query" }
+                    ]
+                }
+            ]
+        }"#,
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_grafatui"))
+        .args(["--validate", "--format", "json", "--grafana-json"])
+        .arg(&path)
+        .output()
+        .unwrap();
+    fs::remove_file(path).unwrap();
+
+    assert!(output.status.success());
+    assert!(output.stderr.is_empty());
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let summary: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(summary["title"], "JSON Warnings");
+    assert_eq!(summary["panel_count"], 1);
+    assert_eq!(summary["diagnostics"][0]["code"], "skipped_panel");
+    assert_eq!(summary["diagnostics"].as_array().unwrap().len(), 1);
+}


### PR DESCRIPTION
## Summary
- Honor Grafana `targets[].hide` by skipping hidden targets during import.
- Add `--validate --strict` so diagnostics can fail CI-style validation.
- Add `--validate --format json` for machine-readable import summaries.
- Add CLI integration tests for strict and JSON validation output, and update docs/compatibility notes.

## Validation
- `cargo test` passed: 110 unit tests plus 2 integration tests.
- `git diff --check` passed.
- Manual smoke checks covered JSON validation output and strict-mode warning failure.

## Notes
- Strict mode only changes validation behavior; interactive imports still print warnings and continue.
- JSON validation writes the summary to stdout and suppresses text diagnostics on stderr unless strict mode fails.
