### PR TITLE
feat: add targeted and filterable JSONL annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ cargo run -- --grafana-json examples/dashboards/prometheus_demo.json --prometheu
 - Keyboard-first navigation, panel search, fullscreen mode, mouse selection, and value inspection.
 - SVG/PNG export and changed-frame recording bundles.
 - TOML configuration and built-in themes.
-- Read-only external JSONL point annotations for graph and timeseries panels.
+- Read-only external JSONL point annotations with panel targeting, tag filtering, and navigable cluster details.
 
 ## Documentation
 

--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -1,7 +1,9 @@
 # External Annotations
 
 Grafatui can overlay read-only, external point events from one JSONL file. It
-never edits or writes the source file.
+never edits or writes the source file. External JSONL is deliberately separate
+from Grafana dashboard annotations: Grafatui does not implement Grafana
+annotation queries, APIs, `annotations`, or `annotations.list`.
 
 ## Enable Annotations
 
@@ -19,10 +21,10 @@ Or configure the same single source in TOML:
 annotations_file = "./events.jsonl"
 ```
 
-The CLI option overrides the configured path. This source is opt-in and is
+The CLI option overrides the configured path. This source is opt-in and
 read-only; Grafatui does not create, edit, or otherwise write the file.
 
-## JSONL Event Format
+## JSONL Event Format and Targeting
 
 The file contains one JSON object per line. Blank lines are ignored. Each event
 requires `time` to be an RFC3339 string with an explicit timezone or offset
@@ -30,35 +32,115 @@ requires `time` to be an RFC3339 string with an explicit timezone or offset
 array of non-empty strings.
 
 ```json
-{"time":"2026-07-23T14:30:00Z","text":"Deployed v2.4","tags":["deploy","production"]}
+{"time":"2026-07-23T14:30:00Z","text":"Maintenance window","tags":["maintenance"]}
+{"time":"2026-07-23T14:30:00Z","text":"Deployed v2.4","tags":["deploy","production"],"panel_titles":["HTTP Request Rate by Status Code"]}
 ```
+
+Omit `panel_titles` to target all eligible graph and timeseries panels, as in
+the first event. When `panel_titles` is present, it must contain one or more
+non-blank titles and each title is matched exactly and case-sensitively against
+eligible graph/timeseries panel titles. `null`, an empty array, and blank
+titles are validation errors.
+
+If a title occurs on multiple eligible panels, the event fans out to all of
+them and Grafatui shows one warning for that duplicate title. A title that is
+missing, or exists only on a non-graph panel, shows one warning and renders no
+marker for that title. These titles are Grafatui routing labels, not Grafana
+panel IDs.
 
 Events are ordered by timestamp. Unknown JSON fields are ignored. Times with
 fractional seconds are accepted, and the full fractional timestamp is used when
 projecting an event onto the graph even when the space-limited inline timestamp
 display shows less precision.
 
-## Automatic Reload
+## Target, Filter, Inspect, and Reload
+
+This walkthrough uses current UTC timestamps so both events fall in the visible
+15-minute range. It uses only POSIX shell tools; no `jq` is required.
+
+First, start the bundled Prometheus demo stack from the repository root:
+
+```bash
+cd examples/demo && docker-compose up -d && sleep 5 && cd ../..
+```
+
+Then create the annotation file and run Grafatui:
+
+```bash
+annotation_demo_file=/tmp/grafatui-annotations-demo.jsonl
+annotation_demo_time="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+
+printf '{"time":"%s","text":"Maintenance window","tags":["maintenance"]}\n' \
+  "$annotation_demo_time" > "$annotation_demo_file"
+printf '{"time":"%s","text":"API deployed","tags":["deploy","production"],"panel_titles":["HTTP Request Rate by Status Code"]}\n' \
+  "$annotation_demo_time" >> "$annotation_demo_file"
+
+cargo run -- \
+  --grafana-json examples/dashboards/prometheus_demo.json \
+  --prometheus-url http://localhost:19090 \
+  --range 15m \
+  --annotations-file "$annotation_demo_file"
+```
+
+`Maintenance window` appears on every graph/timeseries panel. `API deployed`
+appears only on `HTTP Request Rate by Status Code`. Press `t`, select `deploy`
+with `Space`, and press `Enter`; only the targeted deployment remains. Press
+`v`, move the cursor to the marker, and press `Enter`; the selected panel's
+cluster list and selected-event detail pane open.
+
+While Grafatui is running, append an event in a second terminal:
+
+```bash
+annotation_demo_file=/tmp/grafatui-annotations-demo.jsonl
+annotation_demo_time="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+printf '{"time":"%s","text":"Rollback started","tags":["rollback","production"],"panel_titles":["HTTP Request Rate by Status Code"]}\n' \
+  "$annotation_demo_time" >> "$annotation_demo_file"
+```
+
+The new event is loaded after the normal refresh; Grafatui does not need to
+restart. With only `deploy` selected, `Rollback started` remains hidden. Press
+`t`, then `c`, and press `Enter` to apply the cleared filter and reveal the
+rollback marker. Alternatively, select `rollback` in the filter and apply it.
+
+## Tag Filter and Cluster Controls
+
+Press `t` to open the global annotation tag filter. It is runtime-only: it is
+not written to the JSONL source or configuration, and applies to every eligible
+panel. Selected tags use exact, case-sensitive OR matching: an event remains
+visible when it has any selected tag. With no selected tags, events with and
+without tags remain visible. The catalogue keeps a selected tag with a zero
+event count so it can be removed after a reload.
+
+In the tag filter, use `Up`/`Down` or `j`/`k` to move, `Space` to toggle the
+highlighted tag, `c` to clear the draft, `Enter` to apply it, or `Esc` to
+cancel without changing the applied filter. In inspection mode, `Enter` opens
+only the cluster actually rendered by the selected panel at the cursor. In the
+cluster, use `Up`/`Down` or `j`/`k` to select an event, `PgUp`/`PgDn` to page,
+and `Enter` or `Esc` to close. Mouse input is ignored while either annotation
+modal is open.
+
+Cluster contents are frozen when the cluster opens: a later reload can replace
+the live annotation snapshot without moving rows or changing the cluster's
+event details.
+
+## Automatic Reload, Rendering, and Exports
 
 Grafatui checks the file metadata during each normal refresh, including while
 markers are hidden. When it changes, Grafatui reads, parses, and validates the
 full candidate file before atomically replacing the snapshot. A zero-byte file
-is a valid update that clears all events. You can therefore update the JSONL
-file while Grafatui is running without restarting it. Annotation loading is
-independent of Prometheus: annotation failures never fail startup or a
-Prometheus refresh.
-
-## Rendering and Inspection
+is a valid update that clears all events. Annotation loading is independent of
+Prometheus: annotation failures never fail startup or a Prometheus refresh.
 
 Only `graph` and `timeseries` panels receive annotation markers. Press `a` to
-toggle external annotation marker visibility. Events that project to the same
-terminal column are shown as one counted marker: `•` for one event, decimal
-`2`–`9` for two through nine events, and `+` for 10 or more. In inspection
-mode, moving the cursor onto that column shows the clustered events' timestamp,
-text, and tags inline; multi-event details report the exact cluster count.
+toggle marker visibility. Events that project to the same terminal column are
+shown as one counted marker: `•` for one event, decimal `2`–`9` for two through
+nine events, and `+` for 10 or more. In inspection mode, moving the cursor onto
+that column shows the cluster's timestamp, text, and tags inline; multi-event
+details report the exact cluster count.
 
-Visible markers and active inline annotation details are included in SVG/PNG
-exports and changed-frame recordings.
+Applied panel targeting and tag filtering affect the markers in SVG/PNG exports
+and changed-frame recordings. Active inline annotation details are exportable;
+the tag-filter and cluster modal chrome is not.
 
 ## Errors and Last Valid Snapshot
 
@@ -67,21 +149,11 @@ keeps rendering the last valid snapshot and shows an annotation warning. A bad
 update does not replace the previously loaded events, fail startup, or fail the
 Prometheus refresh.
 
-## Current Limitations
+## Current Limits and Roadmap
 
-This iteration supports one external JSONL source and point events applied to
-all graph/timeseries panels. It does not support panel targeting, a navigable
-annotation popup, or tag filtering. `--validate` validates Grafana dashboard
-imports only; it does not validate annotations.
-
-External JSONL events are separate from Grafana dashboard `annotations` and
-`annotations.list`, which remain unsupported. Grafatui also does not run
-Prometheus annotation queries or implement Grafana annotation-query/API
-compatibility.
-
-## Roadmap
-
-Iteration 1 is the shipped external JSONL point-annotation foundation. A future
-iteration 2 PR will add a navigable popup, panel targeting, and tag filtering.
-A separate future iteration 3 PR will introduce a provider API. Neither future
-iteration is implemented yet.
+This feature supports one external JSONL source, point events, panel-title
+routing, and one global runtime-only tag filter. It has no stable event IDs, no
+per-panel tag filters, no multiple sources, no editing, and no provider or API
+work. It does not add Grafana annotation-query/API compatibility. Range events
+and a provider API remain future roadmap work. `--validate` validates Grafana
+dashboard imports only; it does not validate annotations.

--- a/docs/exporting-and-recording.md
+++ b/docs/exporting-and-recording.md
@@ -33,8 +33,12 @@ grafatui-recording-<timestamp>/
 
 If `--export-format png` or `both` is selected, matching PNG files are written too.
 
-When external annotations are visible, their markers and any active inline
-annotation details are included in exports and changed-frame recordings.
+When external annotations are visible, their panel targeting and applied tag
+filter affect the markers written to SVG/PNG exports and changed-frame
+recordings. Any active inline annotation details remain exportable. Annotation
+modal chrome is omitted from exports and recordings, and draft-only tag-filter
+edits do not create recording frames; a frame can change after the filter is
+applied or cleared.
 
 ## Recording Limits
 

--- a/docs/grafana-compatibility.md
+++ b/docs/grafana-compatibility.md
@@ -247,8 +247,10 @@ tooltips.
 | `annotations` | ❌ Not Implemented | |
 | `annotations.list` | ❌ Not Implemented | |
 
-Grafatui external JSONL events are a separate, opt-in read-only source. They do
-not imply compatibility with Grafana annotation queries, APIs, `annotations`, or
+Grafatui external JSONL events are a separate, opt-in read-only source.
+`panel_titles` is Grafatui's external-source routing field: it matches eligible
+graph/timeseries panel titles exactly, not Grafana panel IDs. It does not imply
+compatibility with Grafana annotation queries, APIs, `annotations`, or
 `annotations.list`.
 
 ---

--- a/docs/keyboard-and-mouse.md
+++ b/docs/keyboard-and-mouse.md
@@ -17,9 +17,11 @@ Grafatui is designed for keyboard-first dashboard inspection.
 | `y` | Toggle Y-axis mode |
 | `g` | Toggle autogrid guide lines |
 | `a` | Toggle external annotation markers |
+| `t` | Open the global annotation tag filter |
 | `1` through `9` | Toggle series visibility |
 | `f` / `Enter` | Toggle fullscreen mode |
 | `v` | Toggle value inspection mode |
+| `Enter` in inspect mode | Open the selected panel's annotation cluster at the cursor |
 | `e` | Export current view |
 | `Ctrl+E` | Start or stop changed-frame recording |
 | `/` | Search panels |
@@ -35,3 +37,11 @@ Grafatui is designed for keyboard-first dashboard inspection.
 | Scroll | Scroll the dashboard vertically |
 
 In normal mode, clicking selects panels. Press `v` or `f` to use cursor-focused interactions.
+
+## Annotation Modals
+
+The global tag filter opens with `t`. Use `Up`/`Down` or `k`/`j` to move,
+`Space` to toggle the highlighted tag, `c` to clear the draft, `Enter` to apply
+it, or `Esc` to discard it. In an annotation cluster, use `Up`/`Down` or
+`k`/`j` to select an event, `PgUp`/`PgDn` to page, and `Enter` or `Esc` to
+close it. Mouse input is ignored while either annotation modal is open.

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,14 +16,17 @@ See [`demo/README.md`](demo/README.md) for details.
 ## External Annotations
 
 [`annotations.jsonl`](annotations.jsonl) is a read-only external JSONL event
-source for graph and timeseries panels. Run it with a dashboard:
+source for graph and timeseries panels. Its `Deployed v2.4` event uses
+`panel_titles` to target the bundled `HTTP Request Rate by Status Code` panel;
+the remaining events omit `panel_titles` and therefore remain dashboard-wide.
+Run it with a dashboard:
 
 ```bash
 cargo run -- --grafana-json examples/dashboards/prometheus_demo.json --annotations-file examples/annotations.jsonl
 ```
 
-See the [external annotations guide](../docs/annotations.md) for the event
-format, reload behavior, and limitations.
+See the [external annotations guide](../docs/annotations.md) for targeting,
+tag filtering, inspection, reload behavior, and limitations.
 
 ## Dashboards
 

--- a/examples/annotations.jsonl
+++ b/examples/annotations.jsonl
@@ -1,3 +1,3 @@
-{"time":"2026-07-23T14:30:00Z","text":"Deployed v2.4","tags":["deploy","production"]}
+{"time":"2026-07-23T14:30:00Z","text":"Deployed v2.4","tags":["deploy","production"],"panel_titles":["HTTP Request Rate by Status Code"]}
 {"time":"2026-07-23T15:10:00Z","text":"Rolled back v2.4","tags":["rollback","production"]}
 {"time":"2026-07-23T15:40:00Z","text":"Incident resolved","tags":["incident","production"]}

--- a/src/annotations/details.rs
+++ b/src/annotations/details.rs
@@ -25,7 +25,7 @@ pub(crate) fn format_cluster_detail_lines(
     ]
 }
 
-fn format_event_time(event: &AnnotationEvent) -> String {
+pub(crate) fn format_event_time(event: &AnnotationEvent) -> String {
     if event.time.timestamp_subsec_millis() == 0 {
         event.time.format("%Y-%m-%d %H:%M:%S UTC").to_string()
     } else {

--- a/src/annotations/diagnostics.rs
+++ b/src/annotations/diagnostics.rs
@@ -1,0 +1,122 @@
+use std::collections::BTreeSet;
+use std::fmt;
+
+use super::{AnnotationSnapshot, AnnotationTarget};
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum AnnotationTargetWarning {
+    MissingPanel { title: String },
+    AmbiguousPanel { title: String, matches: usize },
+}
+
+impl fmt::Display for AnnotationTargetWarning {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingPanel { title } => {
+                write!(
+                    formatter,
+                    "target \"{title}\" matches no graph/timeseries panel"
+                )
+            }
+            Self::AmbiguousPanel { title, matches } => write!(
+                formatter,
+                "target \"{title}\" matches {matches} graph/timeseries panels; applied to all"
+            ),
+        }
+    }
+}
+
+pub(crate) fn target_warnings(
+    snapshot: &AnnotationSnapshot,
+    eligible_panel_titles: &[String],
+) -> Vec<AnnotationTargetWarning> {
+    let requested = snapshot
+        .events()
+        .iter()
+        .filter_map(|event| match &event.target {
+            AnnotationTarget::All => None,
+            AnnotationTarget::PanelTitles(titles) => Some(titles.iter()),
+        })
+        .flatten()
+        .cloned()
+        .collect::<BTreeSet<_>>();
+
+    requested
+        .into_iter()
+        .filter_map(|title| {
+            let matches = eligible_panel_titles
+                .iter()
+                .filter(|candidate| candidate.as_str() == title.as_str())
+                .count();
+            match matches {
+                0 => Some(AnnotationTargetWarning::MissingPanel { title }),
+                1 => None,
+                matches => Some(AnnotationTargetWarning::AmbiguousPanel { title, matches }),
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::annotations::{
+        AnnotationSnapshot, AnnotationTarget, AnnotationTargetWarning, target_warnings,
+    };
+
+    fn targeted_event(text: &str, titles: &[&str]) -> crate::annotations::AnnotationEvent {
+        let mut event = crate::annotations::test_event_at(10.0, text);
+        event.target = AnnotationTarget::PanelTitles(
+            titles.iter().map(|title| (*title).to_string()).collect(),
+        );
+        event
+    }
+
+    #[test]
+    fn warns_once_for_missing_and_ambiguous_titles() {
+        let snapshot = AnnotationSnapshot::new(vec![
+            targeted_event("first", &["CPU", "Missing"]),
+            targeted_event("second", &["CPU", "Missing"]),
+        ]);
+        let panels = vec!["CPU".to_string(), "CPU".to_string(), "Memory".to_string()];
+
+        assert_eq!(
+            target_warnings(&snapshot, &panels),
+            vec![
+                AnnotationTargetWarning::AmbiguousPanel {
+                    title: "CPU".to_string(),
+                    matches: 2,
+                },
+                AnnotationTargetWarning::MissingPanel {
+                    title: "Missing".to_string(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn all_targets_do_not_produce_warnings() {
+        let snapshot =
+            AnnotationSnapshot::new(vec![crate::annotations::test_event_at(10.0, "all")]);
+
+        assert!(target_warnings(&snapshot, &["CPU".to_string()]).is_empty());
+    }
+
+    #[test]
+    fn formats_target_warnings_for_the_footer() {
+        assert_eq!(
+            AnnotationTargetWarning::AmbiguousPanel {
+                title: "CPU".to_string(),
+                matches: 2,
+            }
+            .to_string(),
+            "target \"CPU\" matches 2 graph/timeseries panels; applied to all"
+        );
+        assert_eq!(
+            AnnotationTargetWarning::MissingPanel {
+                title: "Missing".to_string(),
+            }
+            .to_string(),
+            "target \"Missing\" matches no graph/timeseries panel"
+        );
+    }
+}

--- a/src/annotations/filter.rs
+++ b/src/annotations/filter.rs
@@ -1,0 +1,123 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use super::{AnnotationEvent, AnnotationSnapshot};
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct TagFilter {
+    selected: BTreeSet<String>,
+}
+
+impl TagFilter {
+    pub(crate) fn from_selected(tags: impl IntoIterator<Item = String>) -> Self {
+        Self {
+            selected: tags.into_iter().collect(),
+        }
+    }
+
+    pub(crate) fn matches(&self, event: &AnnotationEvent) -> bool {
+        self.selected.is_empty() || event.tags.iter().any(|tag| self.selected.contains(tag))
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.selected.is_empty()
+    }
+
+    pub(crate) fn selected(&self) -> &BTreeSet<String> {
+        &self.selected
+    }
+
+    pub(crate) fn summary(&self) -> String {
+        self.selected.iter().cloned().collect::<Vec<_>>().join("|")
+    }
+
+    pub(crate) fn toggle(&mut self, tag: &str) {
+        if !self.selected.remove(tag) {
+            self.selected.insert(tag.to_string());
+        }
+    }
+
+    pub(crate) fn clear(&mut self) {
+        self.selected.clear();
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TagCatalogueEntry {
+    pub(crate) tag: String,
+    pub(crate) count: usize,
+}
+
+pub(crate) fn tag_catalogue(
+    snapshot: &AnnotationSnapshot,
+    filter: &TagFilter,
+) -> Vec<TagCatalogueEntry> {
+    let mut counts = BTreeMap::<String, usize>::new();
+    for event in snapshot.events() {
+        let event_tags = event
+            .tags
+            .iter()
+            .map(String::as_str)
+            .collect::<BTreeSet<_>>();
+        for tag in event_tags {
+            *counts.entry(tag.to_string()).or_default() += 1;
+        }
+    }
+    for tag in filter.selected() {
+        counts.entry(tag.clone()).or_default();
+    }
+    counts
+        .into_iter()
+        .map(|(tag, count)| TagCatalogueEntry { tag, count })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::annotations::{AnnotationEvent, AnnotationSnapshot};
+
+    fn event(tags: &[&str]) -> AnnotationEvent {
+        let mut event = crate::annotations::test_event_at(10.0, "event");
+        event.tags = tags.iter().map(|tag| (*tag).to_string()).collect();
+        event
+    }
+
+    #[test]
+    fn empty_filter_matches_all_and_selected_tags_use_exact_or_semantics() {
+        assert!(TagFilter::default().matches(&event(&[])));
+
+        let filter = TagFilter::from_selected(["deploy".to_string(), "incident".to_string()]);
+        assert!(filter.matches(&event(&["deploy", "production"])));
+        assert!(filter.matches(&event(&["incident"])));
+        assert!(!filter.matches(&event(&["Deploy"])));
+        assert!(!filter.matches(&event(&["production"])));
+        assert!(!filter.matches(&event(&[])));
+    }
+
+    #[test]
+    fn catalogue_counts_unique_events_and_keeps_selected_missing_tags() {
+        let snapshot = AnnotationSnapshot::new(vec![
+            event(&["deploy", "deploy", "production"]),
+            event(&["deploy"]),
+        ]);
+        let filter = TagFilter::from_selected(["missing".to_string()]);
+
+        assert_eq!(
+            tag_catalogue(&snapshot, &filter),
+            vec![
+                TagCatalogueEntry {
+                    tag: "deploy".to_string(),
+                    count: 2,
+                },
+                TagCatalogueEntry {
+                    tag: "missing".to_string(),
+                    count: 0,
+                },
+                TagCatalogueEntry {
+                    tag: "production".to_string(),
+                    count: 1,
+                },
+            ]
+        );
+    }
+}

--- a/src/annotations/filter.rs
+++ b/src/annotations/filter.rs
@@ -8,7 +8,7 @@ pub(crate) struct TagFilter {
 }
 
 impl TagFilter {
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub(crate) fn from_selected(tags: impl IntoIterator<Item = String>) -> Self {
         Self {
             selected: tags.into_iter().collect(),

--- a/src/annotations/filter.rs
+++ b/src/annotations/filter.rs
@@ -23,7 +23,6 @@ impl TagFilter {
         self.selected.is_empty()
     }
 
-    #[allow(dead_code)]
     pub(crate) fn selected(&self) -> &BTreeSet<String> {
         &self.selected
     }
@@ -32,27 +31,23 @@ impl TagFilter {
         self.selected.iter().cloned().collect::<Vec<_>>().join("|")
     }
 
-    #[allow(dead_code)]
     pub(crate) fn toggle(&mut self, tag: &str) {
         if !self.selected.remove(tag) {
             self.selected.insert(tag.to_string());
         }
     }
 
-    #[allow(dead_code)]
     pub(crate) fn clear(&mut self) {
         self.selected.clear();
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[allow(dead_code)]
 pub(crate) struct TagCatalogueEntry {
     pub(crate) tag: String,
     pub(crate) count: usize,
 }
 
-#[allow(dead_code)]
 pub(crate) fn tag_catalogue(
     snapshot: &AnnotationSnapshot,
     filter: &TagFilter,

--- a/src/annotations/filter.rs
+++ b/src/annotations/filter.rs
@@ -8,6 +8,7 @@ pub(crate) struct TagFilter {
 }
 
 impl TagFilter {
+    #[allow(dead_code)]
     pub(crate) fn from_selected(tags: impl IntoIterator<Item = String>) -> Self {
         Self {
             selected: tags.into_iter().collect(),
@@ -22,6 +23,7 @@ impl TagFilter {
         self.selected.is_empty()
     }
 
+    #[allow(dead_code)]
     pub(crate) fn selected(&self) -> &BTreeSet<String> {
         &self.selected
     }
@@ -30,23 +32,27 @@ impl TagFilter {
         self.selected.iter().cloned().collect::<Vec<_>>().join("|")
     }
 
+    #[allow(dead_code)]
     pub(crate) fn toggle(&mut self, tag: &str) {
         if !self.selected.remove(tag) {
             self.selected.insert(tag.to_string());
         }
     }
 
+    #[allow(dead_code)]
     pub(crate) fn clear(&mut self) {
         self.selected.clear();
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(dead_code)]
 pub(crate) struct TagCatalogueEntry {
     pub(crate) tag: String,
     pub(crate) count: usize,
 }
 
+#[allow(dead_code)]
 pub(crate) fn tag_catalogue(
     snapshot: &AnnotationSnapshot,
     filter: &TagFilter,

--- a/src/annotations/jsonl.rs
+++ b/src/annotations/jsonl.rs
@@ -12,6 +12,22 @@ struct RawAnnotationEvent {
     text: String,
     #[serde(default)]
     tags: Vec<String>,
+    #[serde(default)]
+    panel_titles: RawPanelTitles,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum RawPanelTitles {
+    Null(()),
+    Titles(Vec<String>),
+    Missing,
+}
+
+impl Default for RawPanelTitles {
+    fn default() -> Self {
+        Self::Missing
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -64,7 +80,7 @@ pub(crate) fn parse_jsonl(
                 path,
                 line_number,
                 format!(
-                    "invalid annotation event (time, text, and tags must have valid types): {error}"
+                    "invalid annotation event (time, text, tags, and panel_titles must have valid types): {error}"
                 ),
             )
         })?;
@@ -93,11 +109,41 @@ pub(crate) fn parse_jsonl(
             ));
         }
 
+        let target = match raw.panel_titles {
+            RawPanelTitles::Missing => AnnotationTarget::All,
+            RawPanelTitles::Null(()) => {
+                return Err(AnnotationLoadError::at_line(
+                    path,
+                    line_number,
+                    "panel_titles must not be null",
+                ));
+            }
+            RawPanelTitles::Titles(titles) if titles.is_empty() => {
+                return Err(AnnotationLoadError::at_line(
+                    path,
+                    line_number,
+                    "panel_titles must contain at least one title",
+                ));
+            }
+            RawPanelTitles::Titles(titles)
+                if titles.iter().any(|title| title.trim().is_empty()) =>
+            {
+                return Err(AnnotationLoadError::at_line(
+                    path,
+                    line_number,
+                    "panel_titles must not contain blank strings",
+                ));
+            }
+            RawPanelTitles::Titles(titles) => {
+                AnnotationTarget::PanelTitles(titles.into_iter().collect())
+            }
+        };
+
         events.push(AnnotationEvent {
             time,
             text: raw.text,
             tags: raw.tags,
-            target: AnnotationTarget::All,
+            target,
         });
     }
 
@@ -190,6 +236,8 @@ impl JsonlFileSource {
 mod tests {
     use std::path::{Path, PathBuf};
 
+    use crate::annotations::AnnotationTarget;
+
     use super::{JsonlFileSource, SourcePoll, parse_jsonl};
 
     fn temp_path(name: &str) -> PathBuf {
@@ -219,6 +267,53 @@ mod tests {
         assert_eq!(snapshot.events()[0].text, "deploy");
         assert_eq!(snapshot.events()[0].tags, vec!["prod"]);
         assert_eq!(snapshot.events()[1].tags, Vec::<String>::new());
+    }
+
+    #[test]
+    fn parses_optional_panel_titles_and_deduplicates_them() {
+        let snapshot = parse_jsonl(
+            Path::new("events.jsonl"),
+            concat!(
+                r#"{"time":"2026-08-11T14:30:00Z","text":"global"}"#,
+                "\n",
+                r#"{"time":"2026-08-11T14:31:00Z","text":"targeted","panel_titles":["CPU","CPU","Errors"]}"#,
+            ),
+        )
+        .unwrap();
+
+        assert_eq!(snapshot.events()[0].target, AnnotationTarget::All);
+        assert_eq!(
+            snapshot.events()[1].target,
+            AnnotationTarget::PanelTitles(
+                ["CPU".to_string(), "Errors".to_string()]
+                    .into_iter()
+                    .collect()
+            )
+        );
+    }
+
+    #[test]
+    fn rejects_empty_or_blank_panel_titles_with_line_numbers() {
+        for input in [
+            r#"{"time":"2026-08-11T14:30:00Z","text":"x","panel_titles":[]}"#,
+            r#"{"time":"2026-08-11T14:30:00Z","text":"x","panel_titles":["  "]}"#,
+        ] {
+            let error = parse_jsonl(Path::new("events.jsonl"), input).unwrap_err();
+            assert_eq!(error.line(), Some(1));
+            assert!(error.to_string().contains("panel_titles"));
+        }
+    }
+
+    #[test]
+    fn rejects_null_panel_titles_with_line_number() {
+        let error = parse_jsonl(
+            Path::new("events.jsonl"),
+            r#"{"time":"2026-08-11T14:30:00Z","text":"x","panel_titles":null}"#,
+        )
+        .unwrap_err();
+
+        assert_eq!(error.line(), Some(1));
+        assert!(error.to_string().contains("panel_titles"));
     }
 
     #[test]

--- a/src/annotations/jsonl.rs
+++ b/src/annotations/jsonl.rs
@@ -16,18 +16,13 @@ struct RawAnnotationEvent {
     panel_titles: RawPanelTitles,
 }
 
-#[derive(Deserialize)]
+#[derive(Default, Deserialize)]
 #[serde(untagged)]
 enum RawPanelTitles {
     Null(()),
     Titles(Vec<String>),
+    #[default]
     Missing,
-}
-
-impl Default for RawPanelTitles {
-    fn default() -> Self {
-        Self::Missing
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/annotations/mod.rs
+++ b/src/annotations/mod.rs
@@ -11,7 +11,7 @@ mod projection;
 pub(crate) use details::format_cluster_detail_lines;
 pub(crate) use details::format_event_time;
 pub(crate) use diagnostics::{AnnotationTargetWarning, target_warnings};
-#[allow(unused_imports)]
+#[cfg(test)]
 pub(crate) use filter::tag_catalogue;
 pub(crate) use filter::{TagCatalogueEntry, TagFilter};
 pub(crate) use jsonl::{JsonlFileSource, SourcePoll};

--- a/src/annotations/mod.rs
+++ b/src/annotations/mod.rs
@@ -1,12 +1,14 @@
 use std::path::PathBuf;
 
 mod details;
+mod diagnostics;
 mod filter;
 mod jsonl;
 mod model;
 mod projection;
 
 pub(crate) use details::format_cluster_detail_lines;
+pub(crate) use diagnostics::{AnnotationTargetWarning, target_warnings};
 pub(crate) use filter::{TagCatalogueEntry, TagFilter, tag_catalogue};
 pub(crate) use jsonl::{JsonlFileSource, SourcePoll};
 pub(crate) use model::{
@@ -14,12 +16,11 @@ pub(crate) use model::{
 };
 pub(crate) use projection::{AnnotationCluster, cluster_events_by};
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum AnnotationSourceStatus {
-    #[cfg(test)]
-    Disabled,
-    Loaded(usize),
-    Warning(String),
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct AnnotationStatus {
+    loaded_events: usize,
+    source_warning: Option<String>,
+    target_warnings: Vec<AnnotationTargetWarning>,
 }
 
 #[derive(Debug)]
@@ -30,7 +31,7 @@ pub(crate) enum AnnotationState {
         snapshot: AnnotationSnapshot,
         filter: TagFilter,
         visible: bool,
-        status: AnnotationSourceStatus,
+        status: AnnotationStatus,
     },
 }
 
@@ -42,19 +43,19 @@ impl AnnotationState {
                 snapshot: AnnotationSnapshot::new(Vec::new()),
                 filter: TagFilter::default(),
                 visible: true,
-                status: AnnotationSourceStatus::Loaded(0),
+                status: AnnotationStatus::default(),
             },
             None => Self::Disabled,
         }
     }
 
-    pub(crate) async fn refresh_if_changed(&mut self) {
+    pub(crate) async fn refresh_if_changed(&mut self) -> bool {
         let poll = match self {
             Self::Active {
                 source: Some(source),
                 ..
             } => source.poll().await,
-            Self::Disabled | Self::Active { source: None, .. } => return,
+            Self::Disabled | Self::Active { source: None, .. } => return false,
         };
 
         match (self, poll) {
@@ -65,21 +66,27 @@ impl AnnotationState {
                 SourcePoll::Loaded(next_snapshot),
             ) => {
                 *snapshot = next_snapshot;
-                *status = AnnotationSourceStatus::Loaded(snapshot.len());
+                status.loaded_events = snapshot.len();
+                status.source_warning = None;
+                true
             }
-            (
-                Self::Active {
-                    snapshot, status, ..
-                },
-                SourcePoll::Failed(error),
-            ) => {
-                *status = AnnotationSourceStatus::Warning(format!(
+            (Self::Active { status, .. }, SourcePoll::Failed(error)) => {
+                status.source_warning = Some(format!(
                     "{error}; using {} previous event(s)",
-                    snapshot.len()
+                    status.loaded_events
                 ));
+                false
             }
-            (_, SourcePoll::Unchanged) => {}
-            (Self::Disabled, _) => {}
+            (_, SourcePoll::Unchanged) | (Self::Disabled, _) => false,
+        }
+    }
+
+    pub(crate) fn reconcile_targets(&mut self, eligible_panel_titles: &[String]) {
+        if let Self::Active {
+            snapshot, status, ..
+        } = self
+        {
+            status.target_warnings = target_warnings(snapshot, eligible_panel_titles);
         }
     }
 
@@ -91,21 +98,26 @@ impl AnnotationState {
         }
     }
 
-    #[cfg(test)]
-    pub(crate) fn status(&self) -> AnnotationSourceStatus {
+    pub(crate) fn footer_status(&self) -> Option<String> {
         match self {
-            Self::Disabled => AnnotationSourceStatus::Disabled,
-            Self::Active { status, .. } => status.clone(),
-        }
-    }
-
-    pub(crate) fn warning(&self) -> Option<&str> {
-        match self {
-            Self::Active {
-                status: AnnotationSourceStatus::Warning(warning),
-                ..
-            } => Some(warning),
-            Self::Disabled | Self::Active { .. } => None,
+            Self::Disabled => None,
+            Self::Active { filter, status, .. } => {
+                let mut parts = status
+                    .source_warning
+                    .iter()
+                    .cloned()
+                    .chain(status.target_warnings.iter().map(ToString::to_string))
+                    .collect::<Vec<_>>();
+                let warning_count = parts.len();
+                if warning_count > 1 {
+                    parts.truncate(1);
+                    parts[0].push_str(&format!(" (+{} more)", warning_count - 1));
+                }
+                if !filter.is_empty() {
+                    parts.push(format!("tags {}", filter.summary()));
+                }
+                (!parts.is_empty()).then(|| parts.join(" | "))
+            }
         }
     }
 
@@ -173,7 +185,10 @@ impl AnnotationState {
             snapshot,
             filter: TagFilter::default(),
             visible: true,
-            status: AnnotationSourceStatus::Loaded(event_count),
+            status: AnnotationStatus {
+                loaded_events: event_count,
+                ..AnnotationStatus::default()
+            },
         }
     }
 
@@ -184,7 +199,10 @@ impl AnnotationState {
             snapshot: AnnotationSnapshot::new(Vec::new()),
             filter: TagFilter::default(),
             visible: true,
-            status: AnnotationSourceStatus::Warning(message.to_string()),
+            status: AnnotationStatus {
+                source_warning: Some(message.to_string()),
+                ..AnnotationStatus::default()
+            },
         }
     }
 }
@@ -204,10 +222,7 @@ pub(crate) fn test_event_at(timestamp_secs: f64, text: &str) -> AnnotationEvent 
 mod tests {
     use std::path::PathBuf;
 
-    use super::{
-        AnnotationPanelContext, AnnotationSourceStatus, AnnotationState, AnnotationTarget,
-        TagFilter,
-    };
+    use super::{AnnotationPanelContext, AnnotationState, AnnotationTarget, TagFilter};
 
     fn temp_path(name: &str) -> PathBuf {
         let suffix = std::time::SystemTime::now()
@@ -231,19 +246,81 @@ mod tests {
         .unwrap();
         let mut state = AnnotationState::from_path(Some(path.clone()));
 
-        state.refresh_if_changed().await;
+        assert!(state.refresh_if_changed().await);
         assert_eq!(state.snapshot().unwrap().len(), 1);
-        assert!(state.warning().is_none());
+        assert!(state.footer_status().is_none());
+        assert!(!state.refresh_if_changed().await);
 
         tokio::fs::write(&path, "{\"time\":").await.unwrap();
         state.refresh_if_changed().await;
         assert_eq!(state.snapshot().unwrap().len(), 1);
-        assert!(state.warning().unwrap().contains("using 1 previous event"));
+        assert!(
+            state
+                .footer_status()
+                .unwrap()
+                .contains("using 1 previous event")
+        );
 
         tokio::fs::write(&path, "").await.unwrap();
         state.refresh_if_changed().await;
         assert_eq!(state.snapshot().unwrap().len(), 0);
-        assert!(state.warning().is_none());
+        assert!(state.footer_status().is_none());
+
+        tokio::fs::remove_file(path).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn state_composes_source_target_warnings_and_filter_summary() {
+        let path = temp_path("state-status");
+        tokio::fs::write(
+            &path,
+            concat!(
+                r#"{"time":"2026-08-11T14:30:00Z","text":"deploy","panel_titles":["CPU","Missing"]}"#,
+                "\n",
+            ),
+        )
+        .await
+        .unwrap();
+        let mut state = AnnotationState::from_path(Some(path.clone()));
+
+        assert!(state.refresh_if_changed().await);
+        state.reconcile_targets(&["CPU".to_string(), "CPU".to_string()]);
+        assert_eq!(
+            state.footer_status(),
+            Some(
+                "target \"CPU\" matches 2 graph/timeseries panels; applied to all (+1 more)"
+                    .to_string()
+            )
+        );
+
+        tokio::fs::write(&path, "{").await.unwrap();
+        assert!(!state.refresh_if_changed().await);
+        let source_first_status = state.footer_status().unwrap();
+        assert!(source_first_status.starts_with(&format!("{}:1:", path.display())));
+        assert!(source_first_status.contains("using 1 previous event(s)"));
+        assert!(source_first_status.contains("(+2 more)"));
+
+        tokio::fs::write(
+            &path,
+            concat!(
+                r#"{"time":"2026-08-11T14:30:00Z","text":"deploy","panel_titles":["Memory"]}"#,
+                "\n",
+            ),
+        )
+        .await
+        .unwrap();
+        assert!(state.refresh_if_changed().await);
+        state.reconcile_targets(&["Memory".to_string()]);
+        assert_eq!(state.footer_status(), None);
+
+        state.set_filter(TagFilter::from_selected([
+            "incident".to_string(),
+            "deploy".to_string(),
+        ]));
+        assert_eq!(
+            state.footer_status(),
+            Some("tags deploy|incident".to_string())
+        );
 
         tokio::fs::remove_file(path).await.unwrap();
     }
@@ -267,16 +344,22 @@ mod tests {
         tokio::fs::remove_file(&path).await.unwrap();
         state.refresh_if_changed().await;
         assert_eq!(state.snapshot().unwrap().len(), 1);
-        assert!(state.warning().unwrap().contains("using 1 previous event"));
+        assert!(
+            state
+                .footer_status()
+                .unwrap()
+                .contains("using 1 previous event")
+        );
     }
 
-    #[test]
-    fn disabled_state_has_no_source_work_or_visibility() {
+    #[tokio::test]
+    async fn disabled_state_has_no_source_work_or_visibility() {
         let mut state = AnnotationState::from_path(None);
         assert!(!state.is_configured());
         assert!(!state.is_visible());
         assert!(state.snapshot().is_none());
-        assert_eq!(state.status(), AnnotationSourceStatus::Disabled);
+        assert!(state.footer_status().is_none());
+        assert!(!state.refresh_if_changed().await);
         state.toggle_visibility();
         assert!(!state.is_visible());
     }

--- a/src/annotations/mod.rs
+++ b/src/annotations/mod.rs
@@ -1,11 +1,13 @@
 use std::path::PathBuf;
 
 mod details;
+mod filter;
 mod jsonl;
 mod model;
 mod projection;
 
 pub(crate) use details::format_cluster_detail_lines;
+pub(crate) use filter::{TagCatalogueEntry, TagFilter, tag_catalogue};
 pub(crate) use jsonl::{JsonlFileSource, SourcePoll};
 pub(crate) use model::{
     AnnotationEvent, AnnotationPanelContext, AnnotationSnapshot, AnnotationTarget,
@@ -26,6 +28,7 @@ pub(crate) enum AnnotationState {
     Active {
         source: Option<JsonlFileSource>,
         snapshot: AnnotationSnapshot,
+        filter: TagFilter,
         visible: bool,
         status: AnnotationSourceStatus,
     },
@@ -37,6 +40,7 @@ impl AnnotationState {
             Some(path) => Self::Active {
                 source: Some(JsonlFileSource::new(path)),
                 snapshot: AnnotationSnapshot::new(Vec::new()),
+                filter: TagFilter::default(),
                 visible: true,
                 status: AnnotationSourceStatus::Loaded(0),
             },
@@ -121,17 +125,41 @@ impl AnnotationState {
         }
     }
 
+    pub(crate) fn set_filter(&mut self, next: TagFilter) {
+        if let Self::Active { filter, .. } = self {
+            *filter = next;
+        }
+    }
+
+    pub(crate) fn applied_filter(&self) -> Option<&TagFilter> {
+        match self {
+            Self::Active { filter, .. } => Some(filter),
+            Self::Disabled => None,
+        }
+    }
+
+    pub(crate) fn effective_filter(
+        &self,
+        _panel: AnnotationPanelContext<'_>,
+    ) -> Option<&TagFilter> {
+        self.applied_filter()
+    }
+
     pub(crate) fn events_for_panel(
         &self,
         panel: AnnotationPanelContext<'_>,
         bounds: [f64; 2],
     ) -> Vec<&AnnotationEvent> {
+        let Some(filter) = self.effective_filter(panel) else {
+            return Vec::new();
+        };
+
         match self {
             Self::Active {
                 snapshot,
                 visible: true,
                 ..
-            } => projection::events_for_panel(snapshot, panel, bounds),
+            } => projection::events_for_panel(snapshot, filter, panel, bounds),
             Self::Disabled | Self::Active { .. } => Vec::new(),
         }
     }
@@ -143,6 +171,7 @@ impl AnnotationState {
         Self::Active {
             source: None,
             snapshot,
+            filter: TagFilter::default(),
             visible: true,
             status: AnnotationSourceStatus::Loaded(event_count),
         }
@@ -153,6 +182,7 @@ impl AnnotationState {
         Self::Active {
             source: None,
             snapshot: AnnotationSnapshot::new(Vec::new()),
+            filter: TagFilter::default(),
             visible: true,
             status: AnnotationSourceStatus::Warning(message.to_string()),
         }
@@ -174,7 +204,10 @@ pub(crate) fn test_event_at(timestamp_secs: f64, text: &str) -> AnnotationEvent 
 mod tests {
     use std::path::PathBuf;
 
-    use super::{AnnotationSourceStatus, AnnotationState};
+    use super::{
+        AnnotationPanelContext, AnnotationSourceStatus, AnnotationState, AnnotationTarget,
+        TagFilter,
+    };
 
     fn temp_path(name: &str) -> PathBuf {
         let suffix = std::time::SystemTime::now()
@@ -246,5 +279,39 @@ mod tests {
         assert_eq!(state.status(), AnnotationSourceStatus::Disabled);
         state.toggle_visibility();
         assert!(!state.is_visible());
+    }
+
+    #[test]
+    fn active_state_applies_one_global_filter_when_routing_each_panel() {
+        let mut deploy = super::test_event_at(10.0, "deploy");
+        deploy.tags = vec!["deploy".to_string()];
+        deploy.target = AnnotationTarget::PanelTitles(["CPU".to_string()].into_iter().collect());
+
+        let mut incident = super::test_event_at(20.0, "incident");
+        incident.tags = vec!["incident".to_string()];
+        let mut state = AnnotationState::from_events_for_test(vec![deploy, incident]);
+        state.set_filter(TagFilter::from_selected(["deploy".to_string()]));
+
+        assert_eq!(state.applied_filter().unwrap().summary(), "deploy");
+        assert_eq!(
+            state
+                .effective_filter(AnnotationPanelContext { title: "CPU" })
+                .unwrap()
+                .summary(),
+            "deploy"
+        );
+        assert_eq!(
+            state
+                .events_for_panel(AnnotationPanelContext { title: "CPU" }, [0.0, 100.0])
+                .iter()
+                .map(|event| event.text.as_str())
+                .collect::<Vec<_>>(),
+            vec!["deploy"]
+        );
+        assert!(
+            state
+                .events_for_panel(AnnotationPanelContext { title: "Memory" }, [0.0, 100.0])
+                .is_empty()
+        );
     }
 }

--- a/src/annotations/mod.rs
+++ b/src/annotations/mod.rs
@@ -150,10 +150,8 @@ impl AnnotationState {
         }
     }
 
-    pub(crate) fn effective_filter(
-        &self,
-        _panel: AnnotationPanelContext<'_>,
-    ) -> Option<&TagFilter> {
+    pub(crate) fn effective_filter(&self, panel: AnnotationPanelContext<'_>) -> Option<&TagFilter> {
+        let _panel_index = panel.index;
         self.applied_filter()
     }
 
@@ -378,14 +376,23 @@ mod tests {
         assert_eq!(state.applied_filter().unwrap().summary(), "deploy");
         assert_eq!(
             state
-                .effective_filter(AnnotationPanelContext { title: "CPU" })
+                .effective_filter(AnnotationPanelContext {
+                    index: 0,
+                    title: "CPU",
+                })
                 .unwrap()
                 .summary(),
             "deploy"
         );
         assert_eq!(
             state
-                .events_for_panel(AnnotationPanelContext { title: "CPU" }, [0.0, 100.0])
+                .events_for_panel(
+                    AnnotationPanelContext {
+                        index: 0,
+                        title: "CPU",
+                    },
+                    [0.0, 100.0],
+                )
                 .iter()
                 .map(|event| event.text.as_str())
                 .collect::<Vec<_>>(),
@@ -393,7 +400,13 @@ mod tests {
         );
         assert!(
             state
-                .events_for_panel(AnnotationPanelContext { title: "Memory" }, [0.0, 100.0])
+                .events_for_panel(
+                    AnnotationPanelContext {
+                        index: 1,
+                        title: "Memory",
+                    },
+                    [0.0, 100.0],
+                )
                 .is_empty()
         );
     }

--- a/src/annotations/mod.rs
+++ b/src/annotations/mod.rs
@@ -9,7 +9,6 @@ mod model;
 mod projection;
 
 pub(crate) use details::format_cluster_detail_lines;
-#[allow(unused_imports)]
 pub(crate) use details::format_event_time;
 pub(crate) use diagnostics::{AnnotationTargetWarning, target_warnings};
 #[allow(unused_imports)]
@@ -17,7 +16,6 @@ pub(crate) use filter::tag_catalogue;
 pub(crate) use filter::{TagCatalogueEntry, TagFilter};
 pub(crate) use jsonl::{JsonlFileSource, SourcePoll};
 pub(crate) use modal::TagFilterModalState;
-#[allow(unused_imports)]
 pub(crate) use modal::{AnnotationModal, ClusterModalState, visible_range};
 pub(crate) use model::{
     AnnotationEvent, AnnotationPanelContext, AnnotationSnapshot, AnnotationTarget,
@@ -145,7 +143,6 @@ impl AnnotationState {
         }
     }
 
-    #[allow(dead_code)]
     pub(crate) fn set_filter(&mut self, next: TagFilter) {
         if let Self::Active { filter, .. } = self {
             *filter = next;
@@ -159,7 +156,6 @@ impl AnnotationState {
         }
     }
 
-    #[allow(dead_code)]
     pub(crate) fn new_tag_filter_modal(&self) -> Option<TagFilterModalState> {
         match self {
             Self::Disabled => None,

--- a/src/annotations/mod.rs
+++ b/src/annotations/mod.rs
@@ -4,13 +4,21 @@ mod details;
 mod diagnostics;
 mod filter;
 mod jsonl;
+mod modal;
 mod model;
 mod projection;
 
 pub(crate) use details::format_cluster_detail_lines;
+#[allow(unused_imports)]
+pub(crate) use details::format_event_time;
 pub(crate) use diagnostics::{AnnotationTargetWarning, target_warnings};
-pub(crate) use filter::{TagCatalogueEntry, TagFilter, tag_catalogue};
+#[allow(unused_imports)]
+pub(crate) use filter::tag_catalogue;
+pub(crate) use filter::{TagCatalogueEntry, TagFilter};
 pub(crate) use jsonl::{JsonlFileSource, SourcePoll};
+pub(crate) use modal::TagFilterModalState;
+#[allow(unused_imports)]
+pub(crate) use modal::{AnnotationModal, ClusterModalState, visible_range};
 pub(crate) use model::{
     AnnotationEvent, AnnotationPanelContext, AnnotationSnapshot, AnnotationTarget,
 };
@@ -137,6 +145,7 @@ impl AnnotationState {
         }
     }
 
+    #[allow(dead_code)]
     pub(crate) fn set_filter(&mut self, next: TagFilter) {
         if let Self::Active { filter, .. } = self {
             *filter = next;
@@ -147,6 +156,19 @@ impl AnnotationState {
         match self {
             Self::Active { filter, .. } => Some(filter),
             Self::Disabled => None,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn new_tag_filter_modal(&self) -> Option<TagFilterModalState> {
+        match self {
+            Self::Disabled => None,
+            Self::Active {
+                snapshot, filter, ..
+            } => Some(TagFilterModalState::new(
+                filter::tag_catalogue(snapshot, filter),
+                filter.clone(),
+            )),
         }
     }
 

--- a/src/annotations/modal.rs
+++ b/src/annotations/modal.rs
@@ -3,20 +3,17 @@ use std::ops::Range;
 use super::{AnnotationEvent, TagCatalogueEntry, TagFilter};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[allow(dead_code)]
 pub(crate) enum AnnotationModal {
     Cluster(ClusterModalState),
     TagFilter(TagFilterModalState),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[allow(dead_code)]
 pub(crate) struct ClusterModalState {
     events: Vec<AnnotationEvent>,
     selected: usize,
 }
 
-#[allow(dead_code)]
 impl ClusterModalState {
     pub(crate) fn new(events: Vec<AnnotationEvent>) -> Option<Self> {
         (!events.is_empty()).then_some(Self {
@@ -55,14 +52,12 @@ impl ClusterModalState {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[allow(dead_code)]
 pub(crate) struct TagFilterModalState {
     entries: Vec<TagCatalogueEntry>,
     selected: usize,
     draft: TagFilter,
 }
 
-#[allow(dead_code)]
 impl TagFilterModalState {
     pub(crate) fn new(entries: Vec<TagCatalogueEntry>, draft: TagFilter) -> Self {
         Self {
@@ -99,7 +94,6 @@ impl TagFilterModalState {
     }
 }
 
-#[allow(dead_code)]
 pub(crate) fn visible_range(total: usize, selected: usize, rows: usize) -> Range<usize> {
     if total == 0 || rows == 0 {
         return 0..0;
@@ -109,7 +103,6 @@ pub(crate) fn visible_range(total: usize, selected: usize, rows: usize) -> Range
     start..start.saturating_add(rows).min(total)
 }
 
-#[allow(dead_code)]
 fn moved_index(current: usize, len: usize, delta: isize) -> usize {
     if len == 0 {
         return 0;

--- a/src/annotations/modal.rs
+++ b/src/annotations/modal.rs
@@ -1,0 +1,210 @@
+use std::ops::Range;
+
+use super::{AnnotationEvent, TagCatalogueEntry, TagFilter};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(dead_code)]
+pub(crate) enum AnnotationModal {
+    Cluster(ClusterModalState),
+    TagFilter(TagFilterModalState),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(dead_code)]
+pub(crate) struct ClusterModalState {
+    events: Vec<AnnotationEvent>,
+    selected: usize,
+}
+
+#[allow(dead_code)]
+impl ClusterModalState {
+    pub(crate) fn new(events: Vec<AnnotationEvent>) -> Option<Self> {
+        (!events.is_empty()).then_some(Self {
+            events,
+            selected: 0,
+        })
+    }
+
+    pub(crate) fn move_by(&mut self, delta: isize) {
+        self.selected = moved_index(self.selected, self.events.len(), delta);
+    }
+
+    pub(crate) fn move_page(&mut self, direction: isize, rows: usize) {
+        let page_delta = direction.unsigned_abs().saturating_mul(rows);
+        if direction < 0 {
+            self.selected = self.selected.saturating_sub(page_delta);
+        } else {
+            self.selected = self
+                .selected
+                .saturating_add(page_delta)
+                .min(self.events.len().saturating_sub(1));
+        }
+    }
+
+    pub(crate) fn events(&self) -> &[AnnotationEvent] {
+        &self.events
+    }
+
+    pub(crate) fn selected(&self) -> usize {
+        self.selected
+    }
+
+    pub(crate) fn selected_event(&self) -> Option<&AnnotationEvent> {
+        self.events.get(self.selected)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(dead_code)]
+pub(crate) struct TagFilterModalState {
+    entries: Vec<TagCatalogueEntry>,
+    selected: usize,
+    draft: TagFilter,
+}
+
+#[allow(dead_code)]
+impl TagFilterModalState {
+    pub(crate) fn new(entries: Vec<TagCatalogueEntry>, draft: TagFilter) -> Self {
+        Self {
+            entries,
+            selected: 0,
+            draft,
+        }
+    }
+
+    pub(crate) fn move_by(&mut self, delta: isize) {
+        self.selected = moved_index(self.selected, self.entries.len(), delta);
+    }
+
+    pub(crate) fn toggle_selected(&mut self) {
+        if let Some(entry) = self.entries.get(self.selected) {
+            self.draft.toggle(&entry.tag);
+        }
+    }
+
+    pub(crate) fn clear(&mut self) {
+        self.draft.clear();
+    }
+
+    pub(crate) fn entries(&self) -> &[TagCatalogueEntry] {
+        &self.entries
+    }
+
+    pub(crate) fn selected(&self) -> usize {
+        self.selected
+    }
+
+    pub(crate) fn draft(&self) -> &TagFilter {
+        &self.draft
+    }
+}
+
+#[allow(dead_code)]
+pub(crate) fn visible_range(total: usize, selected: usize, rows: usize) -> Range<usize> {
+    if total == 0 || rows == 0 {
+        return 0..0;
+    }
+    let selected = selected.min(total - 1);
+    let start = (selected / rows) * rows;
+    start..start.saturating_add(rows).min(total)
+}
+
+#[allow(dead_code)]
+fn moved_index(current: usize, len: usize, delta: isize) -> usize {
+    if len == 0 {
+        return 0;
+    }
+    if delta < 0 {
+        current.saturating_sub(delta.unsigned_abs())
+    } else {
+        current.saturating_add(delta as usize).min(len - 1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ClusterModalState, TagFilterModalState, visible_range};
+    use crate::annotations::{TagCatalogueEntry, TagFilter};
+
+    #[test]
+    fn cluster_modal_owns_events_and_bounds_navigation() {
+        let events = vec![
+            crate::annotations::test_event_at(10.0, "one"),
+            crate::annotations::test_event_at(11.0, "two"),
+            crate::annotations::test_event_at(12.0, "three"),
+        ];
+        let mut modal = ClusterModalState::new(events).unwrap();
+
+        modal.move_by(1);
+        assert_eq!(modal.selected_event().unwrap().text, "two");
+        modal.move_by(100);
+        assert_eq!(modal.selected_event().unwrap().text, "three");
+        modal.move_page(-1, 2);
+        assert_eq!(modal.selected_event().unwrap().text, "one");
+    }
+
+    #[test]
+    fn cluster_modal_rejects_empty_events() {
+        assert!(ClusterModalState::new(Vec::new()).is_none());
+    }
+
+    #[test]
+    fn cluster_modal_clamps_extreme_page_sizes_in_each_direction() {
+        let events = vec![
+            crate::annotations::test_event_at(10.0, "one"),
+            crate::annotations::test_event_at(11.0, "two"),
+            crate::annotations::test_event_at(12.0, "three"),
+        ];
+        let mut modal = ClusterModalState::new(events).unwrap();
+
+        modal.move_page(1, usize::MAX);
+        assert_eq!(modal.selected_event().unwrap().text, "three");
+        modal.move_page(-1, usize::MAX);
+        assert_eq!(modal.selected_event().unwrap().text, "one");
+        modal.move_page(isize::MAX, usize::MAX);
+        assert_eq!(modal.selected_event().unwrap().text, "three");
+        modal.move_page(isize::MIN, usize::MAX);
+        assert_eq!(modal.selected_event().unwrap().text, "one");
+    }
+
+    #[test]
+    fn tag_modal_edits_a_draft_without_changing_the_applied_filter() {
+        let applied = TagFilter::from_selected(["deploy".to_string()]);
+        let entries = vec![
+            TagCatalogueEntry {
+                tag: "deploy".to_string(),
+                count: 2,
+            },
+            TagCatalogueEntry {
+                tag: "incident".to_string(),
+                count: 1,
+            },
+        ];
+        let mut modal = TagFilterModalState::new(entries, applied.clone());
+
+        modal.move_by(1);
+        modal.toggle_selected();
+        assert_eq!(applied.summary(), "deploy");
+        assert_eq!(modal.draft().summary(), "deploy|incident");
+        modal.clear();
+        assert!(modal.draft().is_empty());
+    }
+
+    #[test]
+    fn tag_modal_ignores_toggles_for_an_empty_catalogue() {
+        let applied = TagFilter::from_selected(["deploy".to_string()]);
+        let mut modal = TagFilterModalState::new(Vec::new(), applied.clone());
+
+        modal.toggle_selected();
+
+        assert_eq!(modal.draft(), &applied);
+    }
+
+    #[test]
+    fn visible_range_is_empty_without_items_or_rows_and_contains_selection() {
+        assert_eq!(visible_range(0, 0, 3), 0..0);
+        assert_eq!(visible_range(3, 0, 0), 0..0);
+        assert_eq!(visible_range(5, 3, 2), 2..4);
+        assert_eq!(visible_range(5, 100, 2), 4..5);
+    }
+}

--- a/src/annotations/model.rs
+++ b/src/annotations/model.rs
@@ -1,8 +1,11 @@
+use std::collections::BTreeSet;
+
 use chrono::{DateTime, Utc};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum AnnotationTarget {
     All,
+    PanelTitles(BTreeSet<String>),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -47,8 +50,10 @@ pub(crate) struct AnnotationPanelContext<'a> {
 
 impl AnnotationTarget {
     pub(crate) fn applies_to(&self, panel: AnnotationPanelContext<'_>) -> bool {
-        let _ = panel.title;
-        matches!(self, Self::All)
+        match self {
+            Self::All => true,
+            Self::PanelTitles(titles) => titles.contains(panel.title),
+        }
     }
 }
 
@@ -56,7 +61,7 @@ impl AnnotationTarget {
 mod tests {
     use chrono::{DateTime, Utc};
 
-    use super::{AnnotationEvent, AnnotationSnapshot, AnnotationTarget};
+    use super::{AnnotationEvent, AnnotationPanelContext, AnnotationSnapshot, AnnotationTarget};
 
     fn event(time: &str, text: &str) -> AnnotationEvent {
         AnnotationEvent {
@@ -91,5 +96,13 @@ mod tests {
         let expected = event.time.timestamp() as f64 + 0.123_456_789;
 
         assert!((event.timestamp_secs() - expected).abs() < 1e-7);
+    }
+
+    #[test]
+    fn panel_title_target_matches_exactly_and_case_sensitively() {
+        let target = AnnotationTarget::PanelTitles(["CPU".to_string()].into_iter().collect());
+
+        assert!(target.applies_to(AnnotationPanelContext { title: "CPU" }));
+        assert!(!target.applies_to(AnnotationPanelContext { title: "cpu" }));
     }
 }

--- a/src/annotations/model.rs
+++ b/src/annotations/model.rs
@@ -45,6 +45,7 @@ impl AnnotationSnapshot {
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct AnnotationPanelContext<'a> {
+    pub(crate) index: usize,
     pub(crate) title: &'a str,
 }
 
@@ -102,7 +103,13 @@ mod tests {
     fn panel_title_target_matches_exactly_and_case_sensitively() {
         let target = AnnotationTarget::PanelTitles(["CPU".to_string()].into_iter().collect());
 
-        assert!(target.applies_to(AnnotationPanelContext { title: "CPU" }));
-        assert!(!target.applies_to(AnnotationPanelContext { title: "cpu" }));
+        assert!(target.applies_to(AnnotationPanelContext {
+            index: 0,
+            title: "CPU",
+        }));
+        assert!(!target.applies_to(AnnotationPanelContext {
+            index: 1,
+            title: "cpu",
+        }));
     }
 }

--- a/src/annotations/projection.rs
+++ b/src/annotations/projection.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use super::{AnnotationEvent, AnnotationPanelContext, AnnotationSnapshot};
+use super::{AnnotationEvent, AnnotationPanelContext, AnnotationSnapshot, TagFilter};
 
 #[derive(Debug)]
 pub(crate) struct AnnotationCluster<'a> {
@@ -10,6 +10,7 @@ pub(crate) struct AnnotationCluster<'a> {
 
 pub(crate) fn events_for_panel<'a>(
     snapshot: &'a AnnotationSnapshot,
+    filter: &TagFilter,
     panel: AnnotationPanelContext<'_>,
     bounds: [f64; 2],
 ) -> Vec<&'a AnnotationEvent> {
@@ -18,7 +19,10 @@ pub(crate) fn events_for_panel<'a>(
         .iter()
         .filter(|event| {
             let timestamp = event.timestamp_secs();
-            timestamp >= bounds[0] && timestamp <= bounds[1] && event.target.applies_to(panel)
+            timestamp >= bounds[0]
+                && timestamp <= bounds[1]
+                && filter.matches(event)
+                && event.target.applies_to(panel)
         })
         .collect()
 }
@@ -42,7 +46,10 @@ pub(crate) fn cluster_events_by<'a>(
 #[cfg(test)]
 mod tests {
     use super::{cluster_events_by, events_for_panel};
-    use crate::annotations::{AnnotationEvent, AnnotationPanelContext, AnnotationSnapshot};
+    use crate::annotations::{
+        AnnotationEvent, AnnotationPanelContext, AnnotationSnapshot, AnnotationTarget,
+        TagCatalogueEntry, TagFilter, tag_catalogue,
+    };
 
     fn event(timestamp: f64, text: &str) -> AnnotationEvent {
         crate::annotations::test_event_at(timestamp, text)
@@ -59,6 +66,7 @@ mod tests {
 
         let events = events_for_panel(
             &snapshot,
+            &TagFilter::default(),
             AnnotationPanelContext { title: "CPU" },
             [0.0, 100.0],
         );
@@ -73,6 +81,47 @@ mod tests {
     }
 
     #[test]
+    fn filters_by_exact_or_tags_before_panel_routing() {
+        let mut deploy = event(10.0, "deploy");
+        deploy.tags = vec!["deploy".to_string()];
+        deploy.target = AnnotationTarget::PanelTitles(["CPU".to_string()].into_iter().collect());
+
+        let mut incident = event(20.0, "incident");
+        incident.tags = vec!["incident".to_string()];
+        let snapshot = AnnotationSnapshot::new(vec![deploy, incident]);
+        let filter = TagFilter::from_selected(["deploy".to_string()]);
+
+        let cpu = events_for_panel(
+            &snapshot,
+            &filter,
+            AnnotationPanelContext { title: "CPU" },
+            [0.0, 100.0],
+        );
+        let memory = events_for_panel(
+            &snapshot,
+            &filter,
+            AnnotationPanelContext { title: "Memory" },
+            [0.0, 100.0],
+        );
+
+        assert_eq!(
+            cpu.iter()
+                .map(|event| event.text.as_str())
+                .collect::<Vec<_>>(),
+            vec!["deploy"]
+        );
+        assert!(memory.is_empty());
+    }
+
+    #[test]
+    fn catalogue_is_available_through_annotations_facade() {
+        assert_eq!(
+            tag_catalogue(&AnnotationSnapshot::default(), &TagFilter::default()),
+            Vec::<TagCatalogueEntry>::new()
+        );
+    }
+
+    #[test]
     fn clusters_events_by_projected_coordinate_in_order() {
         let snapshot = AnnotationSnapshot::new(vec![
             event(10.0, "one"),
@@ -81,6 +130,7 @@ mod tests {
         ]);
         let events = events_for_panel(
             &snapshot,
+            &TagFilter::default(),
             AnnotationPanelContext { title: "CPU" },
             [0.0, 100.0],
         );

--- a/src/annotations/projection.rs
+++ b/src/annotations/projection.rs
@@ -67,7 +67,10 @@ mod tests {
         let events = events_for_panel(
             &snapshot,
             &TagFilter::default(),
-            AnnotationPanelContext { title: "CPU" },
+            AnnotationPanelContext {
+                index: 0,
+                title: "CPU",
+            },
             [0.0, 100.0],
         );
 
@@ -94,13 +97,19 @@ mod tests {
         let cpu = events_for_panel(
             &snapshot,
             &filter,
-            AnnotationPanelContext { title: "CPU" },
+            AnnotationPanelContext {
+                index: 0,
+                title: "CPU",
+            },
             [0.0, 100.0],
         );
         let memory = events_for_panel(
             &snapshot,
             &filter,
-            AnnotationPanelContext { title: "Memory" },
+            AnnotationPanelContext {
+                index: 1,
+                title: "Memory",
+            },
             [0.0, 100.0],
         );
 
@@ -131,7 +140,10 @@ mod tests {
         let events = events_for_panel(
             &snapshot,
             &TagFilter::default(),
-            AnnotationPanelContext { title: "CPU" },
+            AnnotationPanelContext {
+                index: 0,
+                title: "CPU",
+            },
             [0.0, 100.0],
         );
 

--- a/src/app/event_loop.rs
+++ b/src/app/event_loop.rs
@@ -44,7 +44,10 @@ where
 
         if event::poll(timeout)? {
             let action = match event::read()? {
-                Event::Key(key) => input::handle_key(key, app).await?,
+                Event::Key(key) => {
+                    let size = terminal.size()?;
+                    input::handle_key(key, size, app).await?
+                }
                 Event::Mouse(mouse) => {
                     let size = terminal.size()?;
                     input::handle_mouse(mouse, size, app)?

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -15,6 +15,7 @@
  */
 
 use super::state::{AppMode, AppState, YAxisMode};
+use crate::annotations::AnnotationModal;
 use crate::ui;
 use anyhow::Result;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
@@ -34,13 +35,26 @@ enum SharedKeyResult {
     Unhandled,
 }
 
-pub(super) async fn handle_key(key: KeyEvent, app: &mut AppState) -> Result<InputAction> {
+pub(super) async fn handle_key(
+    key: KeyEvent,
+    terminal_size: Size,
+    app: &mut AppState,
+) -> Result<InputAction> {
     if key.code == KeyCode::Char('e') && key.modifiers.contains(KeyModifiers::CONTROL) {
         return Ok(InputAction::ToggleRecording);
     }
 
     if key.code == KeyCode::Char('e') && key.modifiers.is_empty() && app.mode != AppMode::Search {
         return Ok(InputAction::ExportCurrent);
+    }
+
+    if app.annotation_modal.is_some() {
+        return Ok(handle_annotation_modal_key(key, terminal_size, app));
+    }
+
+    if key.code == KeyCode::Char('t') && key.modifiers.is_empty() && app.mode != AppMode::Search {
+        app.open_tag_filter_modal();
+        return Ok(InputAction::Redraw);
     }
 
     if key.code == KeyCode::Char('a') && key.modifiers.is_empty() && app.mode != AppMode::Search {
@@ -58,11 +72,64 @@ pub(super) async fn handle_key(key: KeyEvent, app: &mut AppState) -> Result<Inpu
     Ok(action)
 }
 
+fn handle_annotation_modal_key(
+    key: KeyEvent,
+    terminal_size: Size,
+    app: &mut AppState,
+) -> InputAction {
+    match key.code {
+        KeyCode::Esc => app.annotation_modal = None,
+        KeyCode::Enter => {
+            let next_filter = match app.annotation_modal.as_ref() {
+                Some(AnnotationModal::TagFilter(state)) => Some(state.draft().clone()),
+                Some(AnnotationModal::Cluster(_)) | None => None,
+            };
+            app.annotation_modal = None;
+            if let Some(filter) = next_filter {
+                app.annotations.set_filter(filter);
+            }
+        }
+        KeyCode::Up | KeyCode::Char('k') => match app.annotation_modal.as_mut() {
+            Some(AnnotationModal::Cluster(state)) => state.move_by(-1),
+            Some(AnnotationModal::TagFilter(state)) => state.move_by(-1),
+            None => {}
+        },
+        KeyCode::Down | KeyCode::Char('j') => match app.annotation_modal.as_mut() {
+            Some(AnnotationModal::Cluster(state)) => state.move_by(1),
+            Some(AnnotationModal::TagFilter(state)) => state.move_by(1),
+            None => {}
+        },
+        KeyCode::PageUp | KeyCode::PageDown => {
+            let direction = if key.code == KeyCode::PageUp { -1 } else { 1 };
+            let rows = ui::annotation_cluster_page_size(terminal_size);
+            if let Some(AnnotationModal::Cluster(state)) = app.annotation_modal.as_mut() {
+                state.move_page(direction, rows);
+            }
+        }
+        KeyCode::Char(' ') => {
+            if let Some(AnnotationModal::TagFilter(state)) = app.annotation_modal.as_mut() {
+                state.toggle_selected();
+            }
+        }
+        KeyCode::Char('c') => {
+            if let Some(AnnotationModal::TagFilter(state)) = app.annotation_modal.as_mut() {
+                state.clear();
+            }
+        }
+        _ => {}
+    }
+    InputAction::Redraw
+}
+
 pub(super) fn handle_mouse(
     mouse: MouseEvent,
     terminal_size: Size,
     app: &mut AppState,
 ) -> Result<InputAction> {
+    if app.annotation_modal.is_some() {
+        return Ok(InputAction::Redraw);
+    }
+
     match mouse.kind {
         MouseEventKind::Down(MouseButton::Left) | MouseEventKind::Drag(MouseButton::Left) => {
             let rect = Rect::new(0, 0, terminal_size.width, terminal_size.height);
@@ -129,6 +196,10 @@ fn handle_search_key(key: KeyEvent, app: &mut AppState) -> InputAction {
 
 fn handle_inspect_key(key: KeyEvent, app: &mut AppState) -> InputAction {
     match key.code {
+        KeyCode::Enter => {
+            app.open_rendered_annotation_cluster();
+            InputAction::Redraw
+        }
         KeyCode::Esc | KeyCode::Char('v') => {
             app.mode = AppMode::Normal;
             app.cursor_x = None;
@@ -173,6 +244,10 @@ async fn handle_fullscreen_key(key: KeyEvent, app: &mut AppState) -> Result<Inpu
 
 fn handle_fullscreen_inspect_key(key: KeyEvent, app: &mut AppState) -> InputAction {
     match key.code {
+        KeyCode::Enter => {
+            app.open_rendered_annotation_cluster();
+            InputAction::Redraw
+        }
         KeyCode::Esc | KeyCode::Char('v') => {
             app.mode = AppMode::Fullscreen;
             app.cursor_x = None;
@@ -368,6 +443,10 @@ mod tests {
         KeyEvent::new(code, KeyModifiers::CONTROL)
     }
 
+    fn size() -> Size {
+        Size::new(100, 40)
+    }
+
     fn test_app() -> AppState {
         AppState::new(
             prom::PromClient::new("http://localhost:9090".to_string()),
@@ -418,14 +497,315 @@ mod tests {
         }
     }
 
+    fn tagged_event(text: &str, tag: &str) -> crate::annotations::AnnotationEvent {
+        let mut event = crate::annotations::test_event_at(50.0, text);
+        event.tags = vec![tag.to_string()];
+        event
+    }
+
+    #[tokio::test]
+    async fn t_opens_tag_filter_except_in_search_or_when_disabled() {
+        let mut app = test_app();
+        app.annotations =
+            crate::annotations::AnnotationState::from_events_for_test(vec![tagged_event(
+                "release", "deploy",
+            )]);
+
+        handle_key(key(KeyCode::Char('t')), size(), &mut app)
+            .await
+            .unwrap();
+        assert!(matches!(
+            app.annotation_modal,
+            Some(crate::annotations::AnnotationModal::TagFilter(_))
+        ));
+
+        app.annotation_modal = None;
+        app.mode = AppMode::Search;
+        handle_key(key(KeyCode::Char('t')), size(), &mut app)
+            .await
+            .unwrap();
+        assert_eq!(app.search_query, "t");
+
+        let mut disabled = test_app();
+        handle_key(key(KeyCode::Char('t')), size(), &mut disabled)
+            .await
+            .unwrap();
+        assert!(disabled.annotation_modal.is_none());
+    }
+
+    #[tokio::test]
+    async fn t_opens_tag_filter_while_annotation_markers_are_hidden() {
+        let mut app = test_app();
+        app.annotations =
+            crate::annotations::AnnotationState::from_events_for_test(vec![tagged_event(
+                "release", "deploy",
+            )]);
+        app.annotations.toggle_visibility();
+
+        handle_key(key(KeyCode::Char('t')), size(), &mut app)
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            app.annotation_modal,
+            Some(crate::annotations::AnnotationModal::TagFilter(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn enter_opens_only_the_rendered_selected_cluster_in_inspect_modes() {
+        let mut app = test_app();
+        app.rendered_annotation_cluster =
+            Some(vec![crate::annotations::test_event_at(50.0, "deploy")]);
+
+        handle_key(key(KeyCode::Enter), size(), &mut app)
+            .await
+            .unwrap();
+        assert!(app.annotation_modal.is_none());
+
+        app.mode = AppMode::Inspect;
+        handle_key(key(KeyCode::Enter), size(), &mut app)
+            .await
+            .unwrap();
+        assert!(matches!(
+            app.annotation_modal,
+            Some(crate::annotations::AnnotationModal::Cluster(_))
+        ));
+
+        app.annotation_modal = None;
+        app.mode = AppMode::FullscreenInspect;
+        handle_key(key(KeyCode::Enter), size(), &mut app)
+            .await
+            .unwrap();
+        assert!(matches!(
+            app.annotation_modal,
+            Some(crate::annotations::AnnotationModal::Cluster(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn modal_navigation_consumes_dashboard_navigation_and_zoom_keys() {
+        let mut app = test_app();
+        app.mode = AppMode::Inspect;
+        app.cursor_x = Some(50.0);
+        app.rendered_annotation_cluster = Some(vec![
+            crate::annotations::test_event_at(50.0, "one"),
+            crate::annotations::test_event_at(50.0, "two"),
+            crate::annotations::test_event_at(50.0, "three"),
+        ]);
+        let original_range = app.range;
+        let original_cursor = app.cursor_x;
+
+        handle_key(key(KeyCode::Enter), size(), &mut app)
+            .await
+            .unwrap();
+        handle_key(key(KeyCode::Char('j')), size(), &mut app)
+            .await
+            .unwrap();
+        handle_key(key(KeyCode::PageDown), size(), &mut app)
+            .await
+            .unwrap();
+        handle_key(key(KeyCode::Left), size(), &mut app)
+            .await
+            .unwrap();
+        handle_key(key(KeyCode::Char('+')), size(), &mut app)
+            .await
+            .unwrap();
+
+        let Some(crate::annotations::AnnotationModal::Cluster(modal)) =
+            app.annotation_modal.as_ref()
+        else {
+            panic!("cluster modal should remain open");
+        };
+        assert_eq!(modal.selected_event().unwrap().text, "three");
+        assert_eq!(app.range, original_range);
+        assert_eq!(app.cursor_x, original_cursor);
+
+        app.annotation_modal = None;
+        app.mode = AppMode::Normal;
+        app.annotations = crate::annotations::AnnotationState::from_events_for_test(vec![
+            tagged_event("release", "deploy"),
+            tagged_event("alert", "incident"),
+        ]);
+        handle_key(key(KeyCode::Char('t')), size(), &mut app)
+            .await
+            .unwrap();
+        handle_key(key(KeyCode::Char('j')), size(), &mut app)
+            .await
+            .unwrap();
+        handle_key(key(KeyCode::PageDown), size(), &mut app)
+            .await
+            .unwrap();
+        handle_key(key(KeyCode::Char('+')), size(), &mut app)
+            .await
+            .unwrap();
+
+        let Some(crate::annotations::AnnotationModal::TagFilter(modal)) =
+            app.annotation_modal.as_ref()
+        else {
+            panic!("tag modal should remain open");
+        };
+        assert_eq!(modal.selected(), 1);
+        assert_eq!(app.selected_panel, 0);
+        assert_eq!(app.range, original_range);
+    }
+
+    #[tokio::test]
+    async fn tag_filter_apply_cancel_and_clear_are_draft_isolated() {
+        let mut app = test_app();
+        app.annotations = crate::annotations::AnnotationState::from_events_for_test(vec![
+            tagged_event("release", "deploy"),
+            tagged_event("alert", "incident"),
+        ]);
+
+        handle_key(key(KeyCode::Char('t')), size(), &mut app)
+            .await
+            .unwrap();
+        handle_key(key(KeyCode::Char(' ')), size(), &mut app)
+            .await
+            .unwrap();
+        assert!(app.annotations.applied_filter().unwrap().is_empty());
+        handle_key(key(KeyCode::Enter), size(), &mut app)
+            .await
+            .unwrap();
+        assert!(app.annotation_modal.is_none());
+        assert_eq!(
+            app.annotations.applied_filter().unwrap().summary(),
+            "deploy"
+        );
+
+        handle_key(key(KeyCode::Char('t')), size(), &mut app)
+            .await
+            .unwrap();
+        handle_key(key(KeyCode::Char('j')), size(), &mut app)
+            .await
+            .unwrap();
+        handle_key(key(KeyCode::Char(' ')), size(), &mut app)
+            .await
+            .unwrap();
+        handle_key(key(KeyCode::Esc), size(), &mut app)
+            .await
+            .unwrap();
+        assert_eq!(
+            app.annotations.applied_filter().unwrap().summary(),
+            "deploy"
+        );
+
+        handle_key(key(KeyCode::Char('t')), size(), &mut app)
+            .await
+            .unwrap();
+        handle_key(key(KeyCode::Char('c')), size(), &mut app)
+            .await
+            .unwrap();
+        let Some(crate::annotations::AnnotationModal::TagFilter(modal)) =
+            app.annotation_modal.as_ref()
+        else {
+            panic!("tag modal should remain open");
+        };
+        assert!(modal.draft().is_empty());
+        assert_eq!(
+            app.annotations.applied_filter().unwrap().summary(),
+            "deploy"
+        );
+    }
+
+    #[tokio::test]
+    async fn enter_and_escape_close_cluster_without_changing_cursor_or_mode() {
+        let mut app = test_app();
+        app.mode = AppMode::Inspect;
+        app.cursor_x = Some(50.0);
+        app.rendered_annotation_cluster =
+            Some(vec![crate::annotations::test_event_at(50.0, "deploy")]);
+
+        handle_key(key(KeyCode::Enter), size(), &mut app)
+            .await
+            .unwrap();
+        handle_key(key(KeyCode::Enter), size(), &mut app)
+            .await
+            .unwrap();
+        assert!(app.annotation_modal.is_none());
+        assert_eq!(app.mode, AppMode::Inspect);
+        assert_eq!(app.cursor_x, Some(50.0));
+
+        app.open_rendered_annotation_cluster();
+        handle_key(key(KeyCode::Esc), size(), &mut app)
+            .await
+            .unwrap();
+        assert!(app.annotation_modal.is_none());
+        assert_eq!(app.mode, AppMode::Inspect);
+        assert_eq!(app.cursor_x, Some(50.0));
+    }
+
+    #[tokio::test]
+    async fn export_shortcuts_take_precedence_while_modal_is_open() {
+        let mut app = test_app();
+        app.annotations =
+            crate::annotations::AnnotationState::from_events_for_test(vec![tagged_event(
+                "release", "deploy",
+            )]);
+        app.open_tag_filter_modal();
+
+        let action = handle_key(key(KeyCode::Char('e')), size(), &mut app)
+            .await
+            .unwrap();
+        assert_eq!(action, InputAction::ExportCurrent);
+        assert!(app.annotation_modal.is_some());
+
+        let action = handle_key(ctrl_key(KeyCode::Char('e')), size(), &mut app)
+            .await
+            .unwrap();
+        assert_eq!(action, InputAction::ToggleRecording);
+        assert!(app.annotation_modal.is_some());
+    }
+
+    #[test]
+    fn mouse_events_do_not_mutate_dashboard_state_while_modal_is_open() {
+        let mut app = test_app();
+        app.annotations =
+            crate::annotations::AnnotationState::from_events_for_test(vec![tagged_event(
+                "release", "deploy",
+            )]);
+        app.open_tag_filter_modal();
+        app.mode = AppMode::FullscreenInspect;
+        app.selected_panel = 1;
+        app.cursor_x = Some(50.0);
+        app.vertical_scroll = 3;
+
+        for kind in [
+            MouseEventKind::ScrollDown,
+            MouseEventKind::Down(MouseButton::Left),
+            MouseEventKind::Drag(MouseButton::Left),
+        ] {
+            let action = handle_mouse(
+                MouseEvent {
+                    kind,
+                    column: 10,
+                    row: 10,
+                    modifiers: KeyModifiers::NONE,
+                },
+                size(),
+                &mut app,
+            )
+            .unwrap();
+            assert_eq!(action, InputAction::Redraw);
+            assert_eq!(app.selected_panel, 1);
+            assert_eq!(app.cursor_x, Some(50.0));
+            assert_eq!(app.vertical_scroll, 3);
+        }
+    }
+
     #[tokio::test]
     async fn normal_navigation_updates_selected_panel() {
         let mut app = test_app();
 
-        handle_key(key(KeyCode::Char('j')), &mut app).await.unwrap();
+        handle_key(key(KeyCode::Char('j')), size(), &mut app)
+            .await
+            .unwrap();
         assert_eq!(app.selected_panel, 1);
 
-        handle_key(key(KeyCode::Char('k')), &mut app).await.unwrap();
+        handle_key(key(KeyCode::Char('k')), size(), &mut app)
+            .await
+            .unwrap();
         assert_eq!(app.selected_panel, 0);
     }
 
@@ -433,10 +813,12 @@ mod tests {
     async fn export_shortcuts_return_export_actions() {
         let mut app = test_app();
 
-        let action = handle_key(key(KeyCode::Char('e')), &mut app).await.unwrap();
+        let action = handle_key(key(KeyCode::Char('e')), size(), &mut app)
+            .await
+            .unwrap();
         assert_eq!(action, InputAction::ExportCurrent);
 
-        let action = handle_key(ctrl_key(KeyCode::Char('e')), &mut app)
+        let action = handle_key(ctrl_key(KeyCode::Char('e')), size(), &mut app)
             .await
             .unwrap();
         assert_eq!(action, InputAction::ToggleRecording);
@@ -447,11 +829,13 @@ mod tests {
         let mut app = test_app();
         app.mode = AppMode::Search;
 
-        let action = handle_key(key(KeyCode::Char('e')), &mut app).await.unwrap();
+        let action = handle_key(key(KeyCode::Char('e')), size(), &mut app)
+            .await
+            .unwrap();
         assert_eq!(action, InputAction::Redraw);
         assert_eq!(app.search_query, "e");
 
-        let action = handle_key(ctrl_key(KeyCode::Char('e')), &mut app)
+        let action = handle_key(ctrl_key(KeyCode::Char('e')), size(), &mut app)
             .await
             .unwrap();
         assert_eq!(action, InputAction::ToggleRecording);
@@ -463,15 +847,21 @@ mod tests {
         let mut app = test_app();
         app.annotations = crate::annotations::AnnotationState::from_events_for_test(vec![]);
 
-        handle_key(key(KeyCode::Char('a')), &mut app).await.unwrap();
+        handle_key(key(KeyCode::Char('a')), size(), &mut app)
+            .await
+            .unwrap();
         assert!(!app.annotations.is_visible());
 
         app.mode = AppMode::Inspect;
-        handle_key(key(KeyCode::Char('a')), &mut app).await.unwrap();
+        handle_key(key(KeyCode::Char('a')), size(), &mut app)
+            .await
+            .unwrap();
         assert!(app.annotations.is_visible());
 
         app.mode = AppMode::Search;
-        handle_key(key(KeyCode::Char('a')), &mut app).await.unwrap();
+        handle_key(key(KeyCode::Char('a')), size(), &mut app)
+            .await
+            .unwrap();
         assert_eq!(app.search_query, "a");
     }
 
@@ -479,10 +869,14 @@ mod tests {
     async fn normal_digit_keys_toggle_series_and_zero_shows_all() {
         let mut app = test_app();
 
-        handle_key(key(KeyCode::Char('1')), &mut app).await.unwrap();
+        handle_key(key(KeyCode::Char('1')), size(), &mut app)
+            .await
+            .unwrap();
         assert!(!app.panels[0].series[0].visible);
 
-        handle_key(key(KeyCode::Char('0')), &mut app).await.unwrap();
+        handle_key(key(KeyCode::Char('0')), size(), &mut app)
+            .await
+            .unwrap();
         assert!(app.panels[0].series.iter().all(|series| series.visible));
     }
 
@@ -490,23 +884,35 @@ mod tests {
     async fn search_keys_update_query_results_and_selection() {
         let mut app = test_app();
 
-        handle_key(key(KeyCode::Char('/')), &mut app).await.unwrap();
+        handle_key(key(KeyCode::Char('/')), size(), &mut app)
+            .await
+            .unwrap();
         assert_eq!(app.mode, AppMode::Search);
 
-        handle_key(key(KeyCode::Char('m')), &mut app).await.unwrap();
+        handle_key(key(KeyCode::Char('m')), size(), &mut app)
+            .await
+            .unwrap();
         assert_eq!(app.search_query, "m");
         assert_eq!(app.search_results, vec![1]);
 
-        handle_key(key(KeyCode::Backspace), &mut app).await.unwrap();
+        handle_key(key(KeyCode::Backspace), size(), &mut app)
+            .await
+            .unwrap();
         assert!(app.search_query.is_empty());
         assert!(app.search_results.is_empty());
 
-        handle_key(key(KeyCode::Char('c')), &mut app).await.unwrap();
-        handle_key(key(KeyCode::Enter), &mut app).await.unwrap();
+        handle_key(key(KeyCode::Char('c')), size(), &mut app)
+            .await
+            .unwrap();
+        handle_key(key(KeyCode::Enter), size(), &mut app)
+            .await
+            .unwrap();
         assert_eq!(app.selected_panel, 0);
         assert_eq!(app.mode, AppMode::Fullscreen);
 
-        handle_key(key(KeyCode::Esc), &mut app).await.unwrap();
+        handle_key(key(KeyCode::Esc), size(), &mut app)
+            .await
+            .unwrap();
         assert_eq!(app.mode, AppMode::Normal);
     }
 
@@ -515,17 +921,25 @@ mod tests {
         let mut app = test_app();
         app.mode = AppMode::Fullscreen;
 
-        handle_key(key(KeyCode::PageDown), &mut app).await.unwrap();
+        handle_key(key(KeyCode::PageDown), size(), &mut app)
+            .await
+            .unwrap();
         assert_eq!(app.selected_panel, 1);
 
-        handle_key(key(KeyCode::PageUp), &mut app).await.unwrap();
+        handle_key(key(KeyCode::PageUp), size(), &mut app)
+            .await
+            .unwrap();
         assert_eq!(app.selected_panel, 0);
 
-        handle_key(key(KeyCode::Char('v')), &mut app).await.unwrap();
+        handle_key(key(KeyCode::Char('v')), size(), &mut app)
+            .await
+            .unwrap();
         assert_eq!(app.mode, AppMode::FullscreenInspect);
         assert!(app.cursor_x.is_some());
 
-        handle_key(key(KeyCode::Esc), &mut app).await.unwrap();
+        handle_key(key(KeyCode::Esc), size(), &mut app)
+            .await
+            .unwrap();
         assert_eq!(app.mode, AppMode::Fullscreen);
         assert!(app.cursor_x.is_none());
     }
@@ -534,10 +948,14 @@ mod tests {
     async fn shared_keys_toggle_autogrid_and_y_axis_mode() {
         let mut app = test_app();
 
-        handle_key(key(KeyCode::Char('g')), &mut app).await.unwrap();
+        handle_key(key(KeyCode::Char('g')), size(), &mut app)
+            .await
+            .unwrap();
         assert!(!app.autogrid_enabled);
 
-        handle_key(key(KeyCode::Char('y')), &mut app).await.unwrap();
+        handle_key(key(KeyCode::Char('y')), size(), &mut app)
+            .await
+            .unwrap();
         assert_eq!(app.panels[0].y_axis_mode, YAxisMode::ZeroBased);
     }
 }

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -485,7 +485,16 @@ impl AppState {
     }
 
     pub(crate) async fn refresh(&mut self) -> Result<()> {
-        self.annotations.refresh_if_changed().await;
+        let annotations_changed = self.annotations.refresh_if_changed().await;
+        if annotations_changed {
+            let eligible_titles = self
+                .panels
+                .iter()
+                .filter(|panel| panel.panel_type == PanelType::Graph)
+                .map(|panel| panel.title.clone())
+                .collect::<Vec<_>>();
+            self.annotations.reconcile_targets(&eligible_titles);
+        }
 
         let range = self.range;
         let step = self.step;
@@ -651,6 +660,28 @@ mod tests {
         )
     }
 
+    fn test_panel(title: &str, panel_type: PanelType) -> PanelState {
+        PanelState {
+            title: title.to_string(),
+            exprs: vec![],
+            legends: vec![],
+            query_modes: vec![],
+            series: vec![],
+            last_error: None,
+            last_url: None,
+            last_samples: 0,
+            grid: None,
+            y_axis_mode: YAxisMode::Auto,
+            panel_type,
+            thresholds: None,
+            min: None,
+            max: None,
+            autogrid: None,
+            display: crate::ui::DisplayFormat::default(),
+            options: PanelOptions::None,
+        }
+    }
+
     #[tokio::test]
     async fn test_empty_panels() {
         let mut app = create_test_app();
@@ -677,6 +708,41 @@ mod tests {
         app.refresh().await.unwrap();
 
         assert_eq!(app.annotations.snapshot().unwrap().len(), 1);
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[tokio::test]
+    async fn refresh_reconciles_annotation_targets() {
+        let path = temp_annotation_path("target-reconciliation");
+        std::fs::write(
+            &path,
+            concat!(
+                r#"{"time":"2026-08-11T14:30:00Z","text":"cpu","panel_titles":["CPU"]}"#,
+                "\n",
+                r#"{"time":"2026-08-11T14:31:00Z","text":"stat","panel_titles":["OnlyStat"]}"#,
+                "\n",
+                r#"{"time":"2026-08-11T14:32:00Z","text":"missing","panel_titles":["Missing"]}"#,
+                "\n",
+            ),
+        )
+        .unwrap();
+        let mut app = create_test_app();
+        app.panels = vec![
+            test_panel("CPU", PanelType::Graph),
+            test_panel("CPU", PanelType::Graph),
+            test_panel("OnlyStat", PanelType::Stat),
+        ];
+        app.annotations = crate::annotations::AnnotationState::from_path(Some(path.clone()));
+
+        app.refresh().await.unwrap();
+
+        assert_eq!(
+            app.annotations.footer_status(),
+            Some(
+                "target \"CPU\" matches 2 graph/timeseries panels; applied to all (+2 more)"
+                    .to_string()
+            )
+        );
         std::fs::remove_file(path).unwrap();
     }
 

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -274,6 +274,8 @@ pub(crate) struct AppState {
     pub(crate) prometheus: prom::PromClient,
     /// Optional external point-event state.
     pub(crate) annotations: crate::annotations::AnnotationState,
+    /// Owned active annotation cluster produced by the selected panel's latest draw.
+    pub(crate) rendered_annotation_cluster: Option<Vec<crate::annotations::AnnotationEvent>>,
     /// Current time range window.
     pub(crate) range: Duration,
     /// Query step resolution.
@@ -355,6 +357,7 @@ impl AppState {
         Self {
             prometheus,
             annotations: crate::annotations::AnnotationState::from_path(None),
+            rendered_annotation_cluster: None,
             range,
             step,
             refresh_every,

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -276,6 +276,8 @@ pub(crate) struct AppState {
     pub(crate) annotations: crate::annotations::AnnotationState,
     /// Owned active annotation cluster produced by the selected panel's latest draw.
     pub(crate) rendered_annotation_cluster: Option<Vec<crate::annotations::AnnotationEvent>>,
+    /// Active annotation exploration modal, if any.
+    pub(crate) annotation_modal: Option<crate::annotations::AnnotationModal>,
     /// Current time range window.
     pub(crate) range: Duration,
     /// Query step resolution.
@@ -358,6 +360,7 @@ impl AppState {
             prometheus,
             annotations: crate::annotations::AnnotationState::from_path(None),
             rendered_annotation_cluster: None,
+            annotation_modal: None,
             range,
             step,
             refresh_every,
@@ -484,6 +487,21 @@ impl AppState {
             self.cursor_x = Some(new_x.max(start_ts).min(end_ts));
         } else {
             self.cursor_x = Some((start_ts + end_ts) / 2.0);
+        }
+    }
+
+    pub(crate) fn open_rendered_annotation_cluster(&mut self) {
+        let Some(events) = self.rendered_annotation_cluster.clone() else {
+            return;
+        };
+        if let Some(modal) = crate::annotations::ClusterModalState::new(events) {
+            self.annotation_modal = Some(crate::annotations::AnnotationModal::Cluster(modal));
+        }
+    }
+
+    pub(crate) fn open_tag_filter_modal(&mut self) {
+        if let Some(modal) = self.annotations.new_tag_filter_modal() {
+            self.annotation_modal = Some(crate::annotations::AnnotationModal::TagFilter(modal));
         }
     }
 
@@ -711,6 +729,41 @@ mod tests {
         app.refresh().await.unwrap();
 
         assert_eq!(app.annotations.snapshot().unwrap().len(), 1);
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[tokio::test]
+    async fn reload_preserves_open_cluster_modal() {
+        let path = temp_annotation_path("open-cluster-reload");
+        std::fs::write(
+            &path,
+            "{\"time\":\"2026-07-23T14:30:00Z\",\"text\":\"initial\"}\n",
+        )
+        .unwrap();
+        let mut app = create_test_app();
+        app.annotations = crate::annotations::AnnotationState::from_path(Some(path.clone()));
+        app.refresh().await.unwrap();
+        app.rendered_annotation_cluster =
+            Some(app.annotations.snapshot().unwrap().events().to_vec());
+        app.open_rendered_annotation_cluster();
+
+        std::fs::write(
+            &path,
+            "{\"time\":\"2026-07-23T14:31:00Z\",\"text\":\"replacement event\"}\n",
+        )
+        .unwrap();
+        app.refresh().await.unwrap();
+
+        assert_eq!(
+            app.annotations.snapshot().unwrap().events()[0].text,
+            "replacement event"
+        );
+        let Some(crate::annotations::AnnotationModal::Cluster(modal)) =
+            app.annotation_modal.as_ref()
+        else {
+            panic!("cluster modal should remain open");
+        };
+        assert_eq!(modal.events()[0].text, "initial");
         std::fs::remove_file(path).unwrap();
     }
 

--- a/src/export.rs
+++ b/src/export.rs
@@ -1717,6 +1717,62 @@ mod tests {
         app
     }
 
+    fn targeted(
+        timestamp: f64,
+        text: &str,
+        tags: &[&str],
+        titles: &[&str],
+    ) -> crate::annotations::AnnotationEvent {
+        crate::annotations::AnnotationEvent {
+            time: chrono::DateTime::<chrono::Utc>::from_timestamp_millis(
+                (timestamp * 1_000.0).round() as i64,
+            )
+            .unwrap(),
+            text: text.to_string(),
+            tags: tags.iter().map(|tag| (*tag).to_string()).collect(),
+            target: crate::annotations::AnnotationTarget::PanelTitles(
+                titles.iter().map(|title| (*title).to_string()).collect(),
+            ),
+        }
+    }
+
+    fn global(timestamp: f64, text: &str, tags: &[&str]) -> crate::annotations::AnnotationEvent {
+        let mut event = crate::annotations::test_event_at(timestamp, text);
+        event.tags = tags.iter().map(|tag| (*tag).to_string()).collect();
+        event
+    }
+
+    fn panel_svg_section<'a>(svg: &'a str, title: &str, next_title: Option<&str>) -> &'a str {
+        let start = svg
+            .find(&format!(">{title}</text>"))
+            .unwrap_or_else(|| panic!("missing panel title {title}"));
+        let section = &svg[start..];
+        match next_title {
+            Some(next_title) => {
+                &section[..section
+                    .find(&format!(">{next_title}</text>"))
+                    .unwrap_or_else(|| panic!("missing next panel title {next_title}"))]
+            }
+            None => section,
+        }
+    }
+
+    fn assert_panel_title_offset(app: &AppState, viewport: Rect, index: usize) {
+        let (rect, _) = ui::visible_panel_rects(viewport, app)
+            .into_iter()
+            .find(|(_, panel_index)| *panel_index == index)
+            .unwrap_or_else(|| panic!("panel {index} is not visible"));
+        let rect = scaled_rect(rect);
+        let title = &app.panels[index].title;
+        let svg = render_svg(app, viewport);
+        assert!(svg.contains(&format!(
+            r#"<text x="{:.2}" y="{:.2}""#,
+            rect.left + 8.0,
+            rect.top + 18.0,
+        )));
+        assert!(svg.contains(&format!(">{title}</text>")));
+    }
+
     #[test]
     fn test_escape_xml() {
         assert_eq!(escape_xml("<a&b\"c'>"), "&lt;a&amp;b&quot;c&apos;&gt;");
@@ -1800,6 +1856,126 @@ mod tests {
 
         assert!(svg.contains(&ui::format_time(1_699_999_900.0)));
         assert!(svg.contains(&ui::format_time(1_700_000_000.0)));
+    }
+
+    #[test]
+    fn annotation_target_and_filter_are_shared_by_svg() {
+        let viewport = Rect::new(0, 0, 160, 50);
+        let mut app = test_app(ExportOptions::default());
+        app.panels.push(test_panel(app.view_end_ts as f64 - 100.0));
+        app.panels[0].title = "CPU".to_string();
+        app.panels[1].title = "Memory".to_string();
+        app.view_end_ts = 100;
+        app.range = std::time::Duration::from_secs(100);
+        app.cursor_x = Some(50.0);
+        app.annotations = crate::annotations::AnnotationState::from_events_for_test(vec![
+            targeted(50.0, "cpu deploy", &["deploy"], &["CPU"]),
+            targeted(50.0, "memory incident", &["incident"], &["Memory"]),
+            global(50.0, "global deploy", &["deploy"]),
+        ]);
+        app.annotations
+            .set_filter(crate::annotations::TagFilter::from_selected([
+                "deploy".to_string()
+            ]));
+
+        assert_panel_title_offset(&app, viewport, 0);
+        assert_panel_title_offset(&app, viewport, 1);
+        let svg = render_svg(&app, viewport);
+        let cpu = panel_svg_section(&svg, "CPU", Some("Memory"));
+        let memory = panel_svg_section(&svg, "Memory", None);
+
+        assert_eq!(cpu.matches(r#"data-role="annotation-marker""#).count(), 1);
+        assert!(cpu.contains(r#"data-role="annotation-count">2</text>"#));
+        assert!(cpu.contains("cpu deploy"));
+        assert!(cpu.contains("global deploy"));
+        assert!(!cpu.contains("memory incident"));
+
+        assert_eq!(
+            memory.matches(r#"data-role="annotation-marker""#).count(),
+            1
+        );
+        assert!(memory.contains(r#"data-role="annotation-count">•</text>"#));
+        assert!(memory.contains("global deploy"));
+        assert!(!memory.contains("cpu deploy"));
+        assert!(!memory.contains("memory incident"));
+    }
+
+    #[test]
+    fn annotation_modals_are_omitted_and_latest_snapshot_is_exported() {
+        let viewport = Rect::new(0, 0, 120, 50);
+        let mut app = test_app(ExportOptions::default());
+        app.view_end_ts = 100;
+        app.range = std::time::Duration::from_secs(100);
+        app.cursor_x = Some(50.0);
+        app.rendered_annotation_cluster = Some(vec![global(50.0, "old modal event", &[])]);
+        app.open_rendered_annotation_cluster();
+        app.annotations = crate::annotations::AnnotationState::from_events_for_test(vec![global(
+            50.0,
+            "latest snapshot event",
+            &["draft-only-tag"],
+        )]);
+
+        let svg = render_svg(&app, viewport);
+        assert!(!svg.contains("old modal event"));
+        assert!(svg.contains("latest snapshot event"));
+        assert!(!svg.contains("annotations modal"));
+
+        app.open_tag_filter_modal();
+        let Some(crate::annotations::AnnotationModal::TagFilter(modal)) =
+            app.annotation_modal.as_mut()
+        else {
+            panic!("tag filter modal should open");
+        };
+        modal.toggle_selected();
+
+        app.cursor_x = None;
+        let svg = render_svg(&app, viewport);
+        assert!(!svg.contains("Filter annotations by tag"));
+        assert!(!svg.contains("draft-only-tag"));
+    }
+
+    #[test]
+    fn recording_changes_only_after_filter_apply_or_clear() {
+        let dir = test_export_dir("annotation-filter-recording");
+        let viewport = Rect::new(0, 0, 120, 50);
+        let export = ExportOptions {
+            dir: dir.clone(),
+            format: ExportFormat::Svg,
+            record_max_frames: 10,
+        };
+        let mut app = test_app(export);
+        app.view_end_ts = 100;
+        app.range = std::time::Duration::from_secs(100);
+        app.annotations = crate::annotations::AnnotationState::from_events_for_test(vec![
+            global(50.0, "deploy event", &["deploy"]),
+            global(75.0, "incident event", &["incident"]),
+        ]);
+
+        toggle_recording(&mut app, viewport).unwrap();
+        assert_eq!(app.recording.as_ref().unwrap().frame_count, 1);
+
+        app.open_tag_filter_modal();
+        let draft = match app.annotation_modal.as_mut() {
+            Some(crate::annotations::AnnotationModal::TagFilter(modal)) => {
+                modal.toggle_selected();
+                modal.draft().clone()
+            }
+            _ => panic!("tag filter modal should open"),
+        };
+        capture_recording_frame(&mut app, viewport).unwrap();
+        assert_eq!(app.recording.as_ref().unwrap().frame_count, 1);
+
+        app.annotations.set_filter(draft);
+        capture_recording_frame(&mut app, viewport).unwrap();
+        assert_eq!(app.recording.as_ref().unwrap().frame_count, 2);
+
+        app.annotations
+            .set_filter(crate::annotations::TagFilter::default());
+        capture_recording_frame(&mut app, viewport).unwrap();
+        assert_eq!(app.recording.as_ref().unwrap().frame_count, 3);
+
+        toggle_recording(&mut app, viewport).unwrap();
+        fs::remove_dir_all(dir).unwrap();
     }
 
     #[test]

--- a/src/export.rs
+++ b/src/export.rs
@@ -1765,12 +1765,14 @@ mod tests {
         let rect = scaled_rect(rect);
         let title = &app.panels[index].title;
         let svg = render_svg(app, viewport);
-        assert!(svg.contains(&format!(
-            r#"<text x="{:.2}" y="{:.2}""#,
+        let title_element = format!(
+            r#"<text x="{:.2}" y="{:.2}" fill="{}" font-size="{FONT_SIZE:.1}" text-anchor="start">{}</text>"#,
             rect.left + 8.0,
             rect.top + 18.0,
-        )));
-        assert!(svg.contains(&format!(">{title}</text>")));
+            color_hex(app.theme.title, "#00c8ff"),
+            escape_xml(title),
+        );
+        assert!(svg.contains(&title_element));
     }
 
     #[test]

--- a/src/export.rs
+++ b/src/export.rs
@@ -300,7 +300,7 @@ pub(crate) fn render_svg(app: &AppState, viewport: Rect) -> String {
         };
         let selected = index == app.selected_panel;
         let panel_rect = scaled_rect(rect);
-        render_panel(app, panel, panel_rect, selected, &mut out);
+        render_panel(app, index, panel, panel_rect, selected, &mut out);
     }
 
     render_footer(app, &mut out, width, height, &text, &border);
@@ -366,6 +366,7 @@ fn render_footer(
 
 fn render_panel(
     app: &AppState,
+    panel_index: usize,
     panel: &PanelState,
     rect: PlotRect,
     selected: bool,
@@ -417,7 +418,9 @@ fn render_panel(
     }
 
     match panel.panel_type {
-        PanelType::Graph | PanelType::Unknown => render_graph_panel(app, panel, inner, out),
+        PanelType::Graph | PanelType::Unknown => {
+            render_graph_panel(app, panel_index, panel, inner, out)
+        }
         PanelType::Stat => render_stat_panel(app, panel, inner, out),
         PanelType::Gauge => render_gauge_panel(app, panel, inner, out),
         PanelType::BarGauge => render_bar_gauge_panel(app, panel, inner, out),
@@ -426,7 +429,13 @@ fn render_panel(
     }
 }
 
-fn render_graph_panel(app: &AppState, panel: &PanelState, rect: PlotRect, out: &mut String) {
+fn render_graph_panel(
+    app: &AppState,
+    panel_index: usize,
+    panel: &PanelState,
+    rect: PlotRect,
+    out: &mut String,
+) {
     if rect.width < 120.0 || rect.height < 80.0 {
         return;
     }
@@ -438,6 +447,7 @@ fn render_graph_panel(app: &AppState, panel: &PanelState, rect: PlotRect, out: &
             .annotations
             .events_for_panel(
                 AnnotationPanelContext {
+                    index: panel_index,
                     title: &panel.title,
                 },
                 [x_min, x_max],
@@ -606,7 +616,7 @@ fn render_graph_panel(app: &AppState, panel: &PanelState, rect: PlotRect, out: &
     }
 
     let annotation_clusters = if annotations_enabled {
-        render_graph_annotations(app, panel, plot, x_bounds, out)
+        render_graph_annotations(app, panel_index, panel, plot, x_bounds, out)
     } else {
         Vec::new()
     };
@@ -677,6 +687,7 @@ fn render_graph_panel(app: &AppState, panel: &PanelState, rect: PlotRect, out: &
 
 fn render_graph_annotations<'a>(
     app: &'a AppState,
+    panel_index: usize,
     panel: &PanelState,
     plot: PlotRect,
     x_bounds: [f64; 2],
@@ -684,6 +695,7 @@ fn render_graph_annotations<'a>(
 ) -> Vec<AnnotationCluster<'a>> {
     let events = app.annotations.events_for_panel(
         AnnotationPanelContext {
+            index: panel_index,
             title: &panel.title,
         },
         x_bounds,

--- a/src/ui/annotations.rs
+++ b/src/ui/annotations.rs
@@ -1,0 +1,313 @@
+use super::layout::centered_rect;
+use crate::annotations::{
+    AnnotationModal, ClusterModalState, TagFilterModalState, format_event_time, visible_range,
+};
+use crate::app::AppState;
+use ratatui::{
+    Frame,
+    layout::{Constraint, Layout, Margin, Rect, Size},
+    style::{Modifier, Style},
+    text::Line,
+    widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph, Wrap},
+};
+
+const MODAL_WIDTH_PERCENT: u16 = 80;
+const MODAL_HEIGHT_PERCENT: u16 = 70;
+
+fn modal_area(size: Size) -> Rect {
+    centered_rect(
+        MODAL_WIDTH_PERCENT,
+        MODAL_HEIGHT_PERCENT,
+        Rect::new(0, 0, size.width, size.height),
+    )
+}
+
+fn cluster_chunks(area: Rect) -> [Rect; 4] {
+    let chunks = Layout::vertical([
+        Constraint::Length(1),
+        Constraint::Percentage(45),
+        Constraint::Min(2),
+        Constraint::Length(1),
+    ])
+    .split(area);
+    [chunks[0], chunks[1], chunks[2], chunks[3]]
+}
+
+pub(crate) fn annotation_cluster_page_size(size: Size) -> usize {
+    let outer = modal_area(size);
+    let inner = outer.inner(Margin {
+        vertical: 1,
+        horizontal: 1,
+    });
+    usize::from(cluster_chunks(inner)[1].height).max(1)
+}
+
+pub(crate) fn render_annotation_modal(frame: &mut Frame, app: &AppState) {
+    let Some(modal) = app.annotation_modal.as_ref() else {
+        return;
+    };
+    let frame_area = frame.area();
+    let area = modal_area(Size::new(frame_area.width, frame_area.height));
+    frame.render_widget(Clear, area);
+    match modal {
+        AnnotationModal::Cluster(state) => render_cluster_modal(frame, area, state, app),
+        AnnotationModal::TagFilter(state) => render_tag_filter_modal(frame, area, state, app),
+    }
+}
+
+fn modal_block<'a>(title: &'a str, app: &AppState) -> Block<'a> {
+    Block::default()
+        .title(title)
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(app.theme.border_selected))
+}
+
+fn render_cluster_modal(frame: &mut Frame, area: Rect, state: &ClusterModalState, app: &AppState) {
+    frame.render_widget(modal_block(" Annotation cluster ", app), area);
+    let inner = area.inner(Margin {
+        vertical: 1,
+        horizontal: 1,
+    });
+    let [header_area, list_area, detail_area, hints_area] = cluster_chunks(inner);
+    let total = state.events().len();
+    frame.render_widget(
+        Paragraph::new(format!(
+            "{total} annotations    {} / {total}",
+            state.selected().saturating_add(1)
+        )),
+        header_area,
+    );
+
+    let rows = usize::from(list_area.height);
+    let visible = visible_range(total, state.selected(), rows);
+    let items = state.events()[visible.clone()]
+        .iter()
+        .map(|event| {
+            let time = if event.time.timestamp_subsec_millis() == 0 {
+                event.time.format("%H:%M:%S").to_string()
+            } else {
+                event.time.format("%H:%M:%S%.3f").to_string()
+            };
+            ListItem::new(format!("{time}  {}", event.text))
+        })
+        .collect::<Vec<_>>();
+    let mut list_state = ListState::default();
+    if !items.is_empty() {
+        list_state.select(Some(state.selected().saturating_sub(visible.start)));
+    }
+    let list = List::new(items).highlight_symbol("▶ ").highlight_style(
+        Style::default()
+            .fg(app.theme.title)
+            .add_modifier(Modifier::BOLD),
+    );
+    frame.render_stateful_widget(list, list_area, &mut list_state);
+
+    if let Some(event) = state.selected_event() {
+        let tags = if event.tags.is_empty() {
+            "Tags: —".to_string()
+        } else {
+            format!("Tags: {}", event.tags.join(", "))
+        };
+        let detail = Paragraph::new(vec![
+            Line::from(format_event_time(event)),
+            Line::from(event.text.as_str()),
+            Line::from(tags),
+        ])
+        .wrap(Wrap { trim: false });
+        frame.render_widget(detail, detail_area);
+    }
+
+    frame.render_widget(
+        Paragraph::new("↑/↓ move  PgUp/PgDn page  Enter/Esc close"),
+        hints_area,
+    );
+}
+
+fn render_tag_filter_modal(
+    frame: &mut Frame,
+    area: Rect,
+    state: &TagFilterModalState,
+    app: &AppState,
+) {
+    frame.render_widget(modal_block(" Filter annotations by tag ", app), area);
+    let inner = area.inner(Margin {
+        vertical: 1,
+        horizontal: 1,
+    });
+    let chunks = Layout::vertical([Constraint::Min(1), Constraint::Length(1)]).split(inner);
+    let list_area = chunks[0];
+    let hints_area = chunks[1];
+    let rows = usize::from(list_area.height);
+    let visible = visible_range(state.entries().len(), state.selected(), rows);
+    let row_width = usize::from(list_area.width);
+    let items = state.entries()[visible.clone()]
+        .iter()
+        .map(|entry| {
+            let checked = if state.draft().selected().contains(&entry.tag) {
+                'x'
+            } else {
+                ' '
+            };
+            let label_width = row_width.saturating_sub(4 + entry.count.to_string().len());
+            ListItem::new(format!(
+                "[{checked}] {:<label_width$}{}",
+                entry.tag, entry.count
+            ))
+        })
+        .collect::<Vec<_>>();
+    let mut list_state = ListState::default();
+    if !items.is_empty() {
+        list_state.select(Some(state.selected().saturating_sub(visible.start)));
+    }
+    let list = List::new(items).highlight_style(
+        Style::default()
+            .fg(app.theme.title)
+            .add_modifier(Modifier::BOLD),
+    );
+    frame.render_stateful_widget(list, list_area, &mut list_state);
+    frame.render_widget(
+        Paragraph::new("Space toggle  c clear  Enter apply  Esc cancel"),
+        hints_area,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::annotations::{AnnotationEvent, AnnotationModal, AnnotationTarget, TagFilter};
+    use crate::app::AppState;
+    use crate::export::ExportOptions;
+    use crate::prom::PromClient;
+    use crate::theme::Theme;
+    use ratatui::{Terminal, backend::TestBackend};
+    use std::time::Duration;
+
+    fn test_app() -> AppState {
+        AppState::new(
+            PromClient::new("http://localhost:9090".to_string()),
+            Duration::from_secs(300),
+            Duration::from_secs(5),
+            Duration::from_secs(1),
+            "Test".to_string(),
+            vec![],
+            0,
+            Theme::default(),
+            "dashed-line".to_string(),
+            ExportOptions::default(),
+        )
+    }
+
+    fn event(time: &str, text: &str, tags: &[&str]) -> AnnotationEvent {
+        AnnotationEvent {
+            time: chrono::DateTime::parse_from_rfc3339(time)
+                .unwrap()
+                .with_timezone(&chrono::Utc),
+            text: text.to_string(),
+            tags: tags.iter().map(|tag| (*tag).to_string()).collect(),
+            target: AnnotationTarget::All,
+        }
+    }
+
+    fn buffer_text(terminal: &Terminal<TestBackend>) -> String {
+        let buffer = terminal.backend().buffer();
+        let mut output = String::new();
+        for y in buffer.area.y..buffer.area.bottom() {
+            for x in buffer.area.x..buffer.area.right() {
+                output.push_str(buffer.cell((x, y)).unwrap().symbol());
+            }
+            output.push('\n');
+        }
+        output
+    }
+
+    #[test]
+    fn cluster_modal_renders_summary_truncated_list_full_detail_and_hints() {
+        let long_text = format!(
+            "deploy {} wrapped detail reaches the final sentinel",
+            "abcdefghijklmnopqrstuvwxyz".repeat(3)
+        );
+        let events = vec![
+            event("2026-07-23T14:30:00.125Z", &long_text, &["prod", "api"]),
+            event("2026-07-23T14:30:01Z", "rollback", &[]),
+            event("2026-07-23T14:30:02Z", "resolved", &["incident"]),
+        ];
+        let mut app = test_app();
+        app.annotation_modal = Some(AnnotationModal::Cluster(
+            crate::annotations::ClusterModalState::new(events).unwrap(),
+        ));
+        let mut terminal = Terminal::new(TestBackend::new(100, 40)).unwrap();
+
+        terminal
+            .draw(|frame| render_annotation_modal(frame, &app))
+            .unwrap();
+        let text = buffer_text(&terminal);
+
+        assert!(text.contains("3 annotations"));
+        assert!(text.contains("1 / 3"));
+        assert!(text.contains("2026-07-23 14:30:00.125 UTC"));
+        assert!(text.contains("final sentinel"));
+        assert!(text.contains("Tags: prod, api"));
+        assert!(text.contains("↑/↓ move  PgUp/PgDn page  Enter/Esc close"));
+        assert_eq!(text.matches("final sentinel").count(), 1);
+    }
+
+    #[test]
+    fn tag_modal_renders_alphabetical_counts_selection_and_hints() {
+        let mut app = test_app();
+        app.annotations = crate::annotations::AnnotationState::from_events_for_test(vec![
+            event("2026-07-23T14:30:00Z", "alert", &["incident"]),
+            event("2026-07-23T14:31:00Z", "release", &["deploy"]),
+            event("2026-07-23T14:32:00Z", "release two", &["deploy"]),
+        ]);
+        app.annotations
+            .set_filter(TagFilter::from_selected(["deploy".to_string()]));
+        app.open_tag_filter_modal();
+        let mut terminal = Terminal::new(TestBackend::new(100, 40)).unwrap();
+
+        terminal
+            .draw(|frame| render_annotation_modal(frame, &app))
+            .unwrap();
+        let text = buffer_text(&terminal);
+        let deploy = text.find("[x] deploy").unwrap();
+        let incident = text.find("[ ] incident").unwrap();
+
+        assert!(deploy < incident);
+        assert!(
+            text.lines()
+                .any(|line| line.contains("│[x] deploy") && line.trim_end().ends_with("2│"))
+        );
+        assert!(
+            text.lines()
+                .any(|line| line.contains("│[ ] incident") && line.trim_end().ends_with("1│"))
+        );
+        assert!(text.contains("Space toggle  c clear  Enter apply  Esc cancel"));
+    }
+
+    #[test]
+    fn cluster_page_size_matches_rendered_list_rows() {
+        assert_eq!(annotation_cluster_page_size(Size::new(100, 40)), 12);
+        assert!(annotation_cluster_page_size(Size::new(1, 1)) > 0);
+    }
+
+    #[test]
+    fn annotation_modals_render_safely_on_a_small_terminal() {
+        let mut app = test_app();
+        app.annotation_modal = Some(AnnotationModal::Cluster(
+            crate::annotations::ClusterModalState::new(vec![event(
+                "2026-07-23T14:30:00Z",
+                "deploy",
+                &["prod"],
+            )])
+            .unwrap(),
+        ));
+        let mut terminal = Terminal::new(TestBackend::new(40, 12)).unwrap();
+
+        terminal
+            .draw(|frame| render_annotation_modal(frame, &app))
+            .unwrap();
+
+        let buffer = terminal.backend().buffer();
+        assert_eq!(buffer.area, Rect::new(0, 0, 40, 12));
+        assert_eq!(buffer.content().len(), 40 * 12);
+    }
+}

--- a/src/ui/draw.rs
+++ b/src/ui/draw.rs
@@ -190,8 +190,8 @@ fn build_footer_detail(app: &AppState) -> String {
         parts.push(format!("Cursor: {cursor_time}"));
     }
 
-    if let Some(warning) = app.annotations.warning() {
-        parts.push(format!("Annotations: {warning}"));
+    if let Some(status) = app.annotations.footer_status() {
+        parts.push(format!("Annotations: {status}"));
     }
 
     if let Some(status) = &app.export_status {
@@ -278,6 +278,28 @@ mod tests {
         assert!(detail.contains("Cursor:"));
         assert!(detail.contains("Annotations: events.jsonl:2: invalid time"));
         assert!(detail.contains("Exported frame.svg"));
+    }
+
+    #[test]
+    fn footer_composes_annotation_warning_with_sorted_filter_summary() {
+        let mut event = crate::annotations::test_event_at(10.0, "deploy");
+        event.target = crate::annotations::AnnotationTarget::PanelTitles(
+            ["CPU".to_string()].into_iter().collect(),
+        );
+        let mut app = test_app();
+        app.annotations = crate::annotations::AnnotationState::from_events_for_test(vec![event]);
+        app.annotations
+            .reconcile_targets(&["CPU".to_string(), "CPU".to_string()]);
+        app.annotations
+            .set_filter(crate::annotations::TagFilter::from_selected([
+                "incident".to_string(),
+                "deploy".to_string(),
+            ]));
+
+        assert_eq!(
+            build_footer_detail(&app),
+            "Annotations: target \"CPU\" matches 2 graph/timeseries panels; applied to all | tags deploy|incident"
+        );
     }
 
     #[test]

--- a/src/ui/draw.rs
+++ b/src/ui/draw.rs
@@ -23,7 +23,7 @@ use ratatui::{
     widgets::{Block, Borders, Clear, List, ListItem, Paragraph, Wrap},
 };
 
-pub(crate) fn draw_ui(frame: &mut Frame, app: &AppState) {
+pub(crate) fn draw_ui(frame: &mut Frame, app: &mut AppState) {
     let size = frame.area();
 
     // Layout: title bar, charts area, footer
@@ -59,9 +59,18 @@ pub(crate) fn draw_ui(frame: &mut Frame, app: &AppState) {
         horizontal: 1,
     });
 
+    let mut selected_rendered_cluster = None;
     if app.mode == AppMode::Fullscreen || app.mode == AppMode::FullscreenInspect {
         if let Some(p) = app.panels.get(app.selected_panel) {
-            render_panel(frame, inner_area, p, app, true, app.cursor_x);
+            selected_rendered_cluster = render_panel(
+                frame,
+                inner_area,
+                app.selected_panel,
+                p,
+                app,
+                true,
+                app.cursor_x,
+            );
         }
     } else {
         let has_grid = app.panels.iter().any(|p| p.grid.is_some());
@@ -76,7 +85,11 @@ pub(crate) fn draw_ui(frame: &mut Frame, app: &AppState) {
             // eprintln!("Rendering panel {} at {:?}", panel_idx, rect);
             if let Some(p) = app.panels.get(*panel_idx) {
                 let is_selected = *panel_idx == app.selected_panel;
-                render_panel(frame, *rect, p, app, is_selected, app.cursor_x);
+                let rendered_cluster =
+                    render_panel(frame, *rect, *panel_idx, p, app, is_selected, app.cursor_x);
+                if is_selected {
+                    selected_rendered_cluster = rendered_cluster;
+                }
             }
         }
 
@@ -89,6 +102,7 @@ pub(crate) fn draw_ui(frame: &mut Frame, app: &AppState) {
             // Let's make calculate_grid_layout return extras too.
         }
     }
+    app.rendered_annotation_cluster = selected_rendered_cluster;
 
     // Footer / Status bar
     let errors = app.panels.iter().filter(|p| p.last_error.is_some()).count();
@@ -248,6 +262,7 @@ fn centered_rect(percent_x: u16, percent_y: u16, r: Rect) -> Rect {
 mod tests {
     use super::*;
     use crate::{export::ExportOptions, prom::PromClient, theme::Theme};
+    use ratatui::{Terminal, backend::TestBackend};
 
     fn test_app() -> AppState {
         AppState::new(
@@ -262,6 +277,89 @@ mod tests {
             "dashed-line".to_string(),
             ExportOptions::default(),
         )
+    }
+
+    fn graph_panel(title: &str) -> PanelState {
+        PanelState {
+            title: title.to_string(),
+            exprs: vec![],
+            legends: vec![],
+            query_modes: vec![],
+            series: vec![],
+            last_error: None,
+            last_url: None,
+            last_samples: 0,
+            grid: None,
+            y_axis_mode: crate::app::YAxisMode::Auto,
+            panel_type: crate::app::PanelType::Graph,
+            thresholds: None,
+            min: None,
+            max: None,
+            autogrid: None,
+            display: crate::ui::DisplayFormat::default(),
+            options: crate::app::PanelOptions::None,
+        }
+    }
+
+    #[test]
+    fn draw_caches_only_selected_panels_active_filtered_cluster() {
+        let mut cpu_deploy = crate::annotations::test_event_at(50.0, "cpu deploy");
+        cpu_deploy.tags = vec!["deploy".to_string()];
+        cpu_deploy.target = crate::annotations::AnnotationTarget::PanelTitles(
+            ["CPU".to_string()].into_iter().collect(),
+        );
+        let mut cpu_incident = crate::annotations::test_event_at(50.0, "cpu incident");
+        cpu_incident.tags = vec!["incident".to_string()];
+        cpu_incident.target = crate::annotations::AnnotationTarget::PanelTitles(
+            ["CPU".to_string()].into_iter().collect(),
+        );
+        let mut memory_incident = crate::annotations::test_event_at(50.0, "memory incident");
+        memory_incident.tags = vec!["incident".to_string()];
+        memory_incident.target = crate::annotations::AnnotationTarget::PanelTitles(
+            ["Memory".to_string()].into_iter().collect(),
+        );
+        let mut app = test_app();
+        app.panels = vec![graph_panel("CPU"), graph_panel("Memory")];
+        app.view_end_ts = 100;
+        app.range = std::time::Duration::from_secs(100);
+        app.mode = AppMode::Inspect;
+        app.cursor_x = Some(50.0);
+        app.annotations = crate::annotations::AnnotationState::from_events_for_test(vec![
+            cpu_deploy,
+            cpu_incident,
+            memory_incident,
+        ]);
+        app.annotations
+            .set_filter(crate::annotations::TagFilter::from_selected([
+                "deploy".to_string()
+            ]));
+        let mut terminal = Terminal::new(TestBackend::new(120, 30)).unwrap();
+
+        terminal.draw(|frame| draw_ui(frame, &mut app)).unwrap();
+        assert_eq!(
+            app.rendered_annotation_cluster
+                .as_ref()
+                .unwrap()
+                .iter()
+                .map(|event| event.text.as_str())
+                .collect::<Vec<_>>(),
+            vec!["cpu deploy"]
+        );
+
+        app.selected_panel = 1;
+        terminal.draw(|frame| draw_ui(frame, &mut app)).unwrap();
+        assert!(app.rendered_annotation_cluster.is_none());
+
+        let mut memory_deploy = crate::annotations::test_event_at(50.0, "memory deploy");
+        memory_deploy.tags = vec!["deploy".to_string()];
+        memory_deploy.target = crate::annotations::AnnotationTarget::PanelTitles(
+            ["Memory".to_string()].into_iter().collect(),
+        );
+        app.annotations =
+            crate::annotations::AnnotationState::from_events_for_test(vec![memory_deploy]);
+        app.panels[1].panel_type = crate::app::PanelType::Unknown;
+        terminal.draw(|frame| draw_ui(frame, &mut app)).unwrap();
+        assert!(app.rendered_annotation_cluster.is_none());
     }
 
     #[test]

--- a/src/ui/draw.rs
+++ b/src/ui/draw.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use super::layout::{calculate_grid_layout, calculate_two_column_layout};
+use super::layout::{calculate_grid_layout, calculate_two_column_layout, centered_rect};
 use super::panels::render_panel;
 use crate::app::{AppMode, AppState, PanelState};
 use humantime::format_duration;
@@ -190,6 +190,8 @@ pub(crate) fn draw_ui(frame: &mut Frame, app: &mut AppState) {
         }
         frame.render_stateful_widget(list, chunks[1], &mut list_state);
     }
+
+    super::render_annotation_modal(frame, app);
 }
 
 fn build_footer_detail(app: &AppState) -> String {
@@ -236,26 +238,6 @@ fn build_footer_detail(app: &AppState) -> String {
     }
 
     parts.join(" | ")
-}
-
-fn centered_rect(percent_x: u16, percent_y: u16, r: Rect) -> Rect {
-    let popup_layout = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Percentage((100 - percent_y) / 2),
-            Constraint::Percentage(percent_y),
-            Constraint::Percentage((100 - percent_y) / 2),
-        ])
-        .split(r);
-
-    Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([
-            Constraint::Percentage((100 - percent_x) / 2),
-            Constraint::Percentage(percent_x),
-            Constraint::Percentage((100 - percent_x) / 2),
-        ])
-        .split(popup_layout[1])[1]
 }
 
 #[cfg(test)]

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -17,6 +17,22 @@
 use crate::app::{AppMode, AppState, PanelState};
 use ratatui::prelude::*;
 
+pub(crate) fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
+    let vertical = Layout::vertical([
+        Constraint::Percentage((100 - percent_y) / 2),
+        Constraint::Percentage(percent_y),
+        Constraint::Percentage((100 - percent_y) / 2),
+    ])
+    .split(area);
+
+    Layout::horizontal([
+        Constraint::Percentage((100 - percent_x) / 2),
+        Constraint::Percentage(percent_x),
+        Constraint::Percentage((100 - percent_x) / 2),
+    ])
+    .split(vertical[1])[1]
+}
+
 /// Returns a list of (Rect, panel_index) for all panels to be rendered.
 pub(crate) fn calculate_grid_layout(area: Rect, app: &AppState) -> Vec<(Rect, usize)> {
     let mut results = Vec::new();

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
+mod annotations;
 mod draw;
 mod format;
 mod layout;
 mod panels;
 
+pub(crate) use annotations::{annotation_cluster_page_size, render_annotation_modal};
 pub(crate) use draw::draw_ui;
 pub(crate) use format::{DisplayFormat, format_time, get_hash_color, value_to_heatmap_color};
 pub(crate) use layout::{hit_test, visible_panel_rects};

--- a/src/ui/panels/graph/mod.rs
+++ b/src/ui/panels/graph/mod.rs
@@ -175,18 +175,27 @@ fn render_forced_point_markers(
 pub(super) fn render_graph_panel(
     frame: &mut Frame,
     area: Rect,
+    panel_index: usize,
     p: &PanelState,
     app: &AppState,
     cursor_x: Option<f64>,
-) {
+    is_selected: bool,
+) -> Option<Vec<crate::annotations::AnnotationEvent>> {
     let theme = &app.theme;
     let use_hash_colors = p.series.len() > theme.palette.len();
     // Determine x bounds from the last refreshed query window.
     let (start, now) = app.time_bounds();
-    let annotation_events = app.annotations.events_for_panel(
-        crate::annotations::AnnotationPanelContext { title: &p.title },
-        [start, now],
-    );
+    let annotation_events = if p.panel_type == crate::app::PanelType::Graph {
+        app.annotations.events_for_panel(
+            crate::annotations::AnnotationPanelContext {
+                index: panel_index,
+                title: &p.title,
+            },
+            [start, now],
+        )
+    } else {
+        Vec::new()
+    };
     let strong_data_mask_mode = strong_data_mask_mode(&annotation_events);
 
     // If inspecting, find values at cursor
@@ -458,6 +467,17 @@ pub(super) fn render_graph_panel(
     let annotation_clusters = terminal_clusters(annotation_events, [start, now], plot_bounds);
     let active_annotation =
         active_cluster(&annotation_clusters, cursor_x, [start, now], plot_bounds);
+    let rendered_cluster = if is_selected {
+        active_annotation.map(|cluster| {
+            cluster
+                .events
+                .iter()
+                .map(|event| (*event).clone())
+                .collect::<Vec<_>>()
+        })
+    } else {
+        None
+    };
 
     // Render threshold markers after chart rendering by merging only onto blank cells.
     // This guarantees data curves keep precedence wherever both map to the same terminal cell.
@@ -603,6 +623,8 @@ pub(super) fn render_graph_panel(
             frame.render_widget(legend, legend_area);
         }
     }
+
+    rendered_cluster
 }
 
 #[cfg(test)]
@@ -845,6 +867,7 @@ mod tests {
         let (start, end) = app.time_bounds();
         app.annotations.events_for_panel(
             crate::annotations::AnnotationPanelContext {
+                index: 0,
                 title: &app.panels[0].title,
             },
             [start, end],
@@ -859,7 +882,7 @@ mod tests {
 
         terminal
             .draw(|frame| {
-                render_graph_panel(frame, Rect::new(0, 0, 80, 20), panel, &app, None);
+                render_graph_panel(frame, Rect::new(0, 0, 80, 20), 0, panel, &app, None, false);
             })
             .unwrap();
 
@@ -915,7 +938,7 @@ mod tests {
 
         terminal
             .draw(|frame| {
-                render_graph_panel(frame, Rect::new(0, 0, 80, 20), panel, &app, None);
+                render_graph_panel(frame, Rect::new(0, 0, 80, 20), 0, panel, &app, None, false);
             })
             .unwrap();
 
@@ -955,6 +978,162 @@ mod tests {
     }
 
     #[test]
+    fn targeted_annotation_renders_only_on_matching_title() {
+        let mut app = area_fill_app(area_fill_panel());
+        app.panels[0].title = "CPU".to_string();
+        let mut deploy = crate::annotations::test_event_at(50.0, "deploy");
+        deploy.target = crate::annotations::AnnotationTarget::PanelTitles(
+            ["CPU".to_string()].into_iter().collect(),
+        );
+        app.annotations = crate::annotations::AnnotationState::from_events_for_test(vec![deploy]);
+        let mut memory_panel = app.panels[0].clone();
+        memory_panel.title = "Memory".to_string();
+
+        let mut cpu = Terminal::new(TestBackend::new(80, 20)).unwrap();
+        cpu.draw(|frame| {
+            render_graph_panel(
+                frame,
+                Rect::new(0, 0, 80, 20),
+                0,
+                &app.panels[0],
+                &app,
+                None,
+                false,
+            );
+        })
+        .unwrap();
+        let mut memory = Terminal::new(TestBackend::new(80, 20)).unwrap();
+        memory
+            .draw(|frame| {
+                render_graph_panel(
+                    frame,
+                    Rect::new(0, 0, 80, 20),
+                    1,
+                    &memory_panel,
+                    &app,
+                    None,
+                    false,
+                );
+            })
+            .unwrap();
+
+        let marker_count = |terminal: &Terminal<TestBackend>| {
+            terminal
+                .backend()
+                .buffer()
+                .content()
+                .iter()
+                .filter(|cell| cell.symbol() == "┊")
+                .count()
+        };
+        assert!(marker_count(&cpu) > 0);
+        assert_eq!(marker_count(&memory), 0);
+    }
+
+    #[test]
+    fn unknown_panel_preserves_graph_data_but_omits_annotation_markers() {
+        let mut app = area_fill_app(area_fill_panel());
+        app.panels[0].panel_type = PanelType::Unknown;
+        app.annotations = crate::annotations::AnnotationState::from_events_for_test(vec![
+            crate::annotations::test_event_at(50.0, "deploy"),
+        ]);
+        let mut terminal = Terminal::new(TestBackend::new(80, 20)).unwrap();
+        let mut rendered_cluster = None;
+
+        terminal
+            .draw(|frame| {
+                rendered_cluster = crate::ui::panels::render_panel(
+                    frame,
+                    Rect::new(0, 0, 80, 20),
+                    0,
+                    &app.panels[0],
+                    &app,
+                    true,
+                    None,
+                );
+            })
+            .unwrap();
+
+        let buffer = terminal.backend().buffer();
+        assert!(
+            buffer
+                .content()
+                .iter()
+                .any(|cell| cell.style().fg == Some(app.theme.palette[0])),
+            "unknown panels must retain legacy graph data rendering"
+        );
+        assert_eq!(
+            buffer
+                .content()
+                .iter()
+                .filter(|cell| cell.symbol() == "┊")
+                .count(),
+            0,
+            "unknown panels must not render annotation markers"
+        );
+        assert!(rendered_cluster.is_none());
+    }
+
+    #[test]
+    fn tag_filter_recalculates_same_column_count() {
+        let mut app = area_fill_app(area_fill_panel());
+        let mut deploy = crate::annotations::test_event_at(50.0, "deploy");
+        deploy.tags = vec!["deploy".to_string()];
+        let mut incident = crate::annotations::test_event_at(50.0, "incident");
+        incident.tags = vec!["incident".to_string()];
+        let mut rollback = crate::annotations::test_event_at(50.0, "rollback");
+        rollback.tags = vec!["deploy".to_string()];
+        app.annotations = crate::annotations::AnnotationState::from_events_for_test(vec![
+            deploy, incident, rollback,
+        ]);
+        app.annotations
+            .set_filter(crate::annotations::TagFilter::from_selected([
+                "deploy".to_string()
+            ]));
+        let mut terminal = Terminal::new(TestBackend::new(80, 20)).unwrap();
+
+        terminal
+            .draw(|frame| {
+                render_graph_panel(
+                    frame,
+                    Rect::new(0, 0, 80, 20),
+                    0,
+                    &app.panels[0],
+                    &app,
+                    None,
+                    false,
+                );
+            })
+            .unwrap();
+
+        let chart_area = Rect::new(0, 0, 80, 18);
+        let x_labels = vec![Span::raw("00:00:00"), Span::raw("00:01:40")];
+        let chart_y_labels = vec![Span::raw("0"), Span::raw("10")];
+        let plot = PlotBounds {
+            left: chart_plot_left(
+                chart_area,
+                chart_y_label_width(&chart_y_labels),
+                &x_labels,
+                true,
+            ),
+            right: chart_area.right(),
+            top: chart_area.top(),
+            bottom: chart_area.bottom().saturating_sub(2),
+        };
+        let marker_x = labels::value_to_plot_x(50.0, [0.0, 100.0], plot).unwrap();
+
+        assert_eq!(
+            terminal
+                .backend()
+                .buffer()
+                .cell((marker_x, plot.top))
+                .unwrap()
+                .symbol(),
+            "2"
+        );
+    }
+
+    #[test]
     fn annotation_cluster_renders_and_inspects_on_same_column() {
         let mut app = area_fill_app(area_fill_panel());
         app.annotations = crate::annotations::AnnotationState::from_events_for_test(vec![
@@ -970,9 +1149,11 @@ mod tests {
                 render_graph_panel(
                     frame,
                     Rect::new(0, 0, 80, 20),
+                    0,
                     &app.panels[0],
                     &app,
                     app.cursor_x,
+                    false,
                 );
             })
             .unwrap();
@@ -1004,7 +1185,15 @@ mod tests {
         let mut baseline = Terminal::new(TestBackend::new(80, 20)).unwrap();
         baseline
             .draw(|frame| {
-                render_graph_panel(frame, Rect::new(0, 0, 80, 20), &app.panels[0], &app, None);
+                render_graph_panel(
+                    frame,
+                    Rect::new(0, 0, 80, 20),
+                    0,
+                    &app.panels[0],
+                    &app,
+                    None,
+                    false,
+                );
             })
             .unwrap();
 
@@ -1014,7 +1203,15 @@ mod tests {
         let mut annotated = Terminal::new(TestBackend::new(80, 20)).unwrap();
         annotated
             .draw(|frame| {
-                render_graph_panel(frame, Rect::new(0, 0, 80, 20), &app.panels[0], &app, None);
+                render_graph_panel(
+                    frame,
+                    Rect::new(0, 0, 80, 20),
+                    0,
+                    &app.panels[0],
+                    &app,
+                    None,
+                    false,
+                );
             })
             .unwrap();
 
@@ -1090,9 +1287,11 @@ mod tests {
                 render_graph_panel(
                     frame,
                     Rect::new(0, 0, 30, 12),
+                    0,
                     &app.panels[0],
                     &app,
                     app.cursor_x,
+                    false,
                 );
             })
             .unwrap();
@@ -1131,9 +1330,11 @@ mod tests {
                 render_graph_panel(
                     frame,
                     Rect::new(0, 0, width, height),
+                    0,
                     &app.panels[0],
                     &app,
                     app.cursor_x,
+                    false,
                 );
             })
             .unwrap();

--- a/src/ui/panels/mod.rs
+++ b/src/ui/panels/mod.rs
@@ -46,11 +46,12 @@ use table::render_table;
 pub(crate) fn render_panel(
     frame: &mut Frame,
     area: Rect,
+    panel_index: usize,
     p: &PanelState,
     app: &AppState,
     is_selected: bool,
     cursor_x: Option<f64>,
-) {
+) -> Option<Vec<crate::annotations::AnnotationEvent>> {
     let theme = &app.theme;
     let border_style = if is_selected {
         Style::default().fg(theme.border_selected)
@@ -71,7 +72,7 @@ pub(crate) fn render_panel(
             .wrap(Wrap { trim: true })
             .style(Style::default().fg(theme.text));
         frame.render_widget(para, area);
-        return;
+        return None;
     }
 
     // Render the outer block (Panel container)
@@ -87,23 +88,38 @@ pub(crate) fn render_panel(
     let inner_area = block.inner(area);
 
     match p.panel_type {
-        PanelType::Graph | PanelType::Unknown => {
-            render_graph_panel(frame, inner_area, p, app, cursor_x);
+        PanelType::Graph => render_graph_panel(
+            frame,
+            inner_area,
+            panel_index,
+            p,
+            app,
+            cursor_x,
+            is_selected,
+        ),
+        PanelType::Unknown => {
+            render_graph_panel(frame, inner_area, panel_index, p, app, cursor_x, false);
+            None
         }
         PanelType::Gauge => {
             render_gauge(frame, inner_area, p, app);
+            None
         }
         PanelType::BarGauge => {
             render_bar_gauge(frame, inner_area, p, app);
+            None
         }
         PanelType::Table => {
             render_table(frame, inner_area, p, app);
+            None
         }
         PanelType::Stat => {
             render_stat(frame, inner_area, p, app);
+            None
         }
         PanelType::Heatmap => {
             render_heatmap(frame, inner_area, p, app);
+            None
         }
     }
 }


### PR DESCRIPTION
## Summary

- add exact, case-sensitive `panel_titles` routing for external JSONL point annotations, with deterministic warnings for missing and duplicate panel titles
- add a global runtime tag filter with exact OR semantics and a navigable tag-selection modal
- add a selected-panel cluster modal backed by the exact rendered annotation cluster, with frozen contents across reloads
- keep terminal, SVG/PNG export, and changed-frame recording on the same filtered and targeted event route
- document targeting, filtering, modal controls, reload behavior, export behavior, limitations, and a runnable current-time example

## Behavior and scope

Annotations remain fully optional and use one explicitly configured, read-only JSONL source. Unknown/non-graph panels do not receive annotations. Modal chrome and draft-only filter changes are not exported or recorded.

This does not add Grafana annotation imports, Prometheus annotation queries, provider APIs, event IDs, range events, multiple sources, JSON editing, or per-panel filters.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all-targets` — 194 tests passed
- `mdbook build`
- `git diff --check origin/main...HEAD`
- task-scoped reviews for all eight commits plus a final whole-branch review and scoped fix re-review
