### PR TITLE
Add external JSONL point annotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /book
 .DS_Store
 docs/superpowers/
+.superpowers/

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ cargo run -- --grafana-json examples/dashboards/prometheus_demo.json --prometheu
 - Keyboard-first navigation, panel search, fullscreen mode, mouse selection, and value inspection.
 - SVG/PNG export and changed-frame recording bundles.
 - TOML configuration and built-in themes.
+- Read-only external JSONL point annotations for graph and timeseries panels.
 
 ## Documentation
 
@@ -49,6 +50,7 @@ cargo run -- --grafana-json examples/dashboards/prometheus_demo.json --prometheu
 - [Installation](https://fedexist.github.io/grafatui/installation.html)
 - [Quick start](https://fedexist.github.io/grafatui/quick-start.html)
 - [Configuration](https://fedexist.github.io/grafatui/configuration.html)
+- [External annotations](https://fedexist.github.io/grafatui/annotations.html)
 - [Grafana dashboard import](https://fedexist.github.io/grafatui/grafana-dashboard-import.html)
 - [Grafana compatibility matrix](https://fedexist.github.io/grafatui/grafana-compatibility.html)
 - [Examples](examples/README.md)
@@ -66,6 +68,9 @@ grafatui --grafana-json ./dash.json --var job=node --var instance=server-01
 
 # Use a theme
 grafatui --theme tokyo-night
+
+# Overlay read-only JSONL point events
+grafatui --grafana-json ./dashboard.json --annotations-file ./events.jsonl
 
 # Generate shell completions or a man page
 grafatui completions zsh

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,7 +8,7 @@ oriented around two priorities:
 2. **User-visible product value** - parity work should make real dashboards
    easier to read, debug, and share.
 
-> **Current version**: 0.1.9 · **Status**: Active development, pre-1.0
+> **Current version**: 0.1.10 · **Status**: Active development, pre-1.0
 
 **Legend**:
 - 🟢 Low complexity · 🟡 Medium complexity · 🔴 High complexity
@@ -38,6 +38,7 @@ These features are shipped and available today:
 | UI | **Mouse support** | Click to select, scroll, drag cursor in fullscreen inspect mode |
 | UI | **Value inspection** | Cursor-based point-in-time data exploration |
 | UI | **Series toggling** | Show/hide individual series with `1`-`9` |
+| Annotations | **External JSONL point annotations (iteration 1)** | Read-only JSONL events on graph/timeseries panels, counted same-column markers, inline inspection, export, and recording parity |
 | Rendering | **Smart caching** | Request deduplication and caching for identical queries |
 | Rendering | **Downsampling** | Max-pooling to preserve peaks while fitting the terminal |
 | Rendering | **Adaptive time labels** | Date/time axis labels adjust to the selected range |
@@ -56,6 +57,17 @@ These features are shipped and available today:
 For a field-by-field breakdown of Grafana JSON compatibility, see the
 [compatibility matrix](docs/grafana-compatibility.md). Keep that document
 refreshed alongside parity work so it stays aligned with the current release.
+
+### External Annotation Iterations
+
+| Iteration | Scope | Status |
+|---|---|---|
+| 1 | External JSONL point annotations | ✅ Implemented by the current iteration-1 PR |
+| 2 | Navigable annotation popup, panel targeting, and tag filtering | 📋 Future PR |
+| 3 | Annotation provider API | 📋 Future PR |
+
+These iterations are separate from Grafana `annotations` and `annotations.list`,
+which remain unsupported.
 
 ---
 
@@ -250,7 +262,6 @@ These are valuable, but they should not outrank core Grafana import fidelity.
 | SSH tunnel mode | Connect to remote Prometheus more easily | 🟡 | 💡 |
 | Colorblind palettes | Improve accessibility | 🟢 | 📋 |
 | Custom keybindings | User-remappable shortcuts | 🟡 | 📋 |
-| Panel annotations | Deployment markers/events on graphs | 🟡 | 💡 |
 
 ---
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -5,6 +5,7 @@
 - [Installation](installation.md)
 - [Quick Start](quick-start.md)
 - [Configuration](configuration.md)
+- [External Annotations](annotations.md)
 - [Grafana Dashboard Import](grafana-dashboard-import.md)
 - [Exporting and Recording](exporting-and-recording.md)
 - [Keyboard and Mouse](keyboard-and-mouse.md)

--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -25,8 +25,9 @@ read-only; Grafatui does not create, edit, or otherwise write the file.
 ## JSONL Event Format
 
 The file contains one JSON object per line. Blank lines are ignored. Each event
-requires an RFC 3339 `time` and non-empty `text`; `tags` is optional, but every
-provided tag must be a non-empty string.
+requires `time` to be an RFC3339 string with an explicit timezone or offset
+(numeric timestamps are rejected) and non-empty `text`. `tags` is an optional
+array of non-empty strings.
 
 ```json
 {"time":"2026-07-23T14:30:00Z","text":"Deployed v2.4","tags":["deploy","production"]}
@@ -39,18 +40,22 @@ display shows less precision.
 
 ## Automatic Reload
 
-Grafatui checks the file during each normal refresh and reloads it when its
-metadata changes. You can therefore update the JSONL file while Grafatui is
-running without restarting it. Annotation loading is independent of Prometheus:
-annotation failures never fail startup or a Prometheus refresh.
+Grafatui checks the file metadata during each normal refresh, including while
+markers are hidden. When it changes, Grafatui reads, parses, and validates the
+full candidate file before atomically replacing the snapshot. A zero-byte file
+is a valid update that clears all events. You can therefore update the JSONL
+file while Grafatui is running without restarting it. Annotation loading is
+independent of Prometheus: annotation failures never fail startup or a
+Prometheus refresh.
 
 ## Rendering and Inspection
 
 Only `graph` and `timeseries` panels receive annotation markers. Press `a` to
 toggle external annotation marker visibility. Events that project to the same
-terminal column are shown as one counted marker; in inspection mode, moving the
-cursor onto that column shows the clustered events' timestamp, text, and tags
-inline.
+terminal column are shown as one counted marker: `•` for one event, decimal
+`2`–`9` for two through nine events, and `+` for 10 or more. In inspection
+mode, moving the cursor onto that column shows the clustered events' timestamp,
+text, and tags inline; multi-event details report the exact cluster count.
 
 Visible markers and active inline annotation details are included in SVG/PNG
 exports and changed-frame recordings.

--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -1,0 +1,82 @@
+# External Annotations
+
+Grafatui can overlay read-only, external point events from one JSONL file. It
+never edits or writes the source file.
+
+## Enable Annotations
+
+Pass the source path on the command line:
+
+```bash
+grafatui \
+  --grafana-json ./dashboard.json \
+  --annotations-file ./events.jsonl
+```
+
+Or configure the same single source in TOML:
+
+```toml
+annotations_file = "./events.jsonl"
+```
+
+The CLI option overrides the configured path. This source is opt-in and is
+read-only; Grafatui does not create, edit, or otherwise write the file.
+
+## JSONL Event Format
+
+The file contains one JSON object per line. Blank lines are ignored. Each event
+requires an RFC 3339 `time` and non-empty `text`; `tags` is optional, but every
+provided tag must be a non-empty string.
+
+```json
+{"time":"2026-07-23T14:30:00Z","text":"Deployed v2.4","tags":["deploy","production"]}
+```
+
+Events are ordered by timestamp. Unknown JSON fields are ignored. Times with
+fractional seconds are accepted, and the full fractional timestamp is used when
+projecting an event onto the graph even when the space-limited inline timestamp
+display shows less precision.
+
+## Automatic Reload
+
+Grafatui checks the file during each normal refresh and reloads it when its
+metadata changes. You can therefore update the JSONL file while Grafatui is
+running without restarting it. Annotation loading is independent of Prometheus:
+annotation failures never fail startup or a Prometheus refresh.
+
+## Rendering and Inspection
+
+Only `graph` and `timeseries` panels receive annotation markers. Press `a` to
+toggle external annotation marker visibility. Events that project to the same
+terminal column are shown as one counted marker; in inspection mode, moving the
+cursor onto that column shows the clustered events' timestamp, text, and tags
+inline.
+
+Visible markers and active inline annotation details are included in SVG/PNG
+exports and changed-frame recordings.
+
+## Errors and Last Valid Snapshot
+
+If the file is missing, unreadable, or contains a malformed event, Grafatui
+keeps rendering the last valid snapshot and shows an annotation warning. A bad
+update does not replace the previously loaded events, fail startup, or fail the
+Prometheus refresh.
+
+## Current Limitations
+
+This iteration supports one external JSONL source and point events applied to
+all graph/timeseries panels. It does not support panel targeting, a navigable
+annotation popup, or tag filtering. `--validate` validates Grafana dashboard
+imports only; it does not validate annotations.
+
+External JSONL events are separate from Grafana dashboard `annotations` and
+`annotations.list`, which remain unsupported. Grafatui also does not run
+Prometheus annotation queries or implement Grafana annotation-query/API
+compatibility.
+
+## Roadmap
+
+Iteration 1 is the shipped external JSONL point-annotation foundation. A future
+iteration 2 PR will add a navigable popup, panel targeting, and tag filtering.
+A separate future iteration 3 PR will introduce a provider API. Neither future
+iteration is implemented yet.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,6 +8,7 @@ Grafatui can be configured with CLI options, a TOML configuration file, or both.
 |---|---|---|
 | `--prometheus-url <URL>` | Prometheus server URL | `http://localhost:9090` |
 | `--grafana-json <FILE>` | Grafana dashboard JSON file | none |
+| `--annotations-file <FILE>` | Read-only external JSONL point-event file | none |
 | `--validate` | Check the Grafana dashboard import and exit without starting the TUI | `false` |
 | `--strict` | Make `--validate` fail when diagnostics contain warnings | `false` |
 | `--format <FORMAT>` | Output format for `--validate`: `text` or `json` | `text` |
@@ -46,6 +47,7 @@ record_max_frames = 300
 autogrid = true
 autogrid_color = "dark-gray"
 grafana_json = "~/.config/grafatui/my-dashboard.json"
+annotations_file = "./events.jsonl"
 
 [vars]
 job = "node"

--- a/docs/exporting-and-recording.md
+++ b/docs/exporting-and-recording.md
@@ -33,6 +33,9 @@ grafatui-recording-<timestamp>/
 
 If `--export-format png` or `both` is selected, matching PNG files are written too.
 
+When external annotations are visible, their markers and any active inline
+annotation details are included in exports and changed-frame recordings.
+
 ## Recording Limits
 
 Limit the number of changed frames in one recording:

--- a/docs/grafana-compatibility.md
+++ b/docs/grafana-compatibility.md
@@ -247,6 +247,10 @@ tooltips.
 | `annotations` | ❌ Not Implemented | |
 | `annotations.list` | ❌ Not Implemented | |
 
+Grafatui external JSONL events are a separate, opt-in read-only source. They do
+not imply compatibility with Grafana annotation queries, APIs, `annotations`, or
+`annotations.list`.
+
 ---
 
 ## Data Links & Transformations

--- a/docs/keyboard-and-mouse.md
+++ b/docs/keyboard-and-mouse.md
@@ -16,6 +16,7 @@ Grafatui is designed for keyboard-first dashboard inspection.
 | `Home` / `End` | Jump to top or bottom |
 | `y` | Toggle Y-axis mode |
 | `g` | Toggle autogrid guide lines |
+| `a` | Toggle external annotation markers |
 | `1` through `9` | Toggle series visibility |
 | `f` / `Enter` | Toggle fullscreen mode |
 | `v` | Toggle value inspection mode |

--- a/examples/README.md
+++ b/examples/README.md
@@ -13,6 +13,18 @@ docker-compose up -d && sleep 5 && cd ../.. && cargo run -- --grafana-json examp
 
 See [`demo/README.md`](demo/README.md) for details.
 
+## External Annotations
+
+[`annotations.jsonl`](annotations.jsonl) is a read-only external JSONL event
+source for graph and timeseries panels. Run it with a dashboard:
+
+```bash
+cargo run -- --grafana-json examples/dashboards/prometheus_demo.json --annotations-file examples/annotations.jsonl
+```
+
+See the [external annotations guide](../docs/annotations.md) for the event
+format, reload behavior, and limitations.
+
 ## Dashboards
 
 

--- a/examples/annotations.jsonl
+++ b/examples/annotations.jsonl
@@ -1,0 +1,3 @@
+{"time":"2026-07-23T14:30:00Z","text":"Deployed v2.4","tags":["deploy","production"]}
+{"time":"2026-07-23T15:10:00Z","text":"Rolled back v2.4","tags":["rollback","production"]}
+{"time":"2026-07-23T15:40:00Z","text":"Incident resolved","tags":["incident","production"]}

--- a/src/annotations/details.rs
+++ b/src/annotations/details.rs
@@ -1,0 +1,198 @@
+use super::{AnnotationCluster, AnnotationEvent};
+
+const ELLIPSIS: char = '…';
+
+pub(crate) fn format_cluster_detail_lines(
+    cluster: &AnnotationCluster<'_>,
+    character_budget: usize,
+) -> [String; 2] {
+    let Some(first) = cluster.events.first() else {
+        return [String::new(), String::new()];
+    };
+    let heading = if cluster.events.len() == 1 {
+        format_event_time(first)
+    } else {
+        format!(
+            "{} events near {}",
+            cluster.events.len(),
+            first.time.format("%Y-%m-%d %H:%M:%S UTC")
+        )
+    };
+
+    [
+        bounded_text(&heading, character_budget),
+        format_event_details(cluster, character_budget),
+    ]
+}
+
+fn format_event_time(event: &AnnotationEvent) -> String {
+    if event.time.timestamp_subsec_millis() == 0 {
+        event.time.format("%Y-%m-%d %H:%M:%S UTC").to_string()
+    } else {
+        event.time.format("%Y-%m-%d %H:%M:%S%.3f UTC").to_string()
+    }
+}
+
+fn format_event_details(cluster: &AnnotationCluster<'_>, character_budget: usize) -> String {
+    let mut output = BoundedText::new(character_budget);
+    for (event_index, event) in cluster.events.iter().enumerate() {
+        if event_index > 0 && !output.push_str(" · ") {
+            break;
+        }
+        if !output.push_str(&event.text) {
+            break;
+        }
+        if event.tags.is_empty() {
+            continue;
+        }
+        if !output.push_str(" [") {
+            break;
+        }
+        for (tag_index, tag) in event.tags.iter().enumerate() {
+            if tag_index > 0 && !output.push_str(", ") {
+                return output.finish();
+            }
+            if !output.push_str(tag) {
+                return output.finish();
+            }
+        }
+        if !output.push_str("]") {
+            break;
+        }
+    }
+    output.finish()
+}
+
+fn bounded_text(value: &str, character_budget: usize) -> String {
+    let mut output = BoundedText::new(character_budget);
+    output.push_str(value);
+    output.finish()
+}
+
+struct BoundedText {
+    value: String,
+    characters: usize,
+    budget: usize,
+    omitted: bool,
+}
+
+impl BoundedText {
+    fn new(budget: usize) -> Self {
+        Self {
+            value: String::new(),
+            characters: 0,
+            budget,
+            omitted: false,
+        }
+    }
+
+    fn push_str(&mut self, value: &str) -> bool {
+        if self.omitted {
+            return false;
+        }
+        for character in value.chars() {
+            if self.characters == self.budget {
+                self.mark_omitted();
+                return false;
+            }
+            self.value.push(character);
+            self.characters += 1;
+        }
+        true
+    }
+
+    fn mark_omitted(&mut self) {
+        if self.omitted || self.budget == 0 {
+            return;
+        }
+        if self.characters == self.budget {
+            self.value.pop();
+            self.characters -= 1;
+        }
+        self.value.push(ELLIPSIS);
+        self.characters += 1;
+        self.omitted = true;
+    }
+
+    fn finish(self) -> String {
+        self.value
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::annotations::{AnnotationEvent, AnnotationTarget};
+
+    fn event(time: &str, text: &str, tags: &[&str]) -> AnnotationEvent {
+        AnnotationEvent {
+            time: chrono::DateTime::parse_from_rfc3339(time)
+                .unwrap()
+                .with_timezone(&chrono::Utc),
+            text: text.to_string(),
+            tags: tags.iter().map(|tag| (*tag).to_string()).collect(),
+            target: AnnotationTarget::All,
+        }
+    }
+
+    #[test]
+    fn preserves_precise_single_event_details_when_they_fit() {
+        let events = [event(
+            "2026-07-23T14:30:00.125Z",
+            "deploy",
+            &["prod", "api"],
+        )];
+        let cluster = AnnotationCluster {
+            coordinate: 4,
+            events: events.iter().collect(),
+        };
+
+        let lines = format_cluster_detail_lines(&cluster, 80);
+
+        assert_eq!(lines[0], "2026-07-23 14:30:00.125 UTC");
+        assert_eq!(lines[1], "deploy [prod, api]");
+    }
+
+    #[test]
+    fn preserves_cluster_order_and_tags_when_they_fit() {
+        let events = [
+            event("2026-07-23T14:30:00Z", "deploy", &["prod"]),
+            event("2026-07-23T14:30:01Z", "rollback", &[]),
+        ];
+        let cluster = AnnotationCluster {
+            coordinate: 4,
+            events: events.iter().collect(),
+        };
+
+        let lines = format_cluster_detail_lines(&cluster, 80);
+
+        assert_eq!(lines[0], "2 events near 2026-07-23 14:30:00 UTC");
+        assert_eq!(lines[1], "deploy [prod] · rollback");
+    }
+
+    #[test]
+    fn bounds_large_clusters_without_losing_exact_count_or_order() {
+        let events = (0..100)
+            .map(|index| {
+                event(
+                    "2026-07-23T14:30:00Z",
+                    &format!("event-{index:03}-{}", "x".repeat(80)),
+                    &[],
+                )
+            })
+            .collect::<Vec<_>>();
+        let cluster = AnnotationCluster {
+            coordinate: 4,
+            events: events.iter().collect(),
+        };
+
+        let lines = format_cluster_detail_lines(&cluster, 36);
+
+        assert!(lines[0].starts_with("100 events near"));
+        assert!(lines[0].ends_with(ELLIPSIS));
+        assert!(lines[1].starts_with("event-000-"));
+        assert!(lines[1].ends_with(ELLIPSIS));
+        assert!(!lines[1].contains("event-001-"));
+        assert!(lines.iter().all(|line| line.chars().count() <= 36));
+    }
+}

--- a/src/annotations/jsonl.rs
+++ b/src/annotations/jsonl.rs
@@ -1,0 +1,163 @@
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+
+use super::{AnnotationEvent, AnnotationSnapshot, AnnotationTarget};
+
+#[derive(Deserialize)]
+struct RawAnnotationEvent {
+    time: String,
+    text: String,
+    #[serde(default)]
+    tags: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AnnotationLoadError {
+    path: PathBuf,
+    line: Option<usize>,
+    reason: String,
+}
+
+impl AnnotationLoadError {
+    pub(crate) fn line(&self) -> Option<usize> {
+        self.line
+    }
+
+    fn at_line(path: &Path, line: usize, reason: impl Into<String>) -> Self {
+        Self {
+            path: path.to_path_buf(),
+            line: Some(line),
+            reason: reason.into(),
+        }
+    }
+}
+
+impl fmt::Display for AnnotationLoadError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.line {
+            Some(line) => write!(formatter, "{}:{line}: {}", self.path.display(), self.reason),
+            None => write!(formatter, "{}: {}", self.path.display(), self.reason),
+        }
+    }
+}
+
+impl std::error::Error for AnnotationLoadError {}
+
+pub(crate) fn parse_jsonl(
+    path: &Path,
+    input: &str,
+) -> Result<AnnotationSnapshot, AnnotationLoadError> {
+    let mut events = Vec::new();
+
+    for (index, line) in input.lines().enumerate() {
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        let line_number = index + 1;
+        let raw: RawAnnotationEvent = serde_json::from_str(line).map_err(|error| {
+            AnnotationLoadError::at_line(
+                path,
+                line_number,
+                format!(
+                    "invalid annotation event (time, text, and tags must have valid types): {error}"
+                ),
+            )
+        })?;
+        let time = DateTime::parse_from_rfc3339(&raw.time)
+            .map_err(|error| {
+                AnnotationLoadError::at_line(
+                    path,
+                    line_number,
+                    format!("time must be an RFC 3339 timestamp: {error}"),
+                )
+            })?
+            .with_timezone(&Utc);
+
+        if raw.text.trim().is_empty() {
+            return Err(AnnotationLoadError::at_line(
+                path,
+                line_number,
+                "text must not be empty",
+            ));
+        }
+        if raw.tags.iter().any(|tag| tag.trim().is_empty()) {
+            return Err(AnnotationLoadError::at_line(
+                path,
+                line_number,
+                "tags must not contain empty strings",
+            ));
+        }
+
+        events.push(AnnotationEvent {
+            time,
+            text: raw.text,
+            tags: raw.tags,
+            target: AnnotationTarget::All,
+        });
+    }
+
+    Ok(AnnotationSnapshot::new(events))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::parse_jsonl;
+
+    #[test]
+    fn parses_valid_jsonl_and_ignores_blank_lines_and_unknown_fields() {
+        let input = concat!(
+            "\n",
+            r#"{"time":"2026-07-23T14:30:00+02:00","text":"deploy","tags":["prod"],"extra":1}"#,
+            "\n",
+            r#"{"time":"2026-07-23T13:00:00Z","text":"rollback"}"#,
+            "\n",
+        );
+
+        let snapshot = parse_jsonl(Path::new("events.jsonl"), input).unwrap();
+
+        assert_eq!(snapshot.len(), 2);
+        assert_eq!(snapshot.events()[0].text, "deploy");
+        assert_eq!(snapshot.events()[0].tags, vec!["prod"]);
+        assert_eq!(snapshot.events()[1].tags, Vec::<String>::new());
+    }
+
+    #[test]
+    fn rejects_invalid_required_fields_with_line_number() {
+        let error = parse_jsonl(
+            Path::new("events.jsonl"),
+            "{\"time\":1700000000000,\"text\":\"deploy\"}\n",
+        )
+        .unwrap_err();
+
+        assert_eq!(error.line(), Some(1));
+        assert!(error.to_string().contains("events.jsonl:1"));
+        assert!(error.to_string().contains("time"));
+    }
+
+    #[test]
+    fn rejects_blank_text_and_tags() {
+        let blank_text = parse_jsonl(
+            Path::new("events.jsonl"),
+            r#"{"time":"2026-07-23T14:30:00Z","text":"  "}"#,
+        )
+        .unwrap_err();
+        assert!(blank_text.to_string().contains("text must not be empty"));
+
+        let blank_tag = parse_jsonl(
+            Path::new("events.jsonl"),
+            r#"{"time":"2026-07-23T14:30:00Z","text":"deploy","tags":[""]}"#,
+        )
+        .unwrap_err();
+        assert!(
+            blank_tag
+                .to_string()
+                .contains("tags must not contain empty strings")
+        );
+    }
+}

--- a/src/annotations/jsonl.rs
+++ b/src/annotations/jsonl.rs
@@ -22,6 +22,7 @@ pub(crate) struct AnnotationLoadError {
 }
 
 impl AnnotationLoadError {
+    #[cfg(test)]
     pub(crate) fn line(&self) -> Option<usize> {
         self.line
     }

--- a/src/annotations/jsonl.rs
+++ b/src/annotations/jsonl.rs
@@ -103,11 +103,99 @@ pub(crate) fn parse_jsonl(
     Ok(AnnotationSnapshot::new(events))
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum SourceFingerprint {
+    Missing,
+    Present {
+        len: u64,
+        modified: std::time::SystemTime,
+    },
+}
+
+#[derive(Debug)]
+pub(crate) enum SourcePoll {
+    Unchanged,
+    Loaded(AnnotationSnapshot),
+    Failed(AnnotationLoadError),
+}
+
+#[derive(Debug)]
+pub(crate) struct JsonlFileSource {
+    path: PathBuf,
+    last_seen: Option<SourceFingerprint>,
+}
+
+impl JsonlFileSource {
+    pub(crate) fn new(path: PathBuf) -> Self {
+        Self {
+            path,
+            last_seen: None,
+        }
+    }
+
+    pub(crate) async fn poll(&mut self) -> SourcePoll {
+        let fingerprint = match tokio::fs::metadata(&self.path).await {
+            Ok(metadata) => match metadata.modified() {
+                Ok(modified) => SourceFingerprint::Present {
+                    len: metadata.len(),
+                    modified,
+                },
+                Err(error) => return SourcePoll::Failed(self.io_error(error)),
+            },
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                SourceFingerprint::Missing
+            }
+            Err(error) => return SourcePoll::Failed(self.io_error(error)),
+        };
+
+        if self.last_seen.as_ref() == Some(&fingerprint) {
+            return SourcePoll::Unchanged;
+        }
+        self.last_seen = Some(fingerprint.clone());
+
+        match fingerprint {
+            SourceFingerprint::Missing => SourcePoll::Failed(AnnotationLoadError {
+                path: self.path.clone(),
+                line: None,
+                reason: "annotation file does not exist".to_string(),
+            }),
+            SourceFingerprint::Present { .. } => {
+                match tokio::fs::read_to_string(&self.path).await {
+                    Ok(input) => match parse_jsonl(&self.path, &input) {
+                        Ok(snapshot) => SourcePoll::Loaded(snapshot),
+                        Err(error) => SourcePoll::Failed(error),
+                    },
+                    Err(error) => SourcePoll::Failed(self.io_error(error)),
+                }
+            }
+        }
+    }
+
+    fn io_error(&self, error: std::io::Error) -> AnnotationLoadError {
+        AnnotationLoadError {
+            path: self.path.clone(),
+            line: None,
+            reason: format!("could not read annotation file: {error}"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
 
-    use super::parse_jsonl;
+    use super::{JsonlFileSource, SourcePoll, parse_jsonl};
+
+    fn temp_path(name: &str) -> PathBuf {
+        let suffix = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "grafatui-annotations-{name}-{}-{suffix}.jsonl",
+            std::process::id()
+        ))
+    }
 
     #[test]
     fn parses_valid_jsonl_and_ignores_blank_lines_and_unknown_fields() {
@@ -159,5 +247,62 @@ mod tests {
                 .to_string()
                 .contains("tags must not contain empty strings")
         );
+    }
+
+    #[tokio::test]
+    async fn loads_only_after_metadata_changes() {
+        let path = temp_path("changed");
+        tokio::fs::write(
+            &path,
+            "{\"time\":\"2026-07-23T14:30:00Z\",\"text\":\"deploy\"}\n",
+        )
+        .await
+        .unwrap();
+        let mut source = JsonlFileSource::new(path.clone());
+
+        assert!(matches!(source.poll().await, SourcePoll::Loaded(snapshot) if snapshot.len() == 1));
+        assert!(matches!(source.poll().await, SourcePoll::Unchanged));
+
+        tokio::fs::write(&path, "").await.unwrap();
+        assert!(matches!(source.poll().await, SourcePoll::Loaded(snapshot) if snapshot.len() == 0));
+
+        tokio::fs::remove_file(path).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn reports_missing_then_loads_when_file_appears() {
+        let path = temp_path("appears");
+        let mut source = JsonlFileSource::new(path.clone());
+
+        assert!(matches!(source.poll().await, SourcePoll::Failed(_)));
+        assert!(matches!(source.poll().await, SourcePoll::Unchanged));
+
+        tokio::fs::write(
+            &path,
+            "{\"time\":\"2026-07-23T14:30:00Z\",\"text\":\"deploy\"}\n",
+        )
+        .await
+        .unwrap();
+        assert!(matches!(source.poll().await, SourcePoll::Loaded(snapshot) if snapshot.len() == 1));
+
+        tokio::fs::remove_file(path).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn invalid_replacement_is_reported_as_failed() {
+        let path = temp_path("invalid");
+        tokio::fs::write(
+            &path,
+            "{\"time\":\"2026-07-23T14:30:00Z\",\"text\":\"deploy\"}\n",
+        )
+        .await
+        .unwrap();
+        let mut source = JsonlFileSource::new(path.clone());
+        assert!(matches!(source.poll().await, SourcePoll::Loaded(_)));
+
+        tokio::fs::write(&path, "{\"time\":").await.unwrap();
+        assert!(matches!(source.poll().await, SourcePoll::Failed(_)));
+
+        tokio::fs::remove_file(path).await.unwrap();
     }
 }

--- a/src/annotations/jsonl.rs
+++ b/src/annotations/jsonl.rs
@@ -152,20 +152,25 @@ impl JsonlFileSource {
         if self.last_seen.as_ref() == Some(&fingerprint) {
             return SourcePoll::Unchanged;
         }
-        self.last_seen = Some(fingerprint.clone());
 
         match fingerprint {
-            SourceFingerprint::Missing => SourcePoll::Failed(AnnotationLoadError {
-                path: self.path.clone(),
-                line: None,
-                reason: "annotation file does not exist".to_string(),
-            }),
-            SourceFingerprint::Present { .. } => {
+            SourceFingerprint::Missing => {
+                self.last_seen = Some(SourceFingerprint::Missing);
+                SourcePoll::Failed(AnnotationLoadError {
+                    path: self.path.clone(),
+                    line: None,
+                    reason: "annotation file does not exist".to_string(),
+                })
+            }
+            SourceFingerprint::Present { len, modified } => {
                 match tokio::fs::read_to_string(&self.path).await {
-                    Ok(input) => match parse_jsonl(&self.path, &input) {
-                        Ok(snapshot) => SourcePoll::Loaded(snapshot),
-                        Err(error) => SourcePoll::Failed(error),
-                    },
+                    Ok(input) => {
+                        self.last_seen = Some(SourceFingerprint::Present { len, modified });
+                        match parse_jsonl(&self.path, &input) {
+                            Ok(snapshot) => SourcePoll::Loaded(snapshot),
+                            Err(error) => SourcePoll::Failed(error),
+                        }
+                    }
                     Err(error) => SourcePoll::Failed(self.io_error(error)),
                 }
             }
@@ -303,6 +308,45 @@ mod tests {
 
         tokio::fs::write(&path, "{\"time\":").await.unwrap();
         assert!(matches!(source.poll().await, SourcePoll::Failed(_)));
+        assert!(matches!(source.poll().await, SourcePoll::Unchanged));
+
+        tokio::fs::remove_file(path).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn retries_read_failure_when_metadata_fingerprint_is_unchanged() {
+        let path = temp_path("read-retry");
+        let valid = b"{\"time\":\"2026-07-23T14:30:00Z\",\"text\":\"deploy\"}\n";
+        let mut invalid_utf8 = valid.to_vec();
+        let text_start = invalid_utf8
+            .windows(b"deploy".len())
+            .position(|window| window == b"deploy")
+            .unwrap();
+        invalid_utf8[text_start] = 0xff;
+        tokio::fs::write(&path, invalid_utf8).await.unwrap();
+        let initial_metadata = tokio::fs::metadata(&path).await.unwrap();
+        let initial_modified = initial_metadata.modified().unwrap();
+        let mut source = JsonlFileSource::new(path.clone());
+
+        assert!(
+            matches!(source.poll().await, SourcePoll::Failed(error) if error.to_string().contains("could not read annotation file"))
+        );
+
+        tokio::fs::write(&path, valid).await.unwrap();
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(&path)
+            .unwrap()
+            .set_modified(initial_modified)
+            .unwrap();
+        let recovered_metadata = tokio::fs::metadata(&path).await.unwrap();
+        assert_eq!(recovered_metadata.len(), initial_metadata.len());
+        assert_eq!(recovered_metadata.modified().unwrap(), initial_modified);
+
+        assert!(matches!(
+            source.poll().await,
+            SourcePoll::Loaded(snapshot) if snapshot.len() == 1
+        ));
 
         tokio::fs::remove_file(path).await.unwrap();
     }

--- a/src/annotations/mod.rs
+++ b/src/annotations/mod.rs
@@ -1,0 +1,20 @@
+mod jsonl;
+mod model;
+mod projection;
+
+pub(crate) use jsonl::{AnnotationLoadError, parse_jsonl};
+pub(crate) use model::{
+    AnnotationEvent, AnnotationPanelContext, AnnotationSnapshot, AnnotationTarget,
+};
+pub(crate) use projection::{AnnotationCluster, cluster_events_by, events_for_panel};
+
+#[cfg(test)]
+pub(crate) fn test_event_at(timestamp_secs: f64, text: &str) -> AnnotationEvent {
+    let millis = (timestamp_secs * 1_000.0).round() as i64;
+    AnnotationEvent {
+        time: chrono::DateTime::<chrono::Utc>::from_timestamp_millis(millis).unwrap(),
+        text: text.to_string(),
+        tags: Vec::new(),
+        target: AnnotationTarget::All,
+    }
+}

--- a/src/annotations/mod.rs
+++ b/src/annotations/mod.rs
@@ -1,9 +1,11 @@
 use std::path::PathBuf;
 
+mod details;
 mod jsonl;
 mod model;
 mod projection;
 
+pub(crate) use details::format_cluster_detail_lines;
 pub(crate) use jsonl::{JsonlFileSource, SourcePoll};
 pub(crate) use model::{
     AnnotationEvent, AnnotationPanelContext, AnnotationSnapshot, AnnotationTarget,

--- a/src/annotations/mod.rs
+++ b/src/annotations/mod.rs
@@ -1,12 +1,146 @@
+use std::path::PathBuf;
+
 mod jsonl;
 mod model;
 mod projection;
 
-pub(crate) use jsonl::{AnnotationLoadError, parse_jsonl};
+pub(crate) use jsonl::{AnnotationLoadError, JsonlFileSource, SourcePoll, parse_jsonl};
 pub(crate) use model::{
     AnnotationEvent, AnnotationPanelContext, AnnotationSnapshot, AnnotationTarget,
 };
 pub(crate) use projection::{AnnotationCluster, cluster_events_by, events_for_panel};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum AnnotationSourceStatus {
+    Disabled,
+    Loaded(usize),
+    Warning(String),
+}
+
+#[derive(Debug)]
+pub(crate) enum AnnotationState {
+    Disabled,
+    Active {
+        source: Option<JsonlFileSource>,
+        snapshot: AnnotationSnapshot,
+        visible: bool,
+        status: AnnotationSourceStatus,
+    },
+}
+
+impl AnnotationState {
+    pub(crate) fn from_path(path: Option<PathBuf>) -> Self {
+        match path {
+            Some(path) => Self::Active {
+                source: Some(JsonlFileSource::new(path)),
+                snapshot: AnnotationSnapshot::new(Vec::new()),
+                visible: true,
+                status: AnnotationSourceStatus::Loaded(0),
+            },
+            None => Self::Disabled,
+        }
+    }
+
+    pub(crate) async fn refresh_if_changed(&mut self) {
+        let poll = match self {
+            Self::Active {
+                source: Some(source),
+                ..
+            } => source.poll().await,
+            Self::Disabled | Self::Active { source: None, .. } => return,
+        };
+
+        match (self, poll) {
+            (
+                Self::Active {
+                    snapshot, status, ..
+                },
+                SourcePoll::Loaded(next_snapshot),
+            ) => {
+                *snapshot = next_snapshot;
+                *status = AnnotationSourceStatus::Loaded(snapshot.len());
+            }
+            (
+                Self::Active {
+                    snapshot, status, ..
+                },
+                SourcePoll::Failed(error),
+            ) => {
+                *status = AnnotationSourceStatus::Warning(format!(
+                    "{error}; using {} previous event(s)",
+                    snapshot.len()
+                ));
+            }
+            (_, SourcePoll::Unchanged) => {}
+            (Self::Disabled, _) => {}
+        }
+    }
+
+    pub(crate) fn snapshot(&self) -> Option<&AnnotationSnapshot> {
+        match self {
+            Self::Disabled => None,
+            Self::Active { snapshot, .. } => Some(snapshot),
+        }
+    }
+
+    pub(crate) fn status(&self) -> AnnotationSourceStatus {
+        match self {
+            Self::Disabled => AnnotationSourceStatus::Disabled,
+            Self::Active { status, .. } => status.clone(),
+        }
+    }
+
+    pub(crate) fn warning(&self) -> Option<&str> {
+        match self {
+            Self::Active {
+                status: AnnotationSourceStatus::Warning(warning),
+                ..
+            } => Some(warning),
+            Self::Disabled | Self::Active { .. } => None,
+        }
+    }
+
+    pub(crate) fn is_configured(&self) -> bool {
+        matches!(self, Self::Active { .. })
+    }
+
+    pub(crate) fn is_visible(&self) -> bool {
+        matches!(self, Self::Active { visible: true, .. })
+    }
+
+    pub(crate) fn toggle_visibility(&mut self) {
+        if let Self::Active { visible, .. } = self {
+            *visible = !*visible;
+        }
+    }
+
+    pub(crate) fn events_for_panel(
+        &self,
+        panel: AnnotationPanelContext<'_>,
+        bounds: [f64; 2],
+    ) -> Vec<&AnnotationEvent> {
+        match self {
+            Self::Active {
+                snapshot,
+                visible: true,
+                ..
+            } => projection::events_for_panel(snapshot, panel, bounds),
+            Self::Disabled | Self::Active { .. } => Vec::new(),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_events_for_test(events: Vec<AnnotationEvent>) -> Self {
+        let snapshot = AnnotationSnapshot::new(events);
+        let event_count = snapshot.len();
+        Self::Active {
+            source: None,
+            snapshot,
+            visible: true,
+            status: AnnotationSourceStatus::Loaded(event_count),
+        }
+    }
+}
 
 #[cfg(test)]
 pub(crate) fn test_event_at(timestamp_secs: f64, text: &str) -> AnnotationEvent {
@@ -16,5 +150,84 @@ pub(crate) fn test_event_at(timestamp_secs: f64, text: &str) -> AnnotationEvent 
         text: text.to_string(),
         tags: Vec::new(),
         target: AnnotationTarget::All,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::{AnnotationSourceStatus, AnnotationState};
+
+    fn temp_path(name: &str) -> PathBuf {
+        let suffix = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "grafatui-annotations-{name}-{}-{suffix}.jsonl",
+            std::process::id()
+        ))
+    }
+
+    #[tokio::test]
+    async fn state_retains_last_valid_snapshot_and_clears_warning_on_recovery() {
+        let path = temp_path("state-recovery");
+        tokio::fs::write(
+            &path,
+            "{\"time\":\"2026-07-23T14:30:00Z\",\"text\":\"deploy\"}\n",
+        )
+        .await
+        .unwrap();
+        let mut state = AnnotationState::from_path(Some(path.clone()));
+
+        state.refresh_if_changed().await;
+        assert_eq!(state.snapshot().unwrap().len(), 1);
+        assert!(state.warning().is_none());
+
+        tokio::fs::write(&path, "{\"time\":").await.unwrap();
+        state.refresh_if_changed().await;
+        assert_eq!(state.snapshot().unwrap().len(), 1);
+        assert!(state.warning().unwrap().contains("using 1 previous event"));
+
+        tokio::fs::write(&path, "").await.unwrap();
+        state.refresh_if_changed().await;
+        assert_eq!(state.snapshot().unwrap().len(), 0);
+        assert!(state.warning().is_none());
+
+        tokio::fs::remove_file(path).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn state_keeps_reloading_while_hidden_and_retains_snapshot_if_removed() {
+        let path = temp_path("state-hidden");
+        tokio::fs::write(
+            &path,
+            "{\"time\":\"2026-07-23T14:30:00Z\",\"text\":\"deploy\"}\n",
+        )
+        .await
+        .unwrap();
+        let mut state = AnnotationState::from_path(Some(path.clone()));
+        state.toggle_visibility();
+
+        state.refresh_if_changed().await;
+        assert_eq!(state.snapshot().unwrap().len(), 1);
+        assert!(!state.is_visible());
+
+        tokio::fs::remove_file(&path).await.unwrap();
+        state.refresh_if_changed().await;
+        assert_eq!(state.snapshot().unwrap().len(), 1);
+        assert!(state.warning().unwrap().contains("using 1 previous event"));
+    }
+
+    #[test]
+    fn disabled_state_has_no_source_work_or_visibility() {
+        let mut state = AnnotationState::from_path(None);
+        assert!(!state.is_configured());
+        assert!(!state.is_visible());
+        assert!(state.snapshot().is_none());
+        assert_eq!(state.status(), AnnotationSourceStatus::Disabled);
+        state.toggle_visibility();
+        assert!(!state.is_visible());
     }
 }

--- a/src/annotations/mod.rs
+++ b/src/annotations/mod.rs
@@ -140,6 +140,16 @@ impl AnnotationState {
             status: AnnotationSourceStatus::Loaded(event_count),
         }
     }
+
+    #[cfg(test)]
+    pub(crate) fn warning_for_test(message: &str) -> Self {
+        Self::Active {
+            source: None,
+            snapshot: AnnotationSnapshot::new(Vec::new()),
+            visible: true,
+            status: AnnotationSourceStatus::Warning(message.to_string()),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/annotations/mod.rs
+++ b/src/annotations/mod.rs
@@ -4,14 +4,15 @@ mod jsonl;
 mod model;
 mod projection;
 
-pub(crate) use jsonl::{AnnotationLoadError, JsonlFileSource, SourcePoll, parse_jsonl};
+pub(crate) use jsonl::{JsonlFileSource, SourcePoll};
 pub(crate) use model::{
     AnnotationEvent, AnnotationPanelContext, AnnotationSnapshot, AnnotationTarget,
 };
-pub(crate) use projection::{AnnotationCluster, cluster_events_by, events_for_panel};
+pub(crate) use projection::{AnnotationCluster, cluster_events_by};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum AnnotationSourceStatus {
+    #[cfg(test)]
     Disabled,
     Loaded(usize),
     Warning(String),
@@ -76,6 +77,7 @@ impl AnnotationState {
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn snapshot(&self) -> Option<&AnnotationSnapshot> {
         match self {
             Self::Disabled => None,
@@ -83,6 +85,7 @@ impl AnnotationState {
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn status(&self) -> AnnotationSourceStatus {
         match self {
             Self::Disabled => AnnotationSourceStatus::Disabled,
@@ -100,10 +103,12 @@ impl AnnotationState {
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn is_configured(&self) -> bool {
         matches!(self, Self::Active { .. })
     }
 
+    #[cfg(test)]
     pub(crate) fn is_visible(&self) -> bool {
         matches!(self, Self::Active { visible: true, .. })
     }

--- a/src/annotations/model.rs
+++ b/src/annotations/model.rs
@@ -15,7 +15,8 @@ pub(crate) struct AnnotationEvent {
 
 impl AnnotationEvent {
     pub(crate) fn timestamp_secs(&self) -> f64 {
-        self.time.timestamp_millis() as f64 / 1000.0
+        self.time.timestamp() as f64
+            + f64::from(self.time.timestamp_subsec_nanos()) / 1_000_000_000.0
     }
 }
 
@@ -82,5 +83,13 @@ mod tests {
             .collect();
 
         assert_eq!(texts, vec!["earlier", "first", "second"]);
+    }
+
+    #[test]
+    fn timestamp_secs_preserves_fraction_beyond_milliseconds() {
+        let event = event("2026-07-23T14:30:00.123456789Z", "deploy");
+        let expected = event.time.timestamp() as f64 + 0.123_456_789;
+
+        assert!((event.timestamp_secs() - expected).abs() < 1e-7);
     }
 }

--- a/src/annotations/model.rs
+++ b/src/annotations/model.rs
@@ -1,0 +1,86 @@
+use chrono::{DateTime, Utc};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum AnnotationTarget {
+    All,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AnnotationEvent {
+    pub(crate) time: DateTime<Utc>,
+    pub(crate) text: String,
+    pub(crate) tags: Vec<String>,
+    pub(crate) target: AnnotationTarget,
+}
+
+impl AnnotationEvent {
+    pub(crate) fn timestamp_secs(&self) -> f64 {
+        self.time.timestamp_millis() as f64 / 1000.0
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct AnnotationSnapshot {
+    events: Vec<AnnotationEvent>,
+}
+
+impl AnnotationSnapshot {
+    pub(crate) fn new(mut events: Vec<AnnotationEvent>) -> Self {
+        events.sort_by_key(|event| event.time);
+        Self { events }
+    }
+
+    pub(crate) fn events(&self) -> &[AnnotationEvent] {
+        &self.events
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.events.len()
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct AnnotationPanelContext<'a> {
+    pub(crate) title: &'a str,
+}
+
+impl AnnotationTarget {
+    pub(crate) fn applies_to(&self, panel: AnnotationPanelContext<'_>) -> bool {
+        let _ = panel.title;
+        matches!(self, Self::All)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::{DateTime, Utc};
+
+    use super::{AnnotationEvent, AnnotationSnapshot, AnnotationTarget};
+
+    fn event(time: &str, text: &str) -> AnnotationEvent {
+        AnnotationEvent {
+            time: DateTime::parse_from_rfc3339(time)
+                .unwrap()
+                .with_timezone(&Utc),
+            text: text.to_string(),
+            tags: Vec::new(),
+            target: AnnotationTarget::All,
+        }
+    }
+
+    #[test]
+    fn snapshot_sorts_events_stably() {
+        let first = event("2026-07-23T14:30:00Z", "first");
+        let earlier = event("2026-07-23T14:00:00Z", "earlier");
+        let second = event("2026-07-23T14:30:00Z", "second");
+
+        let snapshot = AnnotationSnapshot::new(vec![first, earlier, second]);
+        let texts: Vec<_> = snapshot
+            .events()
+            .iter()
+            .map(|event| event.text.as_str())
+            .collect();
+
+        assert_eq!(texts, vec!["earlier", "first", "second"]);
+    }
+}

--- a/src/annotations/projection.rs
+++ b/src/annotations/projection.rs
@@ -1,0 +1,103 @@
+use std::collections::BTreeMap;
+
+use super::{AnnotationEvent, AnnotationPanelContext, AnnotationSnapshot};
+
+#[derive(Debug)]
+pub(crate) struct AnnotationCluster<'a> {
+    pub(crate) coordinate: u32,
+    pub(crate) events: Vec<&'a AnnotationEvent>,
+}
+
+pub(crate) fn events_for_panel<'a>(
+    snapshot: &'a AnnotationSnapshot,
+    panel: AnnotationPanelContext<'_>,
+    bounds: [f64; 2],
+) -> Vec<&'a AnnotationEvent> {
+    snapshot
+        .events()
+        .iter()
+        .filter(|event| {
+            let timestamp = event.timestamp_secs();
+            timestamp >= bounds[0] && timestamp <= bounds[1] && event.target.applies_to(panel)
+        })
+        .collect()
+}
+
+pub(crate) fn cluster_events_by<'a>(
+    events: impl IntoIterator<Item = &'a AnnotationEvent>,
+    mut project: impl FnMut(f64) -> Option<u32>,
+) -> Vec<AnnotationCluster<'a>> {
+    let mut grouped: BTreeMap<u32, Vec<&'a AnnotationEvent>> = BTreeMap::new();
+    for event in events {
+        if let Some(coordinate) = project(event.timestamp_secs()) {
+            grouped.entry(coordinate).or_default().push(event);
+        }
+    }
+    grouped
+        .into_iter()
+        .map(|(coordinate, events)| AnnotationCluster { coordinate, events })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{cluster_events_by, events_for_panel};
+    use crate::annotations::{AnnotationEvent, AnnotationPanelContext, AnnotationSnapshot};
+
+    fn event(timestamp: f64, text: &str) -> AnnotationEvent {
+        crate::annotations::test_event_at(timestamp, text)
+    }
+
+    #[test]
+    fn routes_all_targets_and_filters_inclusive_time_bounds() {
+        let snapshot = AnnotationSnapshot::new(vec![
+            event(0.0, "start"),
+            event(50.0, "middle"),
+            event(100.0, "end"),
+            event(101.0, "outside"),
+        ]);
+
+        let events = events_for_panel(
+            &snapshot,
+            AnnotationPanelContext { title: "CPU" },
+            [0.0, 100.0],
+        );
+
+        assert_eq!(
+            events
+                .iter()
+                .map(|event| event.text.as_str())
+                .collect::<Vec<_>>(),
+            vec!["start", "middle", "end"]
+        );
+    }
+
+    #[test]
+    fn clusters_events_by_projected_coordinate_in_order() {
+        let snapshot = AnnotationSnapshot::new(vec![
+            event(10.0, "one"),
+            event(11.0, "two"),
+            event(90.0, "three"),
+        ]);
+        let events = events_for_panel(
+            &snapshot,
+            AnnotationPanelContext { title: "CPU" },
+            [0.0, 100.0],
+        );
+
+        let clusters = cluster_events_by(events, |timestamp| {
+            Some(if timestamp < 50.0 { 4 } else { 9 })
+        });
+
+        assert_eq!(clusters.len(), 2);
+        assert_eq!(clusters[0].coordinate, 4);
+        assert_eq!(
+            clusters[0]
+                .events
+                .iter()
+                .map(|event| event.text.as_str())
+                .collect::<Vec<_>>(),
+            vec!["one", "two"]
+        );
+    }
+}

--- a/src/app/data.rs
+++ b/src/app/data.rs
@@ -74,11 +74,11 @@ fn format_prom_duration(duration: Duration) -> String {
     const HOUR: u64 = 60 * 60;
     const MINUTE: u64 = 60;
 
-    if secs % DAY == 0 {
+    if secs.is_multiple_of(DAY) {
         format!("{}d", secs / DAY)
-    } else if secs % HOUR == 0 {
+    } else if secs.is_multiple_of(HOUR) {
         format!("{}h", secs / HOUR)
-    } else if secs % MINUTE == 0 {
+    } else if secs.is_multiple_of(MINUTE) {
         format!("{}m", secs / MINUTE)
     } else {
         format!("{}s", secs)

--- a/src/app/event_loop.rs
+++ b/src/app/event_loop.rs
@@ -196,6 +196,29 @@ mod tests {
     }
 
     #[test]
+    fn test_capture_recording_after_annotation_change_writes_frame() {
+        let dir = test_export_dir("annotation-recording");
+        let export = ExportOptions {
+            dir: dir.clone(),
+            format: ExportFormat::Svg,
+            record_max_frames: 10,
+        };
+        let mut app = test_app(export);
+        let backend = TestBackend::new(100, 40);
+        let terminal = Terminal::new(backend).unwrap();
+
+        export::toggle_recording(&mut app, Rect::new(0, 0, 100, 40)).unwrap();
+        app.annotations = crate::annotations::AnnotationState::from_events_for_test(vec![
+            crate::annotations::test_event_at(app.view_end_ts as f64, "deploy"),
+        ]);
+
+        capture_recording_after_change(&terminal, &mut app).unwrap();
+
+        assert_eq!(app.recording.as_ref().unwrap().frame_count, 2);
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
     fn test_finalize_recording_before_quit_writes_manifest() {
         let dir = test_export_dir("quit-recording");
         let export = ExportOptions {

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -43,6 +43,11 @@ pub(super) async fn handle_key(key: KeyEvent, app: &mut AppState) -> Result<Inpu
         return Ok(InputAction::ExportCurrent);
     }
 
+    if key.code == KeyCode::Char('a') && key.modifiers.is_empty() && app.mode != AppMode::Search {
+        app.annotations.toggle_visibility();
+        return Ok(InputAction::Redraw);
+    }
+
     let action = match app.mode {
         AppMode::Search => handle_search_key(key, app),
         AppMode::Inspect => handle_inspect_key(key, app),
@@ -451,6 +456,23 @@ mod tests {
             .unwrap();
         assert_eq!(action, InputAction::ToggleRecording);
         assert_eq!(app.search_query, "e");
+    }
+
+    #[tokio::test]
+    async fn annotations_toggle_in_normal_and_inspect_modes_but_types_in_search() {
+        let mut app = test_app();
+        app.annotations = crate::annotations::AnnotationState::from_events_for_test(vec![]);
+
+        handle_key(key(KeyCode::Char('a')), &mut app).await.unwrap();
+        assert!(!app.annotations.is_visible());
+
+        app.mode = AppMode::Inspect;
+        handle_key(key(KeyCode::Char('a')), &mut app).await.unwrap();
+        assert!(app.annotations.is_visible());
+
+        app.mode = AppMode::Search;
+        handle_key(key(KeyCode::Char('a')), &mut app).await.unwrap();
+        assert_eq!(app.search_query, "a");
     }
 
     #[tokio::test]

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -79,16 +79,11 @@ pub(crate) enum PanelType {
 }
 
 /// Renderer-specific options carried by a generic panel.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub(crate) enum PanelOptions {
+    #[default]
     None,
     Graph(GraphOptions),
-}
-
-impl Default for PanelOptions {
-    fn default() -> Self {
-        Self::None
-    }
 }
 
 /// Graph/timeseries rendering options imported from Grafana.
@@ -411,18 +406,18 @@ impl AppState {
 
     /// Automatically scroll to ensure the selected panel is visible.
     pub(crate) fn scroll_to_selected_panel(&mut self) {
-        if let Some(panel) = self.panels.get(self.selected_panel) {
-            if let Some(grid) = panel.grid {
-                let py = grid.y;
-                let ph = grid.h;
-                let scroll_y = self.vertical_scroll as i32;
-                let visible_height = 20;
+        if let Some(panel) = self.panels.get(self.selected_panel)
+            && let Some(grid) = panel.grid
+        {
+            let py = grid.y;
+            let ph = grid.h;
+            let scroll_y = self.vertical_scroll as i32;
+            let visible_height = 20;
 
-                if py < scroll_y {
-                    self.vertical_scroll = py as usize;
-                } else if py + ph > scroll_y + visible_height {
-                    self.vertical_scroll = (py + ph - visible_height).max(0) as usize;
-                }
+            if py < scroll_y {
+                self.vertical_scroll = py as usize;
+            } else if py + ph > scroll_y + visible_height {
+                self.vertical_scroll = (py + ph - visible_height).max(0) as usize;
             }
         }
     }
@@ -596,10 +591,10 @@ impl AppState {
 
                         let mut pts = Vec::with_capacity(s.values.len());
                         for (ts, val) in s.values {
-                            if let Ok(y) = val.parse::<f64>() {
-                                if y.is_finite() {
-                                    pts.push((ts, y));
-                                }
+                            if let Ok(y) = val.parse::<f64>()
+                                && y.is_finite()
+                            {
+                                pts.push((ts, y));
                             }
                         }
                         panel_results.push(SeriesView {

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -277,6 +277,8 @@ pub(crate) enum AppMode {
 pub(crate) struct AppState {
     /// Prometheus client for making requests.
     pub(crate) prometheus: prom::PromClient,
+    /// Optional external point-event state.
+    pub(crate) annotations: crate::annotations::AnnotationState,
     /// Current time range window.
     pub(crate) range: Duration,
     /// Query step resolution.
@@ -357,6 +359,7 @@ impl AppState {
     ) -> Self {
         Self {
             prometheus,
+            annotations: crate::annotations::AnnotationState::from_path(None),
             range,
             step,
             refresh_every,
@@ -487,6 +490,8 @@ impl AppState {
     }
 
     pub(crate) async fn refresh(&mut self) -> Result<()> {
+        self.annotations.refresh_if_changed().await;
+
         let range = self.range;
         let step = self.step;
 
@@ -625,6 +630,17 @@ impl AppState {
 mod tests {
     use super::*;
 
+    fn temp_annotation_path(name: &str) -> std::path::PathBuf {
+        let suffix = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "grafatui-app-{name}-{}-{suffix}.jsonl",
+            std::process::id()
+        ))
+    }
+
     fn create_test_app() -> AppState {
         AppState::new(
             prom::PromClient::new("http://localhost:9090".to_string()),
@@ -650,6 +666,23 @@ mod tests {
         assert_eq!(app.selected_panel, 0);
 
         app.move_cursor(1);
+    }
+
+    #[tokio::test]
+    async fn refresh_reloads_annotations_without_panels() {
+        let path = temp_annotation_path("app-refresh");
+        std::fs::write(
+            &path,
+            "{\"time\":\"2026-07-23T14:30:00Z\",\"text\":\"deploy\"}\n",
+        )
+        .unwrap();
+        let mut app = create_test_app();
+        app.annotations = crate::annotations::AnnotationState::from_path(Some(path.clone()));
+
+        app.refresh().await.unwrap();
+
+        assert_eq!(app.annotations.snapshot().unwrap().len(), 1);
+        std::fs::remove_file(path).unwrap();
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -41,6 +41,10 @@ pub(crate) struct Args {
     #[arg(long, value_name = "FILE")]
     pub(crate) grafana_json: Option<PathBuf>,
 
+    /// Optional JSONL point-event file to overlay on graph panels.
+    #[arg(long, value_name = "FILE")]
+    pub(crate) annotations_file: Option<PathBuf>,
+
     /// Validate a Grafana dashboard import without starting the TUI
     #[arg(long)]
     pub(crate) validate: bool,
@@ -163,5 +167,11 @@ mod tests {
         assert!(args.validate);
         assert!(args.strict);
         assert_eq!(args.format, crate::cli::ValidateFormat::Json);
+    }
+
+    #[test]
+    fn test_parse_annotations_file() {
+        let args = Args::parse_from(["grafatui", "--annotations-file", "events.jsonl"]);
+        assert_eq!(args.annotations_file, Some(PathBuf::from("events.jsonl")));
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -44,12 +44,12 @@ impl Config {
         let config_path = cli_path
             .map(|p| expand_path(&p))
             .or_else(Self::get_config_path);
-        if let Some(path) = config_path {
-            if path.exists() {
-                let content = fs::read_to_string(path)?;
-                let config: Config = toml::from_str(&content)?;
-                return Ok(config);
-            }
+        if let Some(path) = config_path
+            && path.exists()
+        {
+            let content = fs::read_to_string(path)?;
+            let config: Config = toml::from_str(&content)?;
+            return Ok(config);
         }
         Ok(Config::default())
     }
@@ -78,15 +78,15 @@ impl Config {
 /// Expands a path starting with `~` to the user's home directory.
 pub(crate) fn expand_path(path: &std::path::Path) -> PathBuf {
     let path_str = path.to_string_lossy();
-    if path_str.starts_with("~") {
-        if let Some(dirs) = directories::UserDirs::new() {
-            let home = dirs.home_dir();
-            if path_str == "~" {
-                return home.to_path_buf();
-            }
-            if path_str.starts_with("~/") || path_str.starts_with("~\\") {
-                return home.join(&path_str[2..]);
-            }
+    if path_str.starts_with("~")
+        && let Some(dirs) = directories::UserDirs::new()
+    {
+        let home = dirs.home_dir();
+        if path_str == "~" {
+            return home.to_path_buf();
+        }
+        if path_str.starts_with("~/") || path_str.starts_with("~\\") {
+            return home.join(&path_str[2..]);
         }
     }
     path.to_path_buf()

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,6 +29,7 @@ pub(crate) struct Config {
     pub(crate) step: Option<String>,
     pub(crate) theme: Option<String>,
     pub(crate) grafana_json: Option<PathBuf>,
+    pub(crate) annotations_file: Option<PathBuf>,
     pub(crate) threshold_marker: Option<String>,
     pub(crate) export_dir: Option<PathBuf>,
     pub(crate) export_format: Option<crate::export::ExportFormat>,
@@ -104,6 +105,7 @@ mod tests {
             export_format = "svg"
             autogrid = false
             autogrid_color = "gray"
+            annotations_file = "~/events.jsonl"
         "#;
         let config: Config = toml::from_str(toml_str).unwrap();
         assert_eq!(
@@ -115,6 +117,10 @@ mod tests {
         assert_eq!(config.export_format, Some(crate::export::ExportFormat::Svg));
         assert_eq!(config.autogrid, Some(false));
         assert_eq!(config.autogrid_color, Some("gray".to_string()));
+        assert_eq!(
+            config.annotations_file,
+            Some(PathBuf::from("~/events.jsonl"))
+        );
     }
 
     #[test]

--- a/src/export.rs
+++ b/src/export.rs
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-use crate::annotations::{AnnotationCluster, AnnotationPanelContext, cluster_events_by};
+use crate::annotations::{
+    AnnotationCluster, AnnotationPanelContext, cluster_events_by, format_cluster_detail_lines,
+};
 use crate::app::{AppMode, AppState, PanelState, PanelType, SeriesView, ThresholdMode};
 use crate::theme::Theme;
 use crate::ui;
@@ -664,6 +666,7 @@ fn render_graph_panel(app: &AppState, panel: &PanelState, rect: PlotRect, out: &
             cluster,
             plot.left,
             legend_top,
+            plot.width,
             &color_hex(app.theme.border_selected, "#f0d000"),
             out,
         );
@@ -740,10 +743,16 @@ fn render_annotation_details(
     cluster: &AnnotationCluster<'_>,
     left: f64,
     top: f64,
+    width: f64,
     color: &str,
     out: &mut String,
 ) {
-    let [heading, details] = annotation_detail_lines(cluster);
+    let character_budget = if width.is_finite() && width > 0.0 {
+        (width / SMALL_FONT_SIZE).floor() as usize
+    } else {
+        0
+    };
+    let [heading, details] = format_cluster_detail_lines(cluster, character_budget);
     for (row, line) in [heading, details].iter().enumerate() {
         write!(
             out,
@@ -753,38 +762,6 @@ fn render_annotation_details(
         )
         .unwrap();
     }
-}
-
-fn annotation_detail_lines(cluster: &AnnotationCluster<'_>) -> [String; 2] {
-    let first = cluster.events[0];
-    let details = cluster
-        .events
-        .iter()
-        .map(|event| {
-            if event.tags.is_empty() {
-                event.text.clone()
-            } else {
-                format!("{} [{}]", event.text, event.tags.join(", "))
-            }
-        })
-        .collect::<Vec<_>>()
-        .join(" · ");
-
-    let heading = if cluster.events.len() == 1 {
-        if first.time.timestamp_subsec_millis() == 0 {
-            first.time.format("%Y-%m-%d %H:%M:%S UTC").to_string()
-        } else {
-            first.time.format("%Y-%m-%d %H:%M:%S%.3f UTC").to_string()
-        }
-    } else {
-        format!(
-            "{} events near {}",
-            cluster.events.len(),
-            first.time.format("%Y-%m-%d %H:%M:%S UTC")
-        )
-    };
-
-    [heading, details]
 }
 
 fn render_stat_panel(app: &AppState, panel: &PanelState, rect: PlotRect, out: &mut String) {
@@ -1618,12 +1595,31 @@ fn indexed_color_hex(value: u8) -> &'static str {
 }
 
 fn escape_xml(input: &str) -> String {
-    input
-        .replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-        .replace('"', "&quot;")
-        .replace('\'', "&apos;")
+    let mut escaped = String::with_capacity(input.len());
+    for character in input.chars() {
+        match character {
+            '&' => escaped.push_str("&amp;"),
+            '<' => escaped.push_str("&lt;"),
+            '>' => escaped.push_str("&gt;"),
+            '"' => escaped.push_str("&quot;"),
+            '\'' => escaped.push_str("&apos;"),
+            character if is_valid_xml_1_0_character(character) => escaped.push(character),
+            _ => escaped.push(char::REPLACEMENT_CHARACTER),
+        }
+    }
+    escaped
+}
+
+fn is_valid_xml_1_0_character(character: char) -> bool {
+    matches!(
+        character,
+        '\u{9}'
+            | '\u{a}'
+            | '\u{d}'
+            | '\u{20}'..='\u{d7ff}'
+            | '\u{e000}'..='\u{fffd}'
+            | '\u{10000}'..='\u{10ffff}'
+    )
 }
 
 fn timestamp_id() -> String {
@@ -1715,6 +1711,16 @@ mod tests {
     }
 
     #[test]
+    fn test_escape_xml_replaces_invalid_xml_1_0_characters() {
+        assert_eq!(
+            escape_xml(
+                "\u{0}\u{1}\t\n\r \u{d7ff}\u{e000}\u{fffd}\u{fffe}\u{ffff}\u{10000}\u{10ffff}&"
+            ),
+            "��\t\n\r \u{d7ff}\u{e000}\u{fffd}��\u{10000}\u{10ffff}&amp;"
+        );
+    }
+
+    #[test]
     fn test_map_coordinates_respect_bounds() {
         let plot = PlotRect {
             left: 10.0,
@@ -1803,6 +1809,46 @@ mod tests {
         assert_eq!(svg.matches(r#"data-role="annotation-detail""#).count(), 2);
         assert!(svg.contains("3 events near 1970-01-01 00:00:50 UTC"));
         assert!(svg.contains("deploy · rollback · resolved"));
+    }
+
+    #[test]
+    fn graph_export_bounds_large_annotation_details_with_ellipsis() {
+        let mut app = test_app_with_panel_type(PanelType::Graph);
+        app.view_end_ts = 100;
+        app.range = std::time::Duration::from_secs(100);
+        app.annotations = crate::annotations::AnnotationState::from_events_for_test(
+            (0..100)
+                .map(|index| {
+                    crate::annotations::test_event_at(
+                        50.0,
+                        &format!("event-{index:03}-{}", "x".repeat(200)),
+                    )
+                })
+                .collect(),
+        );
+        app.cursor_x = Some(50.0);
+
+        let svg = render_svg(&app, Rect::new(0, 0, 120, 50));
+        let detail_lines = svg
+            .split(r#"data-role="annotation-detail""#)
+            .skip(1)
+            .map(|suffix| {
+                suffix
+                    .split_once('>')
+                    .unwrap()
+                    .1
+                    .split_once("</text>")
+                    .unwrap()
+                    .0
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(detail_lines.len(), 2);
+        assert!(detail_lines[0].starts_with("100 events near"));
+        assert!(detail_lines[1].starts_with("event-000-"));
+        assert!(detail_lines[1].ends_with('…'));
+        assert!(!detail_lines[1].contains("event-001-"));
+        assert!(detail_lines.iter().all(|line| line.chars().count() <= 120));
     }
 
     #[test]
@@ -2077,6 +2123,60 @@ mod tests {
         write_png(&svg, &path).unwrap();
 
         assert!(fs::metadata(&path).unwrap().len() > 0);
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn annotation_xml_controls_are_safe_for_svg_png_and_recording() {
+        let dir = test_export_dir("annotation-xml");
+        let export = ExportOptions {
+            dir: dir.clone(),
+            format: ExportFormat::Both,
+            record_max_frames: 10,
+        };
+        let mut app = test_app(export);
+        app.view_end_ts = 100;
+        app.range = std::time::Duration::from_secs(100);
+        let mut event = crate::annotations::test_event_at(
+            50.0,
+            "deploy\t\n\r Ω😀\u{0}\u{1}\u{fffe}\u{ffff} complete",
+        );
+        event.tags = vec!["valid\u{10000}".to_string(), "bad\u{8}".to_string()];
+        app.annotations = crate::annotations::AnnotationState::from_events_for_test(vec![event]);
+        app.cursor_x = Some(50.0);
+        let viewport = Rect::new(0, 0, 120, 50);
+
+        let svg = render_svg(&app, viewport);
+        assert!(!svg.chars().any(|character| {
+            matches!(
+                character,
+                '\u{0}' | '\u{1}' | '\u{8}' | '\u{fffe}' | '\u{ffff}'
+            )
+        }));
+        assert!(svg.contains("\t\n\r Ω😀"));
+        assert!(svg.contains("valid\u{10000}"));
+        assert!(svg.contains('�'));
+        let options = resvg::usvg::Options::default();
+        resvg::usvg::Tree::from_data(svg.as_bytes(), &options).unwrap();
+
+        toggle_recording(&mut app, viewport).unwrap();
+        let recording = app.recording.as_ref().unwrap();
+        assert_eq!(recording.frame_count, 1);
+        assert_eq!(recording.frames[0].files.len(), 2);
+        assert!(
+            fs::metadata(recording.dir.join("frame-000001.svg"))
+                .unwrap()
+                .len()
+                > 0
+        );
+        assert!(
+            fs::metadata(recording.dir.join("frame-000001.png"))
+                .unwrap()
+                .len()
+                > 0
+        );
+        toggle_recording(&mut app, viewport).unwrap();
+
         fs::remove_dir_all(dir).unwrap();
     }
 

--- a/src/export.rs
+++ b/src/export.rs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+use crate::annotations::{AnnotationCluster, AnnotationPanelContext, cluster_events_by};
 use crate::app::{AppMode, AppState, PanelState, PanelType, SeriesView, ThresholdMode};
 use crate::theme::Theme;
 use crate::ui;
@@ -428,7 +429,19 @@ fn render_graph_panel(app: &AppState, panel: &PanelState, rect: PlotRect, out: &
         return;
     }
 
-    let legend_height = if panel.series.is_empty() {
+    let (x_min, x_max) = app.time_bounds();
+    let annotations_enabled = panel.panel_type == PanelType::Graph;
+    let has_annotations = annotations_enabled
+        && !app
+            .annotations
+            .events_for_panel(
+                AnnotationPanelContext {
+                    title: &panel.title,
+                },
+                [x_min, x_max],
+            )
+            .is_empty();
+    let legend_height = if panel.series.is_empty() && !has_annotations {
         0.0
     } else {
         LEGEND_HEIGHT
@@ -441,7 +454,7 @@ fn render_graph_panel(app: &AppState, panel: &PanelState, rect: PlotRect, out: &
         height: (rect.height - X_LABEL_HEIGHT - legend_height - 10.0).max(1.0),
     };
 
-    let (x_min, x_max) = app.time_bounds();
+    let x_bounds = [x_min, x_max];
     let y_bounds = ui::calculate_y_bounds(panel);
     let text = color_hex(app.theme.text, "#e6e6e6");
     let axis = color_hex(Color::Gray, "#777777");
@@ -491,7 +504,7 @@ fn render_graph_panel(app: &AppState, panel: &PanelState, rect: PlotRect, out: &
     }
 
     for tick in time_ticks(x_min, x_max) {
-        let x = map_x(tick, [x_min, x_max], plot);
+        let x = map_x(tick, x_bounds, plot);
         draw_line(
             out,
             (x, plot.top),
@@ -577,9 +590,58 @@ fn render_graph_panel(app: &AppState, panel: &PanelState, rect: PlotRect, out: &
         );
     }
 
+    // Area fills remain behind annotations so marker lines stay legible.
+    if graph_options.draw_style == crate::app::GraphDrawStyle::Line {
+        if let Some(opacity) = graph_area_opacity(&graph_options) {
+            for (index, series) in panel.series.iter().enumerate() {
+                if !series.visible {
+                    continue;
+                }
+                let color = color_hex(series_color(panel, &app.theme, index), "#00ff88");
+                render_graph_area(series, plot, y_bounds, x_bounds, &color, opacity, out);
+            }
+        }
+    }
+
+    let annotation_clusters = if annotations_enabled {
+        render_graph_annotations(app, panel, plot, x_bounds, out)
+    } else {
+        Vec::new()
+    };
+
+    // Primary data follows annotations to preserve graph-data precedence.
+    for (index, series) in panel.series.iter().enumerate() {
+        if !series.visible {
+            continue;
+        }
+        let color = series_color(panel, &app.theme, index);
+        let color = color_hex(color, "#00ff88");
+
+        match graph_options.draw_style {
+            crate::app::GraphDrawStyle::Points => {
+                render_graph_points(series, plot, y_bounds, x_bounds, &color, out);
+            }
+            crate::app::GraphDrawStyle::Bars => {
+                render_graph_bars(series, plot, y_bounds, x_bounds, &color, out);
+            }
+            crate::app::GraphDrawStyle::Line => {
+                if let Some(path) = series_path(series, x_bounds, y_bounds, plot) {
+                    write!(
+                        out,
+                        r#"<path data-role="graph-line" d="{path}" fill="none" stroke="{color}" stroke-width="1.6" stroke-linejoin="round" stroke-linecap="round"/>"#
+                    )
+                    .unwrap();
+                }
+                if graph_options.show_points == crate::app::GraphPointMode::Always {
+                    render_graph_points(series, plot, y_bounds, x_bounds, &color, out);
+                }
+            }
+        }
+    }
+
     if let Some(cursor_x) = app.cursor_x {
         if cursor_x >= x_min && cursor_x <= x_max {
-            let x = map_x(cursor_x, [x_min, x_max], plot);
+            let x = map_x(cursor_x, x_bounds, plot);
             draw_line(
                 out,
                 (x, plot.top),
@@ -593,47 +655,135 @@ fn render_graph_panel(app: &AppState, panel: &PanelState, rect: PlotRect, out: &
         }
     }
 
-    for (index, series) in panel.series.iter().enumerate() {
-        if !series.visible {
-            continue;
-        }
-        let color = series_color(panel, &app.theme, index);
-        let color = color_hex(color, "#00ff88");
-        let x_bounds = [x_min, x_max];
+    let active_annotation =
+        active_export_annotation(&annotation_clusters, app.cursor_x, x_bounds, plot);
+    let legend_top = plot.bottom() + X_LABEL_HEIGHT;
+    if let Some(cluster) = active_annotation {
+        render_annotation_details(
+            cluster,
+            plot.left,
+            legend_top,
+            &color_hex(app.theme.border_selected, "#f0d000"),
+            out,
+        );
+    } else {
+        render_legend(app, panel, plot.left, legend_top, plot.width, out);
+    }
+}
 
-        match graph_options.draw_style {
-            crate::app::GraphDrawStyle::Points => {
-                render_graph_points(series, plot, y_bounds, x_bounds, &color, out);
-            }
-            crate::app::GraphDrawStyle::Bars => {
-                render_graph_bars(series, plot, y_bounds, x_bounds, &color, out);
-            }
-            crate::app::GraphDrawStyle::Line => {
-                if let Some(opacity) = graph_area_opacity(&graph_options) {
-                    render_graph_area(series, plot, y_bounds, x_bounds, &color, opacity, out);
-                }
-                if let Some(path) = series_path(series, x_bounds, y_bounds, plot) {
-                    write!(
-                        out,
-                        r#"<path d="{path}" fill="none" stroke="{color}" stroke-width="1.6" stroke-linejoin="round" stroke-linecap="round"/>"#
-                    )
-                    .unwrap();
-                }
-                if graph_options.show_points == crate::app::GraphPointMode::Always {
-                    render_graph_points(series, plot, y_bounds, x_bounds, &color, out);
-                }
-            }
-        }
+fn render_graph_annotations<'a>(
+    app: &'a AppState,
+    panel: &PanelState,
+    plot: PlotRect,
+    x_bounds: [f64; 2],
+    out: &mut String,
+) -> Vec<AnnotationCluster<'a>> {
+    let events = app.annotations.events_for_panel(
+        AnnotationPanelContext {
+            title: &panel.title,
+        },
+        x_bounds,
+    );
+    let clusters = cluster_events_by(events, |timestamp| {
+        Some(map_x(timestamp, x_bounds, plot).round() as u32)
+    });
+    let color = color_hex(app.theme.border_selected, "#f0d000");
+
+    for cluster in &clusters {
+        let x = f64::from(cluster.coordinate);
+        write!(
+            out,
+            r#"<line data-role="annotation-marker" x1="{x:.2}" y1="{:.2}" x2="{x:.2}" y2="{:.2}" stroke="{color}" stroke-width="1.00" stroke-dasharray="3 4"/>"#,
+            plot.top,
+            plot.bottom()
+        )
+        .unwrap();
+        write!(
+            out,
+            r#"<text x="{x:.2}" y="{:.2}" fill="{color}" font-size="{SMALL_FONT_SIZE:.1}" text-anchor="middle" data-role="annotation-count">{}</text>"#,
+            plot.top + SMALL_FONT_SIZE,
+            annotation_cluster_badge(cluster.events.len())
+        )
+        .unwrap();
     }
 
-    render_legend(
-        app,
-        panel,
-        plot.left,
-        plot.bottom() + X_LABEL_HEIGHT,
-        plot.width,
-        out,
-    );
+    clusters
+}
+
+fn annotation_cluster_badge(count: usize) -> char {
+    match count {
+        0 => ' ',
+        1 => '•',
+        2..=9 => char::from_digit(count as u32, 10).unwrap(),
+        _ => '+',
+    }
+}
+
+fn active_export_annotation<'a>(
+    clusters: &'a [AnnotationCluster<'a>],
+    cursor_x: Option<f64>,
+    x_bounds: [f64; 2],
+    plot: PlotRect,
+) -> Option<&'a AnnotationCluster<'a>> {
+    let cursor_x = cursor_x?;
+    if cursor_x < x_bounds[0] || cursor_x > x_bounds[1] {
+        return None;
+    }
+    let coordinate = map_x(cursor_x, x_bounds, plot).round() as u32;
+    clusters
+        .iter()
+        .find(|cluster| cluster.coordinate == coordinate)
+}
+
+fn render_annotation_details(
+    cluster: &AnnotationCluster<'_>,
+    left: f64,
+    top: f64,
+    color: &str,
+    out: &mut String,
+) {
+    let [heading, details] = annotation_detail_lines(cluster);
+    for (row, line) in [heading, details].iter().enumerate() {
+        write!(
+            out,
+            r#"<text x="{left:.2}" y="{:.2}" fill="{color}" font-size="{SMALL_FONT_SIZE:.1}" text-anchor="start" data-role="annotation-detail">{}</text>"#,
+            top + 12.0 + row as f64 * 13.0,
+            escape_xml(line)
+        )
+        .unwrap();
+    }
+}
+
+fn annotation_detail_lines(cluster: &AnnotationCluster<'_>) -> [String; 2] {
+    let first = cluster.events[0];
+    let details = cluster
+        .events
+        .iter()
+        .map(|event| {
+            if event.tags.is_empty() {
+                event.text.clone()
+            } else {
+                format!("{} [{}]", event.text, event.tags.join(", "))
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" · ");
+
+    let heading = if cluster.events.len() == 1 {
+        if first.time.timestamp_subsec_millis() == 0 {
+            first.time.format("%Y-%m-%d %H:%M:%S UTC").to_string()
+        } else {
+            first.time.format("%Y-%m-%d %H:%M:%S%.3f UTC").to_string()
+        }
+    } else {
+        format!(
+            "{} events near {}",
+            cluster.events.len(),
+            first.time.format("%Y-%m-%d %H:%M:%S UTC")
+        )
+    };
+
+    [heading, details]
 }
 
 fn render_stat_panel(app: &AppState, panel: &PanelState, rect: PlotRect, out: &mut String) {
@@ -1634,6 +1784,126 @@ mod tests {
     }
 
     #[test]
+    fn graph_export_renders_visible_annotations_and_exact_cluster_count() {
+        let mut app = test_app_with_panel_type(PanelType::Graph);
+        app.view_end_ts = 100;
+        app.range = std::time::Duration::from_secs(100);
+        app.annotations = crate::annotations::AnnotationState::from_events_for_test(vec![
+            crate::annotations::test_event_at(50.0, "deploy"),
+            crate::annotations::test_event_at(50.01, "rollback"),
+            crate::annotations::test_event_at(50.02, "resolved"),
+        ]);
+        app.cursor_x = Some(50.0);
+
+        let svg = render_svg(&app, Rect::new(0, 0, 120, 50));
+
+        assert_eq!(svg.matches(r#"data-role="annotation-marker""#).count(), 1);
+        assert!(svg.contains(r#"data-role="annotation-count">3</text>"#));
+        assert_eq!(svg.matches(r#"data-role="annotation-detail""#).count(), 2);
+        assert!(svg.contains("3 events near 1970-01-01 00:00:50 UTC"));
+        assert!(svg.contains("deploy · rollback · resolved"));
+    }
+
+    #[test]
+    fn graph_export_routes_inclusive_fractional_annotations_and_escapes_active_details() {
+        let mut app = test_app_with_panel_type(PanelType::Graph);
+        app.view_end_ts = 100;
+        app.range = std::time::Duration::from_secs(100);
+        app.theme.border_selected = Color::Rgb(1, 2, 3);
+        let active_time = chrono::DateTime::parse_from_rfc3339("1970-01-01T00:00:50.123456789Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        let active_timestamp = active_time.timestamp() as f64
+            + f64::from(active_time.timestamp_subsec_nanos()) / 1_000_000_000.0;
+        app.annotations = crate::annotations::AnnotationState::from_events_for_test(vec![
+            crate::annotations::test_event_at(0.0, "start"),
+            crate::annotations::AnnotationEvent {
+                time: active_time,
+                text: "deploy <prod> & \"main\"".to_string(),
+                tags: vec!["api&edge".to_string(), "<blue>".to_string()],
+                target: crate::annotations::AnnotationTarget::All,
+            },
+            crate::annotations::test_event_at(100.0, "end"),
+        ]);
+        app.cursor_x = Some(active_timestamp);
+
+        let svg = render_svg(&app, Rect::new(0, 0, 120, 50));
+
+        assert_eq!(svg.matches(r#"data-role="annotation-marker""#).count(), 3);
+        let active_marker = svg
+            .split(r#"data-role="annotation-marker""#)
+            .nth(2)
+            .unwrap()
+            .split("/>")
+            .next()
+            .unwrap();
+        assert!(active_marker.contains(r##"stroke="#010203""##));
+        assert!(svg.contains("1970-01-01 00:00:50.123 UTC"));
+        assert!(!svg.contains("1970-01-01 00:00:50.123456789 UTC"));
+        assert!(
+            svg.contains("deploy &lt;prod&gt; &amp; &quot;main&quot; [api&amp;edge, &lt;blue&gt;]")
+        );
+        assert!(!svg.contains("usage &amp; total ("));
+    }
+
+    #[test]
+    fn graph_export_omits_hidden_annotations_and_non_graph_markers() {
+        let mut hidden = test_app_with_panel_type(PanelType::Graph);
+        hidden.annotations = crate::annotations::AnnotationState::from_events_for_test(vec![
+            crate::annotations::test_event_at(hidden.view_end_ts as f64, "deploy"),
+        ]);
+        hidden.annotations.toggle_visibility();
+        assert!(
+            !render_svg(&hidden, Rect::new(0, 0, 120, 50))
+                .contains(r#"data-role="annotation-marker""#)
+        );
+
+        let mut stat = test_app_with_panel_type(PanelType::Stat);
+        stat.annotations = crate::annotations::AnnotationState::from_events_for_test(vec![
+            crate::annotations::test_event_at(stat.view_end_ts as f64, "deploy"),
+        ]);
+        assert!(
+            !render_svg(&stat, Rect::new(0, 0, 120, 50))
+                .contains(r#"data-role="annotation-marker""#)
+        );
+
+        let mut unknown = test_app_with_panel_type(PanelType::Unknown);
+        unknown.annotations = crate::annotations::AnnotationState::from_events_for_test(vec![
+            crate::annotations::test_event_at(unknown.view_end_ts as f64, "deploy"),
+        ]);
+        assert!(
+            !render_svg(&unknown, Rect::new(0, 0, 120, 50))
+                .contains(r#"data-role="annotation-marker""#)
+        );
+    }
+
+    #[test]
+    fn graph_export_orders_annotations_after_area_and_before_primary_data() {
+        let mut app = test_app_with_panel_type(PanelType::Graph);
+        app.panels[0].options = PanelOptions::Graph(GraphOptions {
+            draw_style: GraphDrawStyle::Line,
+            show_points: GraphPointMode::Always,
+            fill_opacity: Some(30),
+            axis_placement: GraphAxisPlacement::Visible,
+            line_interpolation: None,
+            stacking: GraphStackingMode::Off,
+        });
+        app.annotations = crate::annotations::AnnotationState::from_events_for_test(vec![
+            crate::annotations::test_event_at(app.view_end_ts as f64, "deploy"),
+        ]);
+
+        let svg = render_svg(&app, Rect::new(0, 0, 120, 50));
+        let area = svg.find(r#"data-role="graph-area""#).unwrap();
+        let annotation = svg.find(r#"data-role="annotation-marker""#).unwrap();
+        let line = svg.find(r#"data-role="graph-line""#).unwrap();
+        let point = svg.find(r#"data-role="graph-point""#).unwrap();
+
+        assert!(area < annotation);
+        assert!(annotation < line);
+        assert!(annotation < point);
+    }
+
+    #[test]
     fn test_graph_export_renders_points_area_and_bars() {
         let mut points_app = test_app_with_panel_type(PanelType::Graph);
         points_app.panels[0].options = PanelOptions::Graph(GraphOptions {
@@ -1793,8 +2063,12 @@ mod tests {
 
     #[test]
     fn test_png_rasterization_writes_non_empty_file() {
-        let app = test_app(ExportOptions::default());
+        let mut app = test_app(ExportOptions::default());
+        app.annotations = crate::annotations::AnnotationState::from_events_for_test(vec![
+            crate::annotations::test_event_at(app.view_end_ts as f64, "deploy"),
+        ]);
         let svg = render_svg(&app, Rect::new(0, 0, 100, 40));
+        assert!(svg.contains(r#"data-role="annotation-marker""#));
         let dir = test_export_dir("png");
         fs::create_dir_all(&dir).unwrap();
         let path = dir.join("snapshot.png");

--- a/src/export.rs
+++ b/src/export.rs
@@ -591,15 +591,15 @@ fn render_graph_panel(app: &AppState, panel: &PanelState, rect: PlotRect, out: &
     }
 
     // Area fills remain behind annotations so marker lines stay legible.
-    if graph_options.draw_style == crate::app::GraphDrawStyle::Line {
-        if let Some(opacity) = graph_area_opacity(&graph_options) {
-            for (index, series) in panel.series.iter().enumerate() {
-                if !series.visible {
-                    continue;
-                }
-                let color = color_hex(series_color(panel, &app.theme, index), "#00ff88");
-                render_graph_area(series, plot, y_bounds, x_bounds, &color, opacity, out);
+    if graph_options.draw_style == crate::app::GraphDrawStyle::Line
+        && let Some(opacity) = graph_area_opacity(&graph_options)
+    {
+        for (index, series) in panel.series.iter().enumerate() {
+            if !series.visible {
+                continue;
             }
+            let color = color_hex(series_color(panel, &app.theme, index), "#00ff88");
+            render_graph_area(series, plot, y_bounds, x_bounds, &color, opacity, out);
         }
     }
 
@@ -639,20 +639,21 @@ fn render_graph_panel(app: &AppState, panel: &PanelState, rect: PlotRect, out: &
         }
     }
 
-    if let Some(cursor_x) = app.cursor_x {
-        if cursor_x >= x_min && cursor_x <= x_max {
-            let x = map_x(cursor_x, x_bounds, plot);
-            draw_line(
-                out,
-                (x, plot.top),
-                (x, plot.bottom()),
-                LineStyle {
-                    color: "#ffffff",
-                    dash: Some("4 4"),
-                    width: 1.0,
-                },
-            );
-        }
+    if let Some(cursor_x) = app.cursor_x
+        && cursor_x >= x_min
+        && cursor_x <= x_max
+    {
+        let x = map_x(cursor_x, x_bounds, plot);
+        draw_line(
+            out,
+            (x, plot.top),
+            (x, plot.bottom()),
+            LineStyle {
+                color: "#ffffff",
+                dash: Some("4 4"),
+                width: 1.0,
+            },
+        );
     }
 
     let active_annotation =
@@ -1242,10 +1243,10 @@ fn cursor_values(panel: &PanelState, app: &AppState) -> std::collections::HashMa
             let db = (b.0 - cursor_x).abs();
             da.partial_cmp(&db).unwrap_or(std::cmp::Ordering::Equal)
         });
-        if let Some((ts, value)) = closest {
-            if (ts - cursor_x).abs() <= app.step.as_secs_f64() * 2.0 {
-                values.insert(series.name.clone(), *value);
-            }
+        if let Some((ts, value)) = closest
+            && (ts - cursor_x).abs() <= app.step.as_secs_f64() * 2.0
+        {
+            values.insert(series.name.clone(), *value);
         }
     }
     values

--- a/src/grafana.rs
+++ b/src/grafana.rs
@@ -242,57 +242,57 @@ pub(crate) fn load_grafana_dashboard(path: &std::path::Path) -> Result<Dashboard
 
     let mut vars = HashMap::new();
     let mut query_vars = Vec::new();
-    if let Some(templating) = raw.templating {
-        if let Some(list) = templating.list {
-            for (var_idx, v) in list.into_iter().enumerate() {
-                // Heuristic: prefer 'value' over 'text', handle arrays by taking first or joining?
-                // Grafana 'current' value can be "All" or ["val1", "val2"].
-                // For simple PromQL substitution, we usually want the raw value.
-                // If it's "All", it might be $__all, which is tricky.
-                // Let's try to get a string representation.
-                let val = v
-                    .current
-                    .as_ref()
-                    .and_then(|c| c.value.as_ref())
-                    .or(v.current.as_ref().and_then(|c| c.text.as_ref()));
+    if let Some(templating) = raw.templating
+        && let Some(list) = templating.list
+    {
+        for (var_idx, v) in list.into_iter().enumerate() {
+            // Heuristic: prefer 'value' over 'text', handle arrays by taking first or joining?
+            // Grafana 'current' value can be "All" or ["val1", "val2"].
+            // For simple PromQL substitution, we usually want the raw value.
+            // If it's "All", it might be $__all, which is tricky.
+            // Let's try to get a string representation.
+            let val = v
+                .current
+                .as_ref()
+                .and_then(|c| c.value.as_ref())
+                .or(v.current.as_ref().and_then(|c| c.text.as_ref()));
 
-                if let Some(val) = val {
-                    let mut s = match val {
-                        serde_json::Value::String(s) => s.clone(),
-                        serde_json::Value::Array(arr) => {
-                            // If array, maybe join with pipe for regex? or just take first?
-                            // For now, let's take the first string we find.
-                            arr.iter()
-                                .find_map(|x| x.as_str())
-                                .unwrap_or("")
-                                .to_string()
-                        }
-                        serde_json::Value::Number(n) => n.to_string(),
-                        _ => String::new(),
-                    };
-
-                    // Handle $__all
-                    if s == "$__all" {
-                        // Use allValue if present, otherwise permissive regex
-                        s = v.all_value.clone().unwrap_or_else(|| ".*".to_string());
+            if let Some(val) = val {
+                let mut s = match val {
+                    serde_json::Value::String(s) => s.clone(),
+                    serde_json::Value::Array(arr) => {
+                        // If array, maybe join with pipe for regex? or just take first?
+                        // For now, let's take the first string we find.
+                        arr.iter()
+                            .find_map(|x| x.as_str())
+                            .unwrap_or("")
+                            .to_string()
                     }
+                    serde_json::Value::Number(n) => n.to_string(),
+                    _ => String::new(),
+                };
 
-                    if !s.is_empty() {
-                        vars.insert(v.name.clone(), s);
-                    }
+                // Handle $__all
+                if s == "$__all" {
+                    // Use allValue if present, otherwise permissive regex
+                    s = v.all_value.clone().unwrap_or_else(|| ".*".to_string());
                 }
 
-                if v.var_type.as_deref() == Some("query")
-                    && !v.current_is_all()
-                    && let Some(query) = v.query_string()
-                {
-                    query_vars.push(TemplateQueryVar {
-                        name: v.name,
-                        query,
-                        regex: v.regex.filter(|regex| !regex.trim().is_empty()),
-                        query_path: format!("templating.list[{var_idx}].query"),
-                    });
+                if !s.is_empty() {
+                    vars.insert(v.name.clone(), s);
                 }
+            }
+
+            if v.var_type.as_deref() == Some("query")
+                && !v.current_is_all()
+                && let Some(query) = v.query_string()
+            {
+                query_vars.push(TemplateQueryVar {
+                    name: v.name,
+                    query,
+                    regex: v.regex.filter(|regex| !regex.trim().is_empty()),
+                    query_path: format!("templating.list[{var_idx}].query"),
+                });
             }
         }
     }
@@ -467,78 +467,78 @@ fn collect_panels(out: &mut DashboardImport, panels: Vec<RawPanel>, path: &str) 
             let mut display = crate::ui::DisplayFormat::default();
             let mut graph_options = crate::app::GraphOptions::default();
 
-            if let Some(options) = p.options {
-                if options.reduce_options.is_some() {
-                    out.diagnostics.push(ImportDiagnostic::new(
-                        "ignored_field",
-                        format!("{panel_path}.options.reduceOptions"),
-                        "`options.reduceOptions` is not supported yet; Grafatui will use default value selection",
-                    ));
-                }
+            if let Some(options) = p.options
+                && options.reduce_options.is_some()
+            {
+                out.diagnostics.push(ImportDiagnostic::new(
+                    "ignored_field",
+                    format!("{panel_path}.options.reduceOptions"),
+                    "`options.reduceOptions` is not supported yet; Grafatui will use default value selection",
+                ));
             }
 
-            if let Some(fc) = p.field_config {
-                if let Some(defaults) = fc.defaults {
-                    if defaults.mappings.as_ref().is_some_and(non_empty_json_value) {
-                        out.diagnostics.push(ImportDiagnostic::new(
-                            "ignored_field",
-                            format!("{panel_path}.fieldConfig.defaults.mappings"),
-                            "`fieldConfig.defaults.mappings` is not supported yet; value mappings will be ignored",
-                        ));
+            if let Some(fc) = p.field_config
+                && let Some(defaults) = fc.defaults
+            {
+                if defaults.mappings.as_ref().is_some_and(non_empty_json_value) {
+                    out.diagnostics.push(ImportDiagnostic::new(
+                        "ignored_field",
+                        format!("{panel_path}.fieldConfig.defaults.mappings"),
+                        "`fieldConfig.defaults.mappings` is not supported yet; value mappings will be ignored",
+                    ));
+                }
+
+                graph_options = graph_options_from_custom(defaults.custom.as_ref());
+                display = crate::ui::DisplayFormat {
+                    unit: defaults.unit,
+                    decimals: defaults.decimals,
+                    no_value: defaults.no_value,
+                };
+                min = defaults.min;
+                max = defaults.max;
+                autogrid = defaults
+                    .custom
+                    .as_ref()
+                    .and_then(|custom| custom.axis_grid_show);
+
+                if let Some(th) = defaults.thresholds {
+                    let mode = match th.mode.as_deref() {
+                        Some("percentage") => crate::app::ThresholdMode::Percentage,
+                        _ => crate::app::ThresholdMode::Absolute,
+                    };
+
+                    let mut steps = Vec::new();
+                    if let Some(raw_steps) = th.steps {
+                        for s in raw_steps {
+                            let color = s.color.unwrap_or_else(|| "green".to_string());
+                            let parsed_color = crate::theme::parse_grafana_color(&color);
+                            steps.push(crate::app::ThresholdStep {
+                                value: s.value,
+                                color: parsed_color,
+                            });
+                        }
+                        steps.sort_by(|a, b| {
+                            let a_val = a.value.unwrap_or(f64::NEG_INFINITY);
+                            let b_val = b.value.unwrap_or(f64::NEG_INFINITY);
+                            a_val
+                                .partial_cmp(&b_val)
+                                .unwrap_or(std::cmp::Ordering::Equal)
+                        });
                     }
 
-                    graph_options = graph_options_from_custom(defaults.custom.as_ref());
-                    display = crate::ui::DisplayFormat {
-                        unit: defaults.unit,
-                        decimals: defaults.decimals,
-                        no_value: defaults.no_value,
-                    };
-                    min = defaults.min;
-                    max = defaults.max;
-                    autogrid = defaults
-                        .custom
-                        .as_ref()
-                        .and_then(|custom| custom.axis_grid_show);
+                    if !steps.is_empty() {
+                        let style = defaults
+                            .custom
+                            .as_ref()
+                            .and_then(|c| c.thresholds_style.as_ref())
+                            .and_then(|t| t.mode.clone())
+                            .unwrap_or_else(|| "line".to_string());
 
-                    if let Some(th) = defaults.thresholds {
-                        let mode = match th.mode.as_deref() {
-                            Some("percentage") => crate::app::ThresholdMode::Percentage,
-                            _ => crate::app::ThresholdMode::Absolute,
-                        };
-
-                        let mut steps = Vec::new();
-                        if let Some(raw_steps) = th.steps {
-                            for s in raw_steps {
-                                let color = s.color.unwrap_or_else(|| "green".to_string());
-                                let parsed_color = crate::theme::parse_grafana_color(&color);
-                                steps.push(crate::app::ThresholdStep {
-                                    value: s.value,
-                                    color: parsed_color,
-                                });
-                            }
-                            steps.sort_by(|a, b| {
-                                let a_val = a.value.unwrap_or(f64::NEG_INFINITY);
-                                let b_val = b.value.unwrap_or(f64::NEG_INFINITY);
-                                a_val
-                                    .partial_cmp(&b_val)
-                                    .unwrap_or(std::cmp::Ordering::Equal)
-                            });
-                        }
-
-                        if !steps.is_empty() {
-                            let style = defaults
-                                .custom
-                                .as_ref()
-                                .and_then(|c| c.thresholds_style.as_ref())
-                                .and_then(|t| t.mode.clone())
-                                .unwrap_or_else(|| "line".to_string());
-
-                            thresholds = Some(crate::app::Thresholds {
-                                mode,
-                                steps,
-                                style: Some(style),
-                            });
-                        }
+                        thresholds = Some(crate::app::Thresholds {
+                            mode,
+                            steps,
+                            style: Some(style),
+                        });
                     }
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,6 +88,8 @@ async fn main() -> Result<()> {
         return Ok(());
     }
 
+    let annotations_path = resolve_annotations_path(args.annotations_file, config.annotations_file);
+
     let prometheus_url = args
         .prometheus_url
         .or(config.prometheus_url)
@@ -211,6 +213,7 @@ async fn main() -> Result<()> {
         }
         .validate()?,
     );
+    state.annotations = annotations::AnnotationState::from_path(annotations_path);
     state.autogrid_enabled = autogrid_enabled;
     state.autogrid_color = autogrid_color;
     state.vars = vars; // <— pass variables into the app
@@ -256,6 +259,15 @@ fn resolve_refresh_rate_ms(
         .or(config_refresh_rate)
         .or(dashboard_refresh_rate)
         .unwrap_or(1000)
+}
+
+fn resolve_annotations_path(
+    cli_path: Option<std::path::PathBuf>,
+    config_path: Option<std::path::PathBuf>,
+) -> Option<std::path::PathBuf> {
+    cli_path
+        .or(config_path)
+        .map(|path| config::expand_path(&path))
 }
 
 #[derive(Debug)]
@@ -393,6 +405,15 @@ mod tests {
         assert_eq!(resolve_refresh_rate_ms(None, Some(3000), Some(4000)), 3000);
         assert_eq!(resolve_refresh_rate_ms(None, None, Some(4000)), 4000);
         assert_eq!(resolve_refresh_rate_ms(None, None, None), 1000);
+    }
+
+    #[test]
+    fn test_resolve_annotations_path_prefers_cli_and_expands_selected_path() {
+        let resolved = resolve_annotations_path(
+            Some(std::path::PathBuf::from("./cli.jsonl")),
+            Some(std::path::PathBuf::from("./config.jsonl")),
+        );
+        assert_eq!(resolved, Some(std::path::PathBuf::from("./cli.jsonl")));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+mod annotations;
 mod app;
 mod config;
 mod export;

--- a/src/prom.rs
+++ b/src/prom.rs
@@ -100,10 +100,12 @@ impl PromClient {
         // Check cache
         {
             let cache = self.cache.lock().unwrap();
-            if let Some((c_start, c_end, c_step, data)) = cache.get(expr) {
-                if *c_start == start && *c_end == end && *c_step == step {
-                    return Ok(data.clone());
-                }
+            if let Some((c_start, c_end, c_step, data)) = cache.get(expr)
+                && *c_start == start
+                && *c_end == end
+                && *c_step == step
+            {
+                return Ok(data.clone());
             }
         }
 

--- a/src/ui/draw.rs
+++ b/src/ui/draw.rs
@@ -122,41 +122,7 @@ pub(crate) fn draw_ui(frame: &mut Frame, app: &AppState) {
         if app.debug_bar { "on" } else { "off" }
     );
 
-    let mut detail = String::new();
-    if let Some(status) = &app.export_status {
-        detail = status.clone();
-    }
-    if app.debug_bar {
-        // Choose a debug panel: if we have grid, pick the top-left grid panel; otherwise pick the first panel
-        let debug_panel: Option<&PanelState> = if app.panels.iter().any(|p| p.grid.is_some()) {
-            app.panels
-                .iter()
-                .filter(|p| p.grid.is_some())
-                .min_by_key(|p| {
-                    let g = p.grid.unwrap();
-                    (g.y, g.x)
-                })
-        } else {
-            app.panels.first()
-        };
-
-        if let Some(p) = debug_panel {
-            let url = p.last_url.as_deref().unwrap_or("-");
-            detail = format!(
-                "last panel: {} | samples={} | url={} ",
-                p.title, p.last_samples, url
-            );
-        }
-    }
-
-    if app.mode == AppMode::Inspect {
-        if let Some(cx) = app.cursor_x {
-            let cursor_time = chrono::DateTime::from_timestamp(cx as i64, 0)
-                .map(|dt| dt.format("%H:%M:%S").to_string())
-                .unwrap_or_default();
-            detail = format!("Cursor: {} | {}", cursor_time, detail);
-        }
-    }
+    let detail = build_footer_detail(app);
 
     let footer = Paragraph::new(format!("{}\n{}", summary, detail)).wrap(Wrap { trim: true });
     frame.render_widget(footer, chunks[2]);
@@ -212,6 +178,52 @@ pub(crate) fn draw_ui(frame: &mut Frame, app: &AppState) {
     }
 }
 
+fn build_footer_detail(app: &AppState) -> String {
+    let mut parts = Vec::new();
+
+    if matches!(app.mode, AppMode::Inspect | AppMode::FullscreenInspect) {
+        if let Some(cx) = app.cursor_x {
+            let cursor_time = chrono::DateTime::from_timestamp(cx as i64, 0)
+                .map(|dt| dt.format("%H:%M:%S").to_string())
+                .unwrap_or_default();
+            parts.push(format!("Cursor: {cursor_time}"));
+        }
+    }
+
+    if let Some(warning) = app.annotations.warning() {
+        parts.push(format!("Annotations: {warning}"));
+    }
+
+    if let Some(status) = &app.export_status {
+        parts.push(status.clone());
+    }
+
+    if app.debug_bar {
+        // Choose a debug panel: if we have grid, pick the top-left grid panel; otherwise pick the first panel
+        let debug_panel: Option<&PanelState> = if app.panels.iter().any(|p| p.grid.is_some()) {
+            app.panels
+                .iter()
+                .filter(|p| p.grid.is_some())
+                .min_by_key(|p| {
+                    let g = p.grid.unwrap();
+                    (g.y, g.x)
+                })
+        } else {
+            app.panels.first()
+        };
+
+        if let Some(p) = debug_panel {
+            let url = p.last_url.as_deref().unwrap_or("-");
+            parts.push(format!(
+                "last panel: {} | samples={} | url={}",
+                p.title, p.last_samples, url
+            ));
+        }
+    }
+
+    parts.join(" | ")
+}
+
 fn centered_rect(percent_x: u16, percent_y: u16, r: Rect) -> Rect {
     let popup_layout = Layout::default()
         .direction(Direction::Vertical)
@@ -230,4 +242,47 @@ fn centered_rect(percent_x: u16, percent_y: u16, r: Rect) -> Rect {
             Constraint::Percentage((100 - percent_x) / 2),
         ])
         .split(popup_layout[1])[1]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{export::ExportOptions, prom::PromClient, theme::Theme};
+
+    fn test_app() -> AppState {
+        AppState::new(
+            PromClient::new("http://localhost:9090".to_string()),
+            std::time::Duration::from_secs(300),
+            std::time::Duration::from_secs(5),
+            std::time::Duration::from_secs(1),
+            "Test".to_string(),
+            vec![],
+            0,
+            Theme::default(),
+            "dashed-line".to_string(),
+            ExportOptions::default(),
+        )
+    }
+
+    #[test]
+    fn footer_composes_annotation_warning_with_export_and_inspect_status() {
+        let mut app = test_app();
+        app.export_status = Some("Exported frame.svg".to_string());
+        app.mode = AppMode::Inspect;
+        app.cursor_x = Some(1_700_000_000.0);
+        app.annotations =
+            crate::annotations::AnnotationState::warning_for_test("events.jsonl:2: invalid time");
+
+        let detail = build_footer_detail(&app);
+
+        assert!(detail.contains("Cursor:"));
+        assert!(detail.contains("Annotations: events.jsonl:2: invalid time"));
+        assert!(detail.contains("Exported frame.svg"));
+    }
+
+    #[test]
+    fn footer_omits_annotation_status_when_disabled() {
+        let app = test_app();
+        assert!(!build_footer_detail(&app).contains("Annotations:"));
+    }
 }

--- a/src/ui/draw.rs
+++ b/src/ui/draw.rs
@@ -181,13 +181,13 @@ pub(crate) fn draw_ui(frame: &mut Frame, app: &AppState) {
 fn build_footer_detail(app: &AppState) -> String {
     let mut parts = Vec::new();
 
-    if matches!(app.mode, AppMode::Inspect | AppMode::FullscreenInspect) {
-        if let Some(cx) = app.cursor_x {
-            let cursor_time = chrono::DateTime::from_timestamp(cx as i64, 0)
-                .map(|dt| dt.format("%H:%M:%S").to_string())
-                .unwrap_or_default();
-            parts.push(format!("Cursor: {cursor_time}"));
-        }
+    if matches!(app.mode, AppMode::Inspect | AppMode::FullscreenInspect)
+        && let Some(cx) = app.cursor_x
+    {
+        let cursor_time = chrono::DateTime::from_timestamp(cx as i64, 0)
+            .map(|dt| dt.format("%H:%M:%S").to_string())
+            .unwrap_or_default();
+        parts.push(format!("Cursor: {cursor_time}"));
     }
 
     if let Some(warning) = app.annotations.warning() {

--- a/src/ui/panels/graph/annotations.rs
+++ b/src/ui/panels/graph/annotations.rs
@@ -42,7 +42,7 @@ pub(super) fn render_annotation_clusters(
     frame: &mut Frame,
     clusters: &[AnnotationCluster<'_>],
     plot: PlotBounds,
-    strong_data: &ratatui::buffer::Buffer,
+    strong_data: Option<&ratatui::buffer::Buffer>,
     color: Color,
 ) {
     for cluster in clusters {
@@ -69,7 +69,7 @@ pub(super) fn render_annotation_clusters(
 
 fn render_marker_cell(
     frame: &mut Frame,
-    strong_data: &ratatui::buffer::Buffer,
+    strong_data: Option<&ratatui::buffer::Buffer>,
     x: u16,
     y: u16,
     marker: char,
@@ -78,9 +78,10 @@ fn render_marker_cell(
     let Some(destination) = frame.buffer_mut().cell_mut((x, y)) else {
         return;
     };
-    let Some(strong) = strong_data.cell((x, y)) else {
-        return;
-    };
+    let empty_strong = ratatui::buffer::Cell::default();
+    let strong = strong_data
+        .and_then(|buffer| buffer.cell((x, y)))
+        .unwrap_or(&empty_strong);
     overlay_marker_cell(destination, strong, marker, color);
 }
 

--- a/src/ui/panels/graph/annotations.rs
+++ b/src/ui/panels/graph/annotations.rs
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2026 Federico D'Ambrosio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use super::labels::{PlotBounds, value_to_plot_x};
+use super::overlay::{overlay_cell_if_blank, overlay_cell_if_blank_or_weak_area_fill};
+use crate::annotations::{AnnotationCluster, AnnotationEvent, cluster_events_by};
+use ratatui::prelude::*;
+
+pub(super) fn cluster_badge(count: usize) -> char {
+    match count {
+        0 => ' ',
+        1 => '•',
+        2..=9 => char::from_digit(count as u32, 10).unwrap(),
+        _ => '+',
+    }
+}
+
+pub(super) fn terminal_clusters<'a>(
+    events: Vec<&'a AnnotationEvent>,
+    x_bounds: [f64; 2],
+    plot: PlotBounds,
+) -> Vec<AnnotationCluster<'a>> {
+    cluster_events_by(events, |timestamp| {
+        value_to_plot_x(timestamp, x_bounds, plot).map(u32::from)
+    })
+}
+
+pub(super) fn render_annotation_clusters(
+    frame: &mut Frame,
+    clusters: &[AnnotationCluster<'_>],
+    plot: PlotBounds,
+    strong_data: Option<&ratatui::buffer::Buffer>,
+    color: Color,
+) {
+    for cluster in clusters {
+        let Ok(x) = u16::try_from(cluster.coordinate) else {
+            continue;
+        };
+        if x < plot.left || x >= plot.right {
+            continue;
+        }
+
+        render_marker_cell(
+            frame,
+            strong_data,
+            x,
+            plot.top,
+            cluster_badge(cluster.events.len()),
+            color,
+        );
+        for y in plot.top.saturating_add(1)..=plot.bottom {
+            render_marker_cell(frame, strong_data, x, y, '┊', color);
+        }
+    }
+}
+
+fn render_marker_cell(
+    frame: &mut Frame,
+    strong_data: Option<&ratatui::buffer::Buffer>,
+    x: u16,
+    y: u16,
+    marker: char,
+    color: Color,
+) {
+    let Some(destination) = frame.buffer_mut().cell_mut((x, y)) else {
+        return;
+    };
+    if let Some(strong_data) = strong_data {
+        let Some(strong) = strong_data.cell((x, y)) else {
+            return;
+        };
+        overlay_marker_cell(destination, strong, marker, color);
+    } else {
+        let mut source = ratatui::buffer::Cell::default();
+        source
+            .set_char(marker)
+            .set_style(Style::default().fg(color));
+        overlay_cell_if_blank(destination, &source);
+    }
+}
+
+fn overlay_marker_cell(
+    destination: &mut ratatui::buffer::Cell,
+    strong_data: &ratatui::buffer::Cell,
+    marker: char,
+    color: Color,
+) {
+    let mut source = ratatui::buffer::Cell::default();
+    source
+        .set_char(marker)
+        .set_style(Style::default().fg(color));
+    overlay_cell_if_blank_or_weak_area_fill(destination, &source, strong_data);
+}
+
+pub(super) fn active_cluster<'a>(
+    clusters: &'a [AnnotationCluster<'a>],
+    cursor_x: Option<f64>,
+    x_bounds: [f64; 2],
+    plot: PlotBounds,
+) -> Option<&'a AnnotationCluster<'a>> {
+    let cursor_column = value_to_plot_x(cursor_x?, x_bounds, plot)?;
+    clusters
+        .iter()
+        .find(|cluster| cluster.coordinate == u32::from(cursor_column))
+}
+
+pub(super) fn cluster_detail_lines(cluster: &AnnotationCluster<'_>) -> [String; 2] {
+    let first = cluster.events[0];
+    let details = cluster
+        .events
+        .iter()
+        .map(|event| {
+            if event.tags.is_empty() {
+                event.text.clone()
+            } else {
+                format!("{} [{}]", event.text, event.tags.join(", "))
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" · ");
+
+    let heading = if cluster.events.len() == 1 {
+        if first.time.timestamp_subsec_millis() == 0 {
+            first.time.format("%Y-%m-%d %H:%M:%S UTC").to_string()
+        } else {
+            first.time.format("%Y-%m-%d %H:%M:%S%.3f UTC").to_string()
+        }
+    } else {
+        format!(
+            "{} events near {}",
+            cluster.events.len(),
+            first.time.format("%Y-%m-%d %H:%M:%S UTC")
+        )
+    };
+
+    [heading, details]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::annotations::{AnnotationCluster, AnnotationEvent, AnnotationTarget};
+    use ratatui::style::Color;
+
+    fn event(time: &str, text: &str, tags: &[&str]) -> AnnotationEvent {
+        AnnotationEvent {
+            time: chrono::DateTime::parse_from_rfc3339(time)
+                .unwrap()
+                .with_timezone(&chrono::Utc),
+            text: text.to_string(),
+            tags: tags.iter().map(|tag| (*tag).to_string()).collect(),
+            target: AnnotationTarget::All,
+        }
+    }
+
+    #[test]
+    fn badge_matches_cluster_size() {
+        assert_eq!(cluster_badge(1), '•');
+        assert_eq!(cluster_badge(2), '2');
+        assert_eq!(cluster_badge(9), '9');
+        assert_eq!(cluster_badge(10), '+');
+    }
+
+    #[test]
+    fn detail_text_reports_exact_count_and_order() {
+        let events = [
+            event("2026-07-23T14:30:00Z", "deploy", &["prod"]),
+            event("2026-07-23T14:30:01Z", "rollback", &[]),
+        ];
+        let refs = events.iter().collect();
+        let cluster = AnnotationCluster {
+            coordinate: 4,
+            events: refs,
+        };
+
+        let lines = cluster_detail_lines(&cluster);
+        assert_eq!(lines[0], "2 events near 2026-07-23 14:30:00 UTC");
+        assert_eq!(lines[1], "deploy [prod] · rollback");
+    }
+
+    #[test]
+    fn detail_text_for_one_event_includes_precise_time_text_and_tags() {
+        let events = [event(
+            "2026-07-23T14:30:00.125Z",
+            "deploy",
+            &["prod", "api"],
+        )];
+        let cluster = AnnotationCluster {
+            coordinate: 4,
+            events: events.iter().collect(),
+        };
+
+        let lines = cluster_detail_lines(&cluster);
+        assert_eq!(lines[0], "2026-07-23 14:30:00.125 UTC");
+        assert_eq!(lines[1], "deploy [prod, api]");
+    }
+
+    #[test]
+    fn marker_does_not_replace_strong_data_cell() {
+        let mut destination = ratatui::buffer::Cell::default();
+        destination.set_char('x');
+        let strong = ratatui::buffer::Cell::default();
+
+        overlay_marker_cell(&mut destination, &strong, '┊', Color::Yellow);
+
+        assert_eq!(destination.symbol(), "x");
+    }
+}

--- a/src/ui/panels/graph/annotations.rs
+++ b/src/ui/panels/graph/annotations.rs
@@ -15,7 +15,7 @@
  */
 
 use super::labels::{PlotBounds, value_to_plot_x};
-use super::overlay::{overlay_cell_if_blank, overlay_cell_if_blank_or_weak_area_fill};
+use super::overlay::overlay_cell_if_blank_or_weak_area_fill;
 use crate::annotations::{AnnotationCluster, AnnotationEvent, cluster_events_by};
 use ratatui::prelude::*;
 
@@ -42,7 +42,7 @@ pub(super) fn render_annotation_clusters(
     frame: &mut Frame,
     clusters: &[AnnotationCluster<'_>],
     plot: PlotBounds,
-    strong_data: Option<&ratatui::buffer::Buffer>,
+    strong_data: &ratatui::buffer::Buffer,
     color: Color,
 ) {
     for cluster in clusters {
@@ -69,7 +69,7 @@ pub(super) fn render_annotation_clusters(
 
 fn render_marker_cell(
     frame: &mut Frame,
-    strong_data: Option<&ratatui::buffer::Buffer>,
+    strong_data: &ratatui::buffer::Buffer,
     x: u16,
     y: u16,
     marker: char,
@@ -78,18 +78,10 @@ fn render_marker_cell(
     let Some(destination) = frame.buffer_mut().cell_mut((x, y)) else {
         return;
     };
-    if let Some(strong_data) = strong_data {
-        let Some(strong) = strong_data.cell((x, y)) else {
-            return;
-        };
-        overlay_marker_cell(destination, strong, marker, color);
-    } else {
-        let mut source = ratatui::buffer::Cell::default();
-        source
-            .set_char(marker)
-            .set_style(Style::default().fg(color));
-        overlay_cell_if_blank(destination, &source);
-    }
+    let Some(strong) = strong_data.cell((x, y)) else {
+        return;
+    };
+    overlay_marker_cell(destination, strong, marker, color);
 }
 
 fn overlay_marker_cell(
@@ -117,54 +109,10 @@ pub(super) fn active_cluster<'a>(
         .find(|cluster| cluster.coordinate == u32::from(cursor_column))
 }
 
-pub(super) fn cluster_detail_lines(cluster: &AnnotationCluster<'_>) -> [String; 2] {
-    let first = cluster.events[0];
-    let details = cluster
-        .events
-        .iter()
-        .map(|event| {
-            if event.tags.is_empty() {
-                event.text.clone()
-            } else {
-                format!("{} [{}]", event.text, event.tags.join(", "))
-            }
-        })
-        .collect::<Vec<_>>()
-        .join(" · ");
-
-    let heading = if cluster.events.len() == 1 {
-        if first.time.timestamp_subsec_millis() == 0 {
-            first.time.format("%Y-%m-%d %H:%M:%S UTC").to_string()
-        } else {
-            first.time.format("%Y-%m-%d %H:%M:%S%.3f UTC").to_string()
-        }
-    } else {
-        format!(
-            "{} events near {}",
-            cluster.events.len(),
-            first.time.format("%Y-%m-%d %H:%M:%S UTC")
-        )
-    };
-
-    [heading, details]
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::annotations::{AnnotationCluster, AnnotationEvent, AnnotationTarget};
     use ratatui::style::Color;
-
-    fn event(time: &str, text: &str, tags: &[&str]) -> AnnotationEvent {
-        AnnotationEvent {
-            time: chrono::DateTime::parse_from_rfc3339(time)
-                .unwrap()
-                .with_timezone(&chrono::Utc),
-            text: text.to_string(),
-            tags: tags.iter().map(|tag| (*tag).to_string()).collect(),
-            target: AnnotationTarget::All,
-        }
-    }
 
     #[test]
     fn badge_matches_cluster_size() {
@@ -172,40 +120,6 @@ mod tests {
         assert_eq!(cluster_badge(2), '2');
         assert_eq!(cluster_badge(9), '9');
         assert_eq!(cluster_badge(10), '+');
-    }
-
-    #[test]
-    fn detail_text_reports_exact_count_and_order() {
-        let events = [
-            event("2026-07-23T14:30:00Z", "deploy", &["prod"]),
-            event("2026-07-23T14:30:01Z", "rollback", &[]),
-        ];
-        let refs = events.iter().collect();
-        let cluster = AnnotationCluster {
-            coordinate: 4,
-            events: refs,
-        };
-
-        let lines = cluster_detail_lines(&cluster);
-        assert_eq!(lines[0], "2 events near 2026-07-23 14:30:00 UTC");
-        assert_eq!(lines[1], "deploy [prod] · rollback");
-    }
-
-    #[test]
-    fn detail_text_for_one_event_includes_precise_time_text_and_tags() {
-        let events = [event(
-            "2026-07-23T14:30:00.125Z",
-            "deploy",
-            &["prod", "api"],
-        )];
-        let cluster = AnnotationCluster {
-            coordinate: 4,
-            events: events.iter().collect(),
-        };
-
-        let lines = cluster_detail_lines(&cluster);
-        assert_eq!(lines[0], "2026-07-23 14:30:00.125 UTC");
-        assert_eq!(lines[1], "deploy [prod, api]");
     }
 
     #[test]

--- a/src/ui/panels/graph/labels.rs
+++ b/src/ui/panels/graph/labels.rs
@@ -143,8 +143,8 @@ fn value_to_y_label_row(value: f64, y_bounds: [f64; 2], plot: PlotBounds) -> Opt
     value_to_plot_y(value, y_bounds, plot)
 }
 
-fn value_to_plot_x(value: f64, x_bounds: [f64; 2], plot: PlotBounds) -> Option<u16> {
-    if value <= x_bounds[0] || value >= x_bounds[1] || x_bounds[1] <= x_bounds[0] {
+pub(super) fn value_to_plot_x(value: f64, x_bounds: [f64; 2], plot: PlotBounds) -> Option<u16> {
+    if value < x_bounds[0] || value > x_bounds[1] || x_bounds[1] <= x_bounds[0] {
         return None;
     }
 
@@ -277,8 +277,23 @@ mod tests {
         };
 
         assert_eq!(value_to_plot_x(5.0, [0.0, 10.0], plot), Some(15));
-        assert_eq!(value_to_plot_x(0.0, [0.0, 10.0], plot), None);
-        assert_eq!(value_to_plot_x(10.0, [0.0, 10.0], plot), None);
+        assert_eq!(value_to_plot_x(0.0, [0.0, 10.0], plot), Some(10));
+        assert_eq!(value_to_plot_x(10.0, [0.0, 10.0], plot), Some(20));
+    }
+
+    #[test]
+    fn test_value_to_plot_x_includes_window_boundaries() {
+        let plot = PlotBounds {
+            left: 10,
+            right: 21,
+            top: 0,
+            bottom: 5,
+        };
+
+        assert_eq!(value_to_plot_x(0.0, [0.0, 100.0], plot), Some(10));
+        assert_eq!(value_to_plot_x(100.0, [0.0, 100.0], plot), Some(20));
+        assert_eq!(value_to_plot_x(-1.0, [0.0, 100.0], plot), None);
+        assert_eq!(value_to_plot_x(101.0, [0.0, 100.0], plot), None);
     }
 
     #[test]

--- a/src/ui/panels/graph/labels.rs
+++ b/src/ui/panels/graph/labels.rs
@@ -207,7 +207,7 @@ fn centered_label_start(center: u16, label_width: u16, min_x: u16, max_x: u16) -
     // For even-length labels, bias one cell right so the visual midpoint better matches
     // the target chart column instead of consistently leaning left.
     let mut start_x = center.checked_sub(half_width)?;
-    if label_width % 2 == 0 {
+    if label_width.is_multiple_of(2) {
         start_x = start_x.saturating_add(1);
     }
     let end_x_exclusive = start_x.saturating_add(label_width);

--- a/src/ui/panels/graph/mod.rs
+++ b/src/ui/panels/graph/mod.rs
@@ -21,9 +21,7 @@ mod labels;
 mod overlay;
 mod thresholds;
 
-use annotations::{
-    active_cluster, cluster_detail_lines, render_annotation_clusters, terminal_clusters,
-};
+use annotations::{active_cluster, render_annotation_clusters, terminal_clusters};
 use autogrid::{build_autogrid_datasets, calculate_time_grid_ticks, calculate_value_grid_ticks};
 use labels::{
     PlotBounds, YLabelArea, YLabelContext, render_autogrid_time_labels,
@@ -32,6 +30,7 @@ use labels::{
 use overlay::{merge_overlay_buffer, merge_overlay_buffer_preserving_data};
 use thresholds::{prepare_thresholds, render_raw_threshold_lines, threshold_marker};
 
+use crate::annotations::format_cluster_detail_lines;
 use crate::app::{AppState, PanelState};
 use crate::ui::format::{format_axis_time, get_hash_color};
 use ratatui::{
@@ -282,20 +281,19 @@ pub(super) fn render_graph_panel(
             .graph_type(graph_type_for_draw_style(graph_options.draw_style))
             .style(Style::default().fg(color))
             .data(data);
+        strong_data_datasets.push(
+            Dataset::default()
+                .name("")
+                .marker(ratatui::symbols::Marker::Braille)
+                .graph_type(graph_type_for_draw_style(graph_options.draw_style))
+                .style(Style::default().fg(color))
+                .data(data),
+        );
 
         let is_area_filled = graph_options.fill_opacity.unwrap_or(0) > 0
             && graph_options.draw_style == crate::app::GraphDrawStyle::Line;
 
         if is_area_filled {
-            strong_data_datasets.push(
-                Dataset::default()
-                    .name("")
-                    .marker(ratatui::symbols::Marker::Braille)
-                    .graph_type(GraphType::Line)
-                    .style(Style::default().fg(color))
-                    .data(data),
-            );
-
             dataset = dataset
                 .graph_type(GraphType::Area)
                 .fill_to_y(area_fill_baseline(y_bounds));
@@ -321,17 +319,14 @@ pub(super) fn render_graph_panel(
                 .style(Style::default().fg(Color::White))
                 .data(&cursor_dataset),
         );
-
-        if !strong_data_datasets.is_empty() {
-            strong_data_datasets.push(
-                Dataset::default()
-                    .name("")
-                    .marker(ratatui::symbols::Marker::Braille)
-                    .graph_type(GraphType::Line)
-                    .style(Style::default().fg(Color::White))
-                    .data(&cursor_dataset),
-            );
-        }
+        strong_data_datasets.push(
+            Dataset::default()
+                .name("")
+                .marker(ratatui::symbols::Marker::Braille)
+                .graph_type(GraphType::Line)
+                .style(Style::default().fg(Color::White))
+                .data(&cursor_dataset),
+        );
     }
 
     let time_range_secs = now - start;
@@ -404,9 +399,8 @@ pub(super) fn render_graph_panel(
 
     frame.render_widget(chart, chart_area);
 
-    let strong_data_buf = if strong_data_datasets.is_empty() {
-        None
-    } else {
+    let mut strong_data_buf = ratatui::buffer::Buffer::empty(chart_area);
+    if !strong_data_datasets.is_empty() {
         let strong_data_chart = Chart::new(strong_data_datasets)
             .x_axis(
                 Axis::default()
@@ -420,10 +414,8 @@ pub(super) fn render_graph_panel(
                     .bounds(y_bounds)
                     .labels(chart_y_labels.clone()),
             );
-        let mut buf = ratatui::buffer::Buffer::empty(chart_area);
-        strong_data_chart.render(chart_area, &mut buf);
-        Some(buf)
-    };
+        strong_data_chart.render(chart_area, &mut strong_data_buf);
+    }
 
     let chart_left = chart_plot_left(
         chart_area,
@@ -462,16 +454,7 @@ pub(super) fn render_graph_panel(
         let mut threshold_buf = ratatui::buffer::Buffer::empty(chart_area);
         threshold_chart.render(chart_area, &mut threshold_buf);
 
-        if let Some(strong_data_buf) = strong_data_buf.as_ref() {
-            merge_overlay_buffer_preserving_data(
-                frame,
-                &threshold_buf,
-                strong_data_buf,
-                plot_bounds,
-            );
-        } else {
-            merge_overlay_buffer(frame, &threshold_buf, plot_bounds);
-        }
+        merge_overlay_buffer_preserving_data(frame, &threshold_buf, &strong_data_buf, plot_bounds);
     }
 
     render_raw_threshold_lines(
@@ -480,7 +463,7 @@ pub(super) fn render_graph_panel(
         &threshold_data.labels,
         y_bounds,
         plot_bounds,
-        strong_data_buf.as_ref(),
+        Some(&strong_data_buf),
     );
 
     if show_autogrid && chart_top <= chart_bottom {
@@ -558,7 +541,7 @@ pub(super) fn render_graph_panel(
         frame,
         &annotation_clusters,
         plot_bounds,
-        strong_data_buf.as_ref(),
+        &strong_data_buf,
         theme.border_selected,
     );
 
@@ -573,11 +556,12 @@ pub(super) fn render_graph_panel(
     // Render custom legend
     if legend_height > 0 {
         if let Some(cluster) = active_annotation {
-            let details = cluster_detail_lines(cluster);
+            let [heading, details] =
+                format_cluster_detail_lines(cluster, usize::from(legend_area.width));
             let detail_style = Style::default().fg(theme.border_selected);
             let annotation_detail = Paragraph::new(vec![
-                Line::styled(details[0].clone(), detail_style),
-                Line::styled(details[1].clone(), detail_style),
+                Line::styled(heading, detail_style),
+                Line::styled(details, detail_style),
             ]);
             frame.render_widget(annotation_detail, legend_area);
         } else {
@@ -916,6 +900,92 @@ mod tests {
     }
 
     #[test]
+    fn annotation_replaces_vertical_autogrid_but_preserves_standard_line_data() {
+        let mut panel = area_fill_panel();
+        panel.series[0].points = vec![(0.0, 8.0), (60.0, 8.0), (100.0, 8.0)];
+        panel.options = PanelOptions::Graph(GraphOptions {
+            draw_style: GraphDrawStyle::Line,
+            show_points: GraphPointMode::Never,
+            fill_opacity: None,
+            axis_placement: GraphAxisPlacement::Visible,
+            line_interpolation: None,
+            stacking: GraphStackingMode::Off,
+        });
+        let mut app = area_fill_app(panel);
+        let mut baseline = Terminal::new(TestBackend::new(80, 20)).unwrap();
+        baseline
+            .draw(|frame| {
+                render_graph_panel(frame, Rect::new(0, 0, 80, 20), &app.panels[0], &app, None);
+            })
+            .unwrap();
+
+        app.annotations = crate::annotations::AnnotationState::from_events_for_test(vec![
+            crate::annotations::test_event_at(60.0, "deploy"),
+        ]);
+        let mut annotated = Terminal::new(TestBackend::new(80, 20)).unwrap();
+        annotated
+            .draw(|frame| {
+                render_graph_panel(frame, Rect::new(0, 0, 80, 20), &app.panels[0], &app, None);
+            })
+            .unwrap();
+
+        let panel = &app.panels[0];
+        let y_bounds = calculate_y_bounds(panel);
+        let chart_area = Rect::new(0, 0, 80, 18);
+        let x_labels = vec![Span::raw("00:00:00"), Span::raw("00:01:40")];
+        let chart_y_labels = vec![Span::raw("0"), Span::raw("10")];
+        let plot = PlotBounds {
+            left: chart_plot_left(
+                chart_area,
+                chart_y_label_width(&chart_y_labels),
+                &x_labels,
+                true,
+            ),
+            right: chart_area.right(),
+            top: chart_area.top(),
+            bottom: chart_area.bottom().saturating_sub(2),
+        };
+        let marker_x = labels::value_to_plot_x(60.0, [0.0, 100.0], plot).unwrap();
+        let strong_cell = point_to_braille_cell(60.0, 8.0, [0.0, 100.0], y_bounds, plot).unwrap();
+        assert_eq!(
+            baseline
+                .backend()
+                .buffer()
+                .cell(strong_cell)
+                .unwrap()
+                .style()
+                .fg,
+            Some(app.theme.palette[0]),
+            "the collision cell must contain standard-line series data"
+        );
+
+        assert_eq!(
+            annotated
+                .backend()
+                .buffer()
+                .cell((marker_x, plot.top))
+                .unwrap()
+                .symbol(),
+            "•"
+        );
+        assert!(
+            (plot.top.saturating_add(1)..=plot.bottom).any(|y| {
+                annotated
+                    .backend()
+                    .buffer()
+                    .cell((marker_x, y))
+                    .is_some_and(|cell| cell.symbol() == "┊")
+            }),
+            "annotation marker should replace vertical autogrid cells"
+        );
+        assert_eq!(
+            annotated.backend().buffer().cell(strong_cell),
+            baseline.backend().buffer().cell(strong_cell),
+            "the standard line cell must remain visually dominant"
+        );
+    }
+
+    #[test]
     fn annotation_details_keep_one_logical_line_per_reserved_row() {
         let mut app = area_fill_app(area_fill_panel());
         app.annotations = crate::annotations::AnnotationState::from_events_for_test(vec![
@@ -947,5 +1017,55 @@ mod tests {
             .collect::<String>();
         assert!(rendered.contains("3 events near"));
         assert!(rendered.contains("deploy"));
+    }
+
+    #[test]
+    fn annotation_details_are_bounded_by_terminal_legend_width() {
+        let mut app = area_fill_app(area_fill_panel());
+        app.annotations = crate::annotations::AnnotationState::from_events_for_test(
+            (0..100)
+                .map(|index| {
+                    crate::annotations::test_event_at(
+                        50.0,
+                        &format!("event-{index:03}-{}", "x".repeat(80)),
+                    )
+                })
+                .collect(),
+        );
+        app.cursor_x = Some(50.0);
+        let width = 36;
+        let height = 12;
+        let mut terminal = Terminal::new(TestBackend::new(width, height)).unwrap();
+
+        terminal
+            .draw(|frame| {
+                render_graph_panel(
+                    frame,
+                    Rect::new(0, 0, width, height),
+                    &app.panels[0],
+                    &app,
+                    app.cursor_x,
+                );
+            })
+            .unwrap();
+
+        let row_text = |y| {
+            (0..width)
+                .filter_map(|x| terminal.backend().buffer().cell((x, y)))
+                .map(|cell| cell.symbol())
+                .collect::<String>()
+                .trim_end()
+                .to_string()
+        };
+        let heading = row_text(height - 2);
+        let details = row_text(height - 1);
+
+        assert!(heading.starts_with("100 events near"));
+        assert!(heading.ends_with('…'));
+        assert!(details.starts_with("event-000-"));
+        assert!(details.ends_with('…'));
+        assert!(!details.contains("event-001-"));
+        assert!(heading.chars().count() <= usize::from(width));
+        assert!(details.chars().count() <= usize::from(width));
     }
 }

--- a/src/ui/panels/graph/mod.rs
+++ b/src/ui/panels/graph/mod.rs
@@ -617,9 +617,11 @@ mod tests {
 
     #[test]
     fn test_should_overlay_points() {
-        let mut options = GraphOptions::default();
-        options.draw_style = GraphDrawStyle::Line;
-        options.show_points = GraphPointMode::Auto;
+        let mut options = GraphOptions {
+            draw_style: GraphDrawStyle::Line,
+            show_points: GraphPointMode::Auto,
+            ..GraphOptions::default()
+        };
         assert!(!should_overlay_points(&options));
 
         options.show_points = GraphPointMode::Always;

--- a/src/ui/panels/graph/mod.rs
+++ b/src/ui/panels/graph/mod.rs
@@ -14,12 +14,16 @@
  * limitations under the License.
  */
 
+mod annotations;
 mod autogrid;
 mod bounds;
 mod labels;
 mod overlay;
 mod thresholds;
 
+use annotations::{
+    active_cluster, cluster_detail_lines, render_annotation_clusters, terminal_clusters,
+};
 use autogrid::{build_autogrid_datasets, calculate_time_grid_ticks, calculate_value_grid_ticks};
 use labels::{
     PlotBounds, YLabelArea, YLabelContext, render_autogrid_time_labels,
@@ -162,6 +166,12 @@ pub(super) fn render_graph_panel(
 ) {
     let theme = &app.theme;
     let use_hash_colors = p.series.len() > theme.palette.len();
+    // Determine x bounds from the last refreshed query window.
+    let (start, now) = app.time_bounds();
+    let annotation_events = app.annotations.events_for_panel(
+        crate::annotations::AnnotationPanelContext { title: &p.title },
+        [start, now],
+    );
 
     // If inspecting, find values at cursor
     let cursor_values: HashMap<String, f64> = if let Some(cx) = cursor_x {
@@ -192,12 +202,13 @@ pub(super) fn render_graph_panel(
     };
 
     // Split inner area into chart and legend
-    // If we have series, reserve space for legend
-    let legend_height = if !p.series.is_empty() && area.height > 5 {
-        2
-    } else {
-        0
-    };
+    // If we have series or annotations, reserve space for legend or annotation details.
+    let legend_height =
+        if (!p.series.is_empty() || !annotation_events.is_empty()) && area.height > 5 {
+            2
+        } else {
+            0
+        };
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)
@@ -206,9 +217,6 @@ pub(super) fn render_graph_panel(
 
     let chart_area = chunks[0];
     let legend_area = chunks[1];
-
-    // Determine x bounds from the last refreshed query window.
-    let (start, now) = app.time_bounds();
 
     // Calculate y_bounds once
     let y_bounds = calculate_y_bounds(p);
@@ -430,6 +438,9 @@ pub(super) fn render_graph_panel(
         top: chart_top,
         bottom: chart_bottom,
     };
+    let annotation_clusters = terminal_clusters(annotation_events, [start, now], plot_bounds);
+    let active_annotation =
+        active_cluster(&annotation_clusters, cursor_x, [start, now], plot_bounds);
 
     // Render threshold markers after chart rendering by merging only onto blank cells.
     // This guarantees data curves keep precedence wherever both map to the same terminal cell.
@@ -543,6 +554,14 @@ pub(super) fn render_graph_panel(
         );
     }
 
+    render_annotation_clusters(
+        frame,
+        &annotation_clusters,
+        plot_bounds,
+        strong_data_buf.as_ref(),
+        theme.border_selected,
+    );
+
     render_forced_point_markers(
         frame,
         &forced_point_markers,
@@ -553,8 +572,18 @@ pub(super) fn render_graph_panel(
 
     // Render custom legend
     if legend_height > 0 {
-        let legend = Paragraph::new(Line::from(legend_items)).wrap(Wrap { trim: true });
-        frame.render_widget(legend, legend_area);
+        if let Some(cluster) = active_annotation {
+            let details = cluster_detail_lines(cluster);
+            let detail_style = Style::default().fg(theme.border_selected);
+            let annotation_detail = Paragraph::new(vec![
+                Line::styled(details[0].clone(), detail_style),
+                Line::styled(details[1].clone(), detail_style),
+            ]);
+            frame.render_widget(annotation_detail, legend_area);
+        } else {
+            let legend = Paragraph::new(Line::from(legend_items)).wrap(Wrap { trim: true });
+            frame.render_widget(legend, legend_area);
+        }
     }
 }
 
@@ -848,5 +877,73 @@ mod tests {
 
         assert!(!visible_point_cells.is_empty());
         assert_eq!(visible_point_cells, expected_cells);
+    }
+
+    #[test]
+    fn annotation_cluster_renders_and_inspects_on_same_column() {
+        let mut app = area_fill_app(area_fill_panel());
+        app.annotations = crate::annotations::AnnotationState::from_events_for_test(vec![
+            crate::annotations::test_event_at(50.0, "deploy"),
+            crate::annotations::test_event_at(50.1, "rollback"),
+            crate::annotations::test_event_at(50.2, "resolved"),
+        ]);
+        app.cursor_x = Some(50.0);
+        let mut terminal = Terminal::new(TestBackend::new(80, 20)).unwrap();
+
+        terminal
+            .draw(|frame| {
+                render_graph_panel(
+                    frame,
+                    Rect::new(0, 0, 80, 20),
+                    &app.panels[0],
+                    &app,
+                    app.cursor_x,
+                );
+            })
+            .unwrap();
+
+        let rendered = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+        assert!(rendered.contains("3 events near"));
+        assert!(rendered.contains("deploy"));
+    }
+
+    #[test]
+    fn annotation_details_keep_one_logical_line_per_reserved_row() {
+        let mut app = area_fill_app(area_fill_panel());
+        app.annotations = crate::annotations::AnnotationState::from_events_for_test(vec![
+            crate::annotations::test_event_at(50.0, "deploy"),
+            crate::annotations::test_event_at(50.1, "rollback"),
+            crate::annotations::test_event_at(50.2, "resolved"),
+        ]);
+        app.cursor_x = Some(50.0);
+        let mut terminal = Terminal::new(TestBackend::new(30, 12)).unwrap();
+
+        terminal
+            .draw(|frame| {
+                render_graph_panel(
+                    frame,
+                    Rect::new(0, 0, 30, 12),
+                    &app.panels[0],
+                    &app,
+                    app.cursor_x,
+                );
+            })
+            .unwrap();
+
+        let rendered = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+        assert!(rendered.contains("3 events near"));
+        assert!(rendered.contains("deploy"));
     }
 }

--- a/src/ui/panels/graph/mod.rs
+++ b/src/ui/panels/graph/mod.rs
@@ -66,6 +66,22 @@ fn is_y_axis_hidden(options: &crate::app::GraphOptions) -> bool {
     options.axis_placement == crate::app::GraphAxisPlacement::Hidden
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StrongDataMaskMode {
+    AreaFillOnly,
+    AllDrawStyles,
+}
+
+fn strong_data_mask_mode(
+    annotation_events: &[&crate::annotations::AnnotationEvent],
+) -> StrongDataMaskMode {
+    if annotation_events.is_empty() {
+        StrongDataMaskMode::AreaFillOnly
+    } else {
+        StrongDataMaskMode::AllDrawStyles
+    }
+}
+
 fn chart_plot_left(
     chart_area: Rect,
     y_label_width: u16,
@@ -171,6 +187,7 @@ pub(super) fn render_graph_panel(
         crate::annotations::AnnotationPanelContext { title: &p.title },
         [start, now],
     );
+    let strong_data_mask_mode = strong_data_mask_mode(&annotation_events);
 
     // If inspecting, find values at cursor
     let cursor_values: HashMap<String, f64> = if let Some(cx) = cursor_x {
@@ -281,17 +298,18 @@ pub(super) fn render_graph_panel(
             .graph_type(graph_type_for_draw_style(graph_options.draw_style))
             .style(Style::default().fg(color))
             .data(data);
-        strong_data_datasets.push(
-            Dataset::default()
-                .name("")
-                .marker(ratatui::symbols::Marker::Braille)
-                .graph_type(graph_type_for_draw_style(graph_options.draw_style))
-                .style(Style::default().fg(color))
-                .data(data),
-        );
-
         let is_area_filled = graph_options.fill_opacity.unwrap_or(0) > 0
             && graph_options.draw_style == crate::app::GraphDrawStyle::Line;
+        if is_area_filled || strong_data_mask_mode == StrongDataMaskMode::AllDrawStyles {
+            strong_data_datasets.push(
+                Dataset::default()
+                    .name("")
+                    .marker(ratatui::symbols::Marker::Braille)
+                    .graph_type(graph_type_for_draw_style(graph_options.draw_style))
+                    .style(Style::default().fg(color))
+                    .data(data),
+            );
+        }
 
         if is_area_filled {
             dataset = dataset
@@ -319,14 +337,18 @@ pub(super) fn render_graph_panel(
                 .style(Style::default().fg(Color::White))
                 .data(&cursor_dataset),
         );
-        strong_data_datasets.push(
-            Dataset::default()
-                .name("")
-                .marker(ratatui::symbols::Marker::Braille)
-                .graph_type(GraphType::Line)
-                .style(Style::default().fg(Color::White))
-                .data(&cursor_dataset),
-        );
+        if !strong_data_datasets.is_empty()
+            || strong_data_mask_mode == StrongDataMaskMode::AllDrawStyles
+        {
+            strong_data_datasets.push(
+                Dataset::default()
+                    .name("")
+                    .marker(ratatui::symbols::Marker::Braille)
+                    .graph_type(GraphType::Line)
+                    .style(Style::default().fg(Color::White))
+                    .data(&cursor_dataset),
+            );
+        }
     }
 
     let time_range_secs = now - start;
@@ -399,8 +421,10 @@ pub(super) fn render_graph_panel(
 
     frame.render_widget(chart, chart_area);
 
-    let mut strong_data_buf = ratatui::buffer::Buffer::empty(chart_area);
-    if !strong_data_datasets.is_empty() {
+    let strong_data_buf = if strong_data_datasets.is_empty() {
+        None
+    } else {
+        let mut strong_data_buf = ratatui::buffer::Buffer::empty(chart_area);
         let strong_data_chart = Chart::new(strong_data_datasets)
             .x_axis(
                 Axis::default()
@@ -415,7 +439,8 @@ pub(super) fn render_graph_panel(
                     .labels(chart_y_labels.clone()),
             );
         strong_data_chart.render(chart_area, &mut strong_data_buf);
-    }
+        Some(strong_data_buf)
+    };
 
     let chart_left = chart_plot_left(
         chart_area,
@@ -454,7 +479,16 @@ pub(super) fn render_graph_panel(
         let mut threshold_buf = ratatui::buffer::Buffer::empty(chart_area);
         threshold_chart.render(chart_area, &mut threshold_buf);
 
-        merge_overlay_buffer_preserving_data(frame, &threshold_buf, &strong_data_buf, plot_bounds);
+        if let Some(strong_data_buf) = strong_data_buf.as_ref() {
+            merge_overlay_buffer_preserving_data(
+                frame,
+                &threshold_buf,
+                strong_data_buf,
+                plot_bounds,
+            );
+        } else {
+            merge_overlay_buffer(frame, &threshold_buf, plot_bounds);
+        }
     }
 
     render_raw_threshold_lines(
@@ -463,7 +497,7 @@ pub(super) fn render_graph_panel(
         &threshold_data.labels,
         y_bounds,
         plot_bounds,
-        Some(&strong_data_buf),
+        strong_data_buf.as_ref(),
     );
 
     if show_autogrid && chart_top <= chart_bottom {
@@ -541,7 +575,7 @@ pub(super) fn render_graph_panel(
         frame,
         &annotation_clusters,
         plot_bounds,
-        &strong_data_buf,
+        strong_data_buf.as_ref(),
         theme.border_selected,
     );
 
@@ -640,6 +674,51 @@ mod tests {
             stacking: GraphStackingMode::Normal,
         };
         assert!(is_y_axis_hidden(&hidden));
+    }
+
+    #[test]
+    fn comprehensive_strong_data_mask_requires_visible_routed_annotations() {
+        let mut disabled = area_fill_app(area_fill_panel());
+        disabled.annotations = crate::annotations::AnnotationState::from_path(None);
+        let disabled_events = routed_annotation_events(&disabled);
+        assert!(disabled_events.is_empty());
+        assert_eq!(
+            strong_data_mask_mode(&disabled_events),
+            StrongDataMaskMode::AreaFillOnly
+        );
+
+        let mut hidden = area_fill_app(area_fill_panel());
+        hidden.annotations = crate::annotations::AnnotationState::from_events_for_test(vec![
+            crate::annotations::test_event_at(50.0, "hidden"),
+        ]);
+        hidden.annotations.toggle_visibility();
+        let hidden_events = routed_annotation_events(&hidden);
+        assert!(hidden_events.is_empty());
+        assert_eq!(
+            strong_data_mask_mode(&hidden_events),
+            StrongDataMaskMode::AreaFillOnly
+        );
+
+        let mut outside = area_fill_app(area_fill_panel());
+        outside.annotations = crate::annotations::AnnotationState::from_events_for_test(vec![
+            crate::annotations::test_event_at(101.0, "outside"),
+        ]);
+        let outside_events = routed_annotation_events(&outside);
+        assert!(outside_events.is_empty());
+        assert_eq!(
+            strong_data_mask_mode(&outside_events),
+            StrongDataMaskMode::AreaFillOnly
+        );
+
+        let mut visible = area_fill_app(area_fill_panel());
+        visible.annotations = crate::annotations::AnnotationState::from_events_for_test(vec![
+            crate::annotations::test_event_at(50.0, "visible"),
+        ]);
+        let visible_events = routed_annotation_events(&visible);
+        assert_eq!(
+            strong_data_mask_mode(&visible_events),
+            StrongDataMaskMode::AllDrawStyles
+        );
     }
 
     #[test]
@@ -760,6 +839,16 @@ mod tests {
         app.view_end_ts = 100;
         app.autogrid_color = Color::Red;
         app
+    }
+
+    fn routed_annotation_events(app: &AppState) -> Vec<&crate::annotations::AnnotationEvent> {
+        let (start, end) = app.time_bounds();
+        app.annotations.events_for_panel(
+            crate::annotations::AnnotationPanelContext {
+                title: &app.panels[0].title,
+            },
+            [start, end],
+        )
     }
 
     #[test]

--- a/src/ui/panels/graph/overlay.rs
+++ b/src/ui/panels/graph/overlay.rs
@@ -61,7 +61,7 @@ pub(super) fn is_blank_cell(cell: &ratatui::buffer::Cell) -> bool {
     cell.symbol().chars().all(char::is_whitespace)
 }
 
-fn overlay_cell_if_blank(dst: &mut ratatui::buffer::Cell, src: &ratatui::buffer::Cell) {
+pub(super) fn overlay_cell_if_blank(dst: &mut ratatui::buffer::Cell, src: &ratatui::buffer::Cell) {
     if is_blank_cell(dst) && !is_blank_cell(src) {
         dst.set_symbol(src.symbol()).set_style(src.style());
     }

--- a/tests/annotations_cli.rs
+++ b/tests/annotations_cli.rs
@@ -1,0 +1,34 @@
+use std::process::Command;
+
+#[test]
+fn help_lists_annotations_file() {
+    let output = Command::new(env!("CARGO_BIN_EXE_grafatui"))
+        .arg("--help")
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("--annotations-file <FILE>"));
+}
+
+#[test]
+fn validate_does_not_read_annotations_file() {
+    let dashboard = std::env::temp_dir().join(format!(
+        "grafatui-annotations-validate-{}.json",
+        std::process::id()
+    ));
+    std::fs::write(&dashboard, r#"{"title":"empty","panels":[]}"#).unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_grafatui"))
+        .args([
+            "--validate",
+            "--grafana-json",
+            dashboard.to_str().unwrap(),
+            "--annotations-file",
+            "does-not-exist.jsonl",
+        ])
+        .output()
+        .unwrap();
+    std::fs::remove_file(dashboard).unwrap();
+
+    assert!(output.status.success());
+}


### PR DESCRIPTION
## Description

Adds an optional, explicit, read-only JSONL point-event source for graph/timeseries annotations.

This gives Grafatui users a lightweight way to visualize deployments, incidents, and other events without requiring Grafana annotation storage or Prometheus annotation queries. The implementation keeps annotation data separate from Prometheus series and preserves Grafatui's read-only dashboard philosophy.

### What changed

- add `--annotations-file` and TOML `annotations_file` activation
- parse strict timezone-aware RFC 3339 JSONL point events with optional tags
- reload changed files automatically and retain the last valid snapshot on failures
- route events through an internal `AnnotationTarget::All` seam for future targeted rendering
- render counted, same-column markers across graph/timeseries panels
- inspect annotation clusters inline and toggle visibility with `a`
- include visible annotations in SVG/PNG exports and changed-frame recordings
- document the external format, compatibility boundary, and iterative roadmap

Iteration 2 targeting/filtering/popup exploration and iteration 3 provider APIs remain intentionally out of scope and will use separate PRs.

Fixes #27

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have checked whether the [user guide](https://fedexist.github.io/grafatui/) needs an update
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have used Conventional Commits for my commit messages

## Verification

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all-targets` — 153 tests passed
- `git diff --check origin/main...HEAD`
