### PR TITLE
feat: add command-backed annotation providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ cargo run -- --grafana-json examples/dashboards/prometheus_demo.json --prometheu
 - Keyboard-first navigation, panel search, fullscreen mode, mouse selection, and value inspection.
 - SVG/PNG export and changed-frame recording bundles.
 - TOML configuration and built-in themes.
-- Read-only external JSONL point annotations with panel targeting, tag filtering, and navigable cluster details.
+- Read-only external file or command-backed JSONL point annotations with panel targeting, tag filtering, and navigable cluster details.
 
 ## Documentation
 
@@ -71,6 +71,9 @@ grafatui --theme tokyo-night
 
 # Overlay read-only JSONL point events
 grafatui --grafana-json ./dashboard.json --annotations-file ./events.jsonl
+
+# Query read-only annotations through a command provider
+grafatui --grafana-json ./dashboard.json --annotations-command ./target/debug/examples/git_annotation_provider --annotations-command-arg=.
 
 # Generate shell completions or a man page
 grafatui completions zsh

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -38,7 +38,7 @@ These features are shipped and available today:
 | UI | **Mouse support** | Click to select, scroll, drag cursor in fullscreen inspect mode |
 | UI | **Value inspection** | Cursor-based point-in-time data exploration |
 | UI | **Series toggling** | Show/hide individual series with `1`-`9` |
-| Annotations | **External JSONL point annotations (iteration 1)** | Read-only JSONL events on graph/timeseries panels, counted same-column markers, inline inspection, export, and recording parity |
+| Annotations | **External annotation providers (iterations 1–3)** | Read-only file/command JSONL events on graph/timeseries panels, targeting, tag filtering, bounded provider protocol, concurrent refresh, export, and recording parity |
 | Rendering | **Smart caching** | Request deduplication and caching for identical queries |
 | Rendering | **Downsampling** | Max-pooling to preserve peaks while fitting the terminal |
 | Rendering | **Adaptive time labels** | Date/time axis labels adjust to the selected range |
@@ -62,12 +62,27 @@ refreshed alongside parity work so it stays aligned with the current release.
 
 | Iteration | Scope | Status |
 |---|---|---|
-| 1 | External JSONL point annotations | ✅ Implemented by the current iteration-1 PR |
-| 2 | Navigable annotation popup, panel targeting, and tag filtering | 📋 Future PR |
-| 3 | Annotation provider API | 📋 Future PR |
+| 1 | External JSONL point annotations | ✅ Shipped |
+| 2 | Navigable annotation popup, panel targeting, and tag filtering | ✅ Shipped |
+| 3 | Bounded command provider protocol and Prometheus-coordinated refresh | ✅ Implemented by this PR |
 
 These iterations are separate from Grafana `annotations` and `annotations.list`,
 which remain unsupported.
+
+### Provider Ecosystem and Integrations (Post-Core)
+
+| Item | User value | Complexity | Status |
+|---|---|---|---|
+| Independent provider scheduling and redraw | Refresh slow providers without coupling them to Prometheus redraws | 🟡 | 📋 |
+| Stable public Rust provider API | Build supported native providers outside Grafatui | 🟡 | 📋 |
+| Possible Python SDK | Make provider authoring accessible without Rust | 🟡 | 💡 |
+| Long-running providers | Reuse authenticated clients and streams safely | 🔴 | 📋 |
+| Multiple annotation sources | Combine independent event systems in one overlay | 🔴 | 📋 |
+| Range events | Show maintenance windows and other duration-based annotations | 🟡 | 📋 |
+| Stable event IDs | Support deduplication and reliable provider updates | 🟡 | 📋 |
+| Per-panel tag filters | Let each panel narrow the shared annotation stream | 🟡 | 📋 |
+| Reference/community CI/CD providers | Turn durable CI/CD deployment records into useful overlays | 🟡 | 📋 |
+| HTTP, Grafana, and vendor adapters | Add integrations only where demonstrated demand exists | 🔴 | 💡 |
 
 ---
 

--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -57,6 +57,9 @@ input, then closes stdin. The request defines the complete refresh window:
 {"version":1,"range":{"from":"2026-08-12T10:00:00Z","to":"2026-08-12T10:05:00Z"}}
 ```
 
+`range.from` and `range.to` are inclusive UTC RFC 3339 bounds. Grafatui
+defensively applies its visible-range filtering to the events returned.
+
 The provider writes zero or more existing JSONL events to stdout and diagnostics
 to stderr. Exit `0` with valid bounded JSONL replaces the complete annotation
 snapshot; an empty successful stdout clears it. A spawn failure, timeout,

--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -1,13 +1,15 @@
 # External Annotations
 
-Grafatui can overlay read-only, external point events from one JSONL file. It
-never edits or writes the source file. External JSONL is deliberately separate
-from Grafana dashboard annotations: Grafatui does not implement Grafana
-annotation queries, APIs, `annotations`, or `annotations.list`.
+Grafatui can overlay read-only, external point events from exactly one source:
+a JSONL file or a command provider. It never edits or writes either source.
+External annotations are deliberately separate from Grafana dashboard
+annotations: Grafatui does not implement Grafana annotation queries, APIs,
+`annotations`, or `annotations.list`.
 
 ## Enable Annotations
 
-Pass the source path on the command line:
+Select exactly one source. For a file source, pass the path on the command
+line:
 
 ```bash
 grafatui \
@@ -15,14 +17,64 @@ grafatui \
   --annotations-file ./events.jsonl
 ```
 
-Or configure the same single source in TOML:
+Or configure the file source in TOML:
 
 ```toml
 annotations_file = "./events.jsonl"
 ```
 
-The CLI option overrides the configured path. This source is opt-in and
-read-only; Grafatui does not create, edit, or otherwise write the file.
+For a command source, configure an executable that accepts the request protocol
+below. The command receives no shell interpolation:
+
+```toml
+[annotations_command]
+program = "./target/debug/examples/git_annotation_provider"
+args = ["."]
+timeout = "10s"
+```
+
+Or select it from the command line:
+
+```bash
+grafatui \
+  --grafana-json ./dashboard.json \
+  --annotations-command ./target/debug/examples/git_annotation_provider \
+  --annotations-command-arg=.
+```
+
+File and command sources are mutually exclusive. A TOML configuration that
+sets both is rejected even if the CLI selects a source. A CLI file or command
+replaces the complete TOML annotation source; it never mixes a CLI program,
+arguments, or timeout with TOML values. Sources are opt-in and read-only;
+Grafatui does not create, edit, or otherwise write them.
+
+## Command Provider Protocol
+
+Grafatui writes exactly one version-1 request line to the command's standard
+input, then closes stdin. The request defines the complete refresh window:
+
+```json
+{"version":1,"range":{"from":"2026-08-12T10:00:00Z","to":"2026-08-12T10:05:00Z"}}
+```
+
+The provider writes zero or more existing JSONL events to stdout and diagnostics
+to stderr. Exit `0` with valid bounded JSONL replaces the complete annotation
+snapshot; an empty successful stdout clears it. A spawn failure, timeout,
+nonzero exit, invalid UTF-8 or JSONL, or oversized stdout keeps the last valid
+snapshot and shows a warning.
+
+The default timeout is 10 seconds. Grafatui accepts at most 10 MiB of stdout
+and captures at most 64 KiB of stderr. Providers inherit Grafatui's current
+directory and environment. Put credentials in that environment or use standard
+credential tooling; never place secrets in dashboard JSON or command arguments.
+
+The included Git provider is a practical starting point:
+
+```bash
+cargo build --example git_annotation_provider
+printf '%s\n' '{"version":1,"range":{"from":"2026-08-12T10:00:00Z","to":"2026-08-12T10:05:00Z"}}' \
+  | ./target/debug/examples/git_annotation_provider .
+```
 
 ## JSONL Event Format and Targeting
 
@@ -125,11 +177,13 @@ event details.
 
 ## Automatic Reload, Rendering, and Exports
 
-Grafatui checks the file metadata during each normal refresh, including while
-markers are hidden. When it changes, Grafatui reads, parses, and validates the
-full candidate file before atomically replacing the snapshot. A zero-byte file
-is a valid update that clears all events. Annotation loading is independent of
-Prometheus: annotation failures never fail startup or a Prometheus refresh.
+Grafatui refreshes both source types during each normal refresh, including
+while markers are hidden. It checks a file source's metadata and, when it
+changes, reads, parses, and validates the full candidate file before atomically
+replacing the snapshot. A zero-byte file is a valid update that clears all
+events. Command and Prometheus refreshes share the same time range, start
+together, and redraw together. Annotation loading is independent of Prometheus:
+annotation failures never fail startup or a Prometheus refresh.
 
 Only `graph` and `timeseries` panels receive annotation markers. Press `a` to
 toggle marker visibility. Events that project to the same terminal column are
@@ -144,16 +198,36 @@ the tag-filter and cluster modal chrome is not.
 
 ## Errors and Last Valid Snapshot
 
-If the file is missing, unreadable, or contains a malformed event, Grafatui
-keeps rendering the last valid snapshot and shows an annotation warning. A bad
-update does not replace the previously loaded events, fail startup, or fail the
-Prometheus refresh.
+If a file is missing, unreadable, or contains a malformed event, Grafatui keeps
+rendering the last valid snapshot and shows an annotation warning. Command
+provider failures follow the same rule. A bad update does not replace the
+previously loaded events, fail startup, or fail the Prometheus refresh.
+
+## CI/CD and Provider Integrations
+
+```text
+CI workflow → durable deployment/release record → command provider query
+            → normalized JSONL point events → Grafatui overlay
+```
+
+GitHub Actions is a useful concrete pattern: let a workflow record deployment,
+release, or workflow outcomes in an API, object store, database, or shared event
+log. A local provider receives Grafatui's requested range and queries that
+system of record, then emits normalized JSONL point events. Useful tags include
+repository, workflow, environment, status, commit, and deployment.
+
+Give the provider credentials through its environment or standard credential
+tooling, never dashboard JSON or command arguments. A shared JSONL file is a
+reasonable source only when the workflow and Grafatui genuinely share storage;
+do not commit an ever-growing event log to the application repository.
+Vendor-specific providers should normally live as user or community plugins.
+Built-in integrations remain demand-driven.
 
 ## Current Limits and Roadmap
 
-This feature supports one external JSONL source, point events, panel-title
-routing, and one global runtime-only tag filter. It has no stable event IDs, no
-per-panel tag filters, no multiple sources, no editing, and no provider or API
-work. It does not add Grafana annotation-query/API compatibility. Range events
-and a provider API remain future roadmap work. `--validate` validates Grafana
-dashboard imports only; it does not validate annotations.
+This feature supports one external file or command source, point events,
+panel-title routing, and one global runtime-only tag filter. It has no stable
+event IDs, no per-panel tag filters, no multiple sources, and no editing. It
+does not add Grafana annotation-query/API compatibility. Range events, stable
+event IDs, and per-panel tag filters remain deferred. `--validate` validates
+Grafana dashboard imports only; it does not validate annotations.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -60,8 +60,9 @@ instance = "server-01"
 ## External Annotation Sources
 
 Select one read-only annotation source: `annotations_file` or the nested
-`[annotations_command]` table. The two TOML forms conflict, and a file source
-also conflicts with all command CLI flags.
+`[annotations_command]` table. The two TOML forms conflict. The
+`--annotations-file` CLI flag conflicts with every command-source CLI flag;
+CLI source selection still replaces the complete TOML annotation source.
 
 ```toml
 [annotations_command]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,6 +9,9 @@ Grafatui can be configured with CLI options, a TOML configuration file, or both.
 | `--prometheus-url <URL>` | Prometheus server URL | `http://localhost:9090` |
 | `--grafana-json <FILE>` | Grafana dashboard JSON file | none |
 | `--annotations-file <FILE>` | Read-only external JSONL point-event file | none |
+| `--annotations-command <PROGRAM>` | Read-only executable annotation provider | none |
+| `--annotations-command-arg <ARG>` | Argument for `--annotations-command`; repeat to preserve order | none |
+| `--annotations-command-timeout <DURATION>` | Maximum command-provider runtime | `10s` |
 | `--validate` | Check the Grafana dashboard import and exit without starting the TUI | `false` |
 | `--strict` | Make `--validate` fail when diagnostics contain warnings | `false` |
 | `--format <FORMAT>` | Output format for `--validate`: `text` or `json` | `text` |
@@ -53,6 +56,35 @@ annotations_file = "./events.jsonl"
 job = "node"
 instance = "server-01"
 ```
+
+## External Annotation Sources
+
+Select one read-only annotation source: `annotations_file` or the nested
+`[annotations_command]` table. The two TOML forms conflict, and a file source
+also conflicts with all command CLI flags.
+
+```toml
+[annotations_command]
+program = "./target/debug/examples/git_annotation_provider"
+args = ["."]
+timeout = "10s"
+```
+
+`program` is required; `args` defaults to an empty list and `timeout` defaults
+to `10s`. The matching CLI source is:
+
+```bash
+grafatui \
+  --annotations-command ./target/debug/examples/git_annotation_provider \
+  --annotations-command-arg=. \
+  --annotations-command-timeout 10s
+```
+
+`--annotations-command-arg` and `--annotations-command-timeout` require
+`--annotations-command`; repeat the argument flag to retain argument order.
+`--annotations-file` and `--annotations-command` cannot be combined. A CLI file
+or command has whole-source precedence over TOML: it replaces the configured
+file or complete command configuration rather than merging individual fields.
 
 ## Themes
 

--- a/docs/grafana-compatibility.md
+++ b/docs/grafana-compatibility.md
@@ -244,10 +244,10 @@ tooltips.
 
 | JSON Field | Status | Notes |
 |---|---|---|
-| `annotations` | ❌ Not Implemented | |
-| `annotations.list` | ❌ Not Implemented | |
+| `annotations` | ❌ Not Implemented | External file/command providers do not implement this Grafana field. |
+| `annotations.list` | ❌ Not Implemented | External file/command providers do not implement this Grafana field. |
 
-Grafatui external JSONL events are a separate, opt-in read-only source.
+Grafatui external file/command JSONL events are a separate, opt-in read-only source.
 `panel_titles` is Grafatui's external-source routing field: it matches eligible
 graph/timeseries panel titles exactly, not Grafana panel IDs. It does not imply
 compatibility with Grafana annotation queries, APIs, `annotations`, or

--- a/examples/README.md
+++ b/examples/README.md
@@ -28,6 +28,26 @@ cargo run -- --grafana-json examples/dashboards/prometheus_demo.json --annotatio
 See the [external annotations guide](../docs/annotations.md) for targeting,
 tag filtering, inspection, reload behavior, and limitations.
 
+### Git Command Provider
+
+`git_annotation_provider.rs` turns commits in Grafatui's requested time window
+into external JSONL annotations. Build it from the repository root:
+
+```bash
+cargo build --example git_annotation_provider
+```
+
+Then configure the compiled example as the one annotation source:
+
+```toml
+[annotations_command]
+program = "./target/debug/examples/git_annotation_provider"
+args = ["."]
+timeout = "10s"
+```
+
+The optional first argument is the Git repository path and defaults to `.`.
+
 ## Dashboards
 
 

--- a/examples/git_annotation_provider.rs
+++ b/examples/git_annotation_provider.rs
@@ -1,0 +1,97 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::io::Read;
+use std::process::Command;
+
+#[derive(Deserialize)]
+struct Request {
+    version: u8,
+    range: Range,
+}
+
+#[derive(Deserialize)]
+struct Range {
+    from: String,
+    to: String,
+}
+
+#[derive(Serialize)]
+struct Event {
+    time: String,
+    text: String,
+    tags: Vec<String>,
+}
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("{error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), String> {
+    let mut input = String::new();
+    std::io::stdin()
+        .read_to_string(&mut input)
+        .map_err(|error| format!("could not read request: {error}"))?;
+    let request: Request =
+        serde_json::from_str(&input).map_err(|error| format!("invalid request: {error}"))?;
+    if request.version != 1 {
+        return Err(format!("unsupported request version {}", request.version));
+    }
+
+    let from = parse_time("range.from", &request.range.from)?;
+    let to = parse_time("range.to", &request.range.to)?;
+    let repository = std::env::args().nth(1).unwrap_or_else(|| ".".to_string());
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repository)
+        .arg("log")
+        .arg(format!("--since={}", from.to_rfc3339()))
+        .arg(format!("--until={}", to.to_rfc3339()))
+        .arg("--format=%cI%x09%h%x09%s")
+        .output()
+        .map_err(|error| format!("could not run git: {error}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(if stderr.trim().is_empty() {
+            "git log failed".to_string()
+        } else {
+            stderr.trim_end().to_string()
+        });
+    }
+
+    let output = String::from_utf8(output.stdout)
+        .map_err(|error| format!("git output was not UTF-8: {error}"))?;
+    for line in output.lines() {
+        let mut fields = line.splitn(3, '\t');
+        let time = fields
+            .next()
+            .filter(|value| !value.is_empty())
+            .ok_or("git output missing commit time")?;
+        let hash = fields
+            .next()
+            .filter(|value| !value.is_empty())
+            .ok_or("git output missing commit hash")?;
+        let subject = fields.next().ok_or("git output missing commit subject")?;
+        let event = Event {
+            time: time.to_string(),
+            text: format!("Commit {hash}: {subject}"),
+            tags: vec!["git".to_string(), "commit".to_string()],
+        };
+        println!(
+            "{}",
+            serde_json::to_string(&event)
+                .map_err(|error| format!("could not encode event: {error}"))?
+        );
+    }
+
+    Ok(())
+}
+
+fn parse_time(field: &str, value: &str) -> Result<DateTime<Utc>, String> {
+    DateTime::parse_from_rfc3339(value)
+        .map(|time| time.with_timezone(&Utc))
+        .map_err(|error| format!("invalid {field}: {error}"))
+}

--- a/src/annotations/command.rs
+++ b/src/annotations/command.rs
@@ -1,9 +1,324 @@
+#![allow(dead_code)] // Command providers are implemented here before runtime wiring.
+
 use chrono::SecondsFormat;
 use serde::Serialize;
+use std::io;
+use std::process::Stdio;
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::process::{Child, ChildStderr, ChildStdout, Command};
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
 
 use super::{
-    AnnotationProviderError, AnnotationRefreshContext, AnnotationSnapshot, jsonl::parse_jsonl,
+    AnnotationCommandConfig, AnnotationProvider, AnnotationProviderError, AnnotationRefreshContext,
+    AnnotationSnapshot, ProviderFuture, ProviderPoll, jsonl::parse_jsonl,
 };
+
+#[derive(Debug)]
+pub(crate) struct CommandProvider {
+    config: AnnotationCommandConfig,
+}
+
+pub(crate) const MAX_STDOUT_BYTES: usize = 10 * 1024 * 1024;
+pub(crate) const MAX_STDERR_BYTES: usize = 64 * 1024;
+
+enum CapturedStdout {
+    Complete(Vec<u8>),
+    LimitExceeded,
+}
+
+struct CollectedProcess {
+    status: std::process::ExitStatus,
+    stdout: io::Result<CapturedStdout>,
+    stderr: io::Result<Vec<u8>>,
+    stdin: io::Result<()>,
+}
+
+enum ProtocolOutcome {
+    Complete(CollectedProcess),
+    StdoutLimitExceeded,
+}
+
+struct ProcessTasks {
+    stdin: JoinHandle<io::Result<()>>,
+    stdout: JoinHandle<()>,
+    stderr: JoinHandle<io::Result<Vec<u8>>>,
+}
+
+impl CommandProvider {
+    pub(crate) fn new(config: AnnotationCommandConfig) -> Self {
+        Self { config }
+    }
+
+    async fn run(&self, context: &AnnotationRefreshContext) -> ProviderPoll {
+        match self.run_inner(context).await {
+            Ok(snapshot) => ProviderPoll::Loaded(snapshot),
+            Err(error) => ProviderPoll::Failed(error),
+        }
+    }
+
+    async fn run_inner(
+        &self,
+        context: &AnnotationRefreshContext,
+    ) -> Result<AnnotationSnapshot, AnnotationProviderError> {
+        let request = encode_request(context).map_err(|error| self.error(error))?;
+        let mut child = Command::new(&self.config.program)
+            .args(&self.config.args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+            .map_err(|error| self.error(format!("could not start: {error}")))?;
+
+        let stdin = child
+            .stdin
+            .take()
+            .expect("command configured with piped stdin");
+        let stdout = child
+            .stdout
+            .take()
+            .expect("command configured with piped stdout");
+        let stderr = child
+            .stderr
+            .take()
+            .expect("command configured with piped stderr");
+
+        let (stdout_sender, stdout_receiver) = oneshot::channel();
+        let mut tasks = ProcessTasks {
+            stdin: tokio::spawn(write_request(stdin, request)),
+            stdout: tokio::spawn(async move {
+                let _ = stdout_sender.send(read_stdout_limited(stdout).await);
+            }),
+            stderr: tokio::spawn(read_stderr_capped(stderr)),
+        };
+
+        let protocol = collect_process(&mut child, stdout_receiver, &mut tasks);
+        let outcome = match tokio::time::timeout(self.config.timeout, protocol).await {
+            Ok(Ok(outcome)) => outcome,
+            Ok(Err(reason)) => {
+                let cleanup = kill_and_reap(&mut child).await;
+                abort_tasks(tasks);
+                return Err(self.error(append_cleanup(reason, cleanup)));
+            }
+            Err(_) => {
+                let cleanup = kill_and_reap(&mut child).await;
+                abort_tasks(tasks);
+                let reason = format!(
+                    "timed out after {}",
+                    humantime::format_duration(self.config.timeout)
+                );
+                return Err(self.error(append_cleanup(reason, cleanup)));
+            }
+        };
+
+        match outcome {
+            ProtocolOutcome::StdoutLimitExceeded => {
+                let cleanup = kill_and_reap(&mut child).await;
+                join_or_abort_tasks(tasks).await;
+                Err(self.error(append_cleanup(
+                    "exceeded 10 MiB stdout limit".to_string(),
+                    cleanup,
+                )))
+            }
+            ProtocolOutcome::Complete(collected) if !collected.status.success() => {
+                let reason = match collected.status.code() {
+                    Some(code) => format!("exited with status {code}"),
+                    None => "terminated by signal".to_string(),
+                };
+                let reason = match collected.stderr {
+                    Ok(stderr) => append_stderr(reason, &stderr),
+                    Err(error) => format!("{reason}; could not read stderr: {error}"),
+                };
+                Err(self.error(reason))
+            }
+            ProtocolOutcome::Complete(collected) => {
+                collected
+                    .stdin
+                    .map_err(|error| self.error(format!("could not write request: {error}")))?;
+                let stdout = collected
+                    .stdout
+                    .map_err(|error| self.error(format!("could not read stdout: {error}")))?;
+                collected
+                    .stderr
+                    .map_err(|error| self.error(format!("could not read stderr: {error}")))?;
+                let CapturedStdout::Complete(stdout) = stdout else {
+                    unreachable!("stdout limit is handled before successful completion")
+                };
+                parse_stdout(&self.config.program, &stdout)
+            }
+        }
+    }
+
+    fn error(&self, reason: impl std::fmt::Display) -> AnnotationProviderError {
+        AnnotationProviderError::command(&self.config.program, reason)
+    }
+}
+
+async fn write_request(mut stdin: tokio::process::ChildStdin, request: Vec<u8>) -> io::Result<()> {
+    stdin.write_all(&request).await?;
+    stdin.shutdown().await
+}
+
+async fn read_stdout_limited(mut stdout: ChildStdout) -> io::Result<CapturedStdout> {
+    let mut captured = Vec::new();
+    let mut chunk = [0_u8; 8192];
+    loop {
+        let read = stdout.read(&mut chunk).await?;
+        if read == 0 {
+            return Ok(CapturedStdout::Complete(captured));
+        }
+        if captured.len() + read > MAX_STDOUT_BYTES {
+            return Ok(CapturedStdout::LimitExceeded);
+        }
+        captured.extend_from_slice(&chunk[..read]);
+    }
+}
+
+async fn read_stderr_capped(mut stderr: ChildStderr) -> io::Result<Vec<u8>> {
+    let mut captured = Vec::new();
+    let mut chunk = [0_u8; 8192];
+    loop {
+        let read = stderr.read(&mut chunk).await?;
+        if read == 0 {
+            return Ok(captured);
+        }
+        let retained = (MAX_STDERR_BYTES - captured.len()).min(read);
+        captured.extend_from_slice(&chunk[..retained]);
+    }
+}
+
+fn stderr_excerpt(bytes: &[u8]) -> Option<String> {
+    let decoded = String::from_utf8_lossy(bytes);
+    let mut excerpt = String::new();
+    let mut characters = 0;
+    let mut separating = false;
+
+    for character in decoded.chars() {
+        if character.is_whitespace() || character.is_control() {
+            separating = !excerpt.is_empty();
+            continue;
+        }
+        if separating {
+            if characters == 512 {
+                break;
+            }
+            excerpt.push(' ');
+            characters += 1;
+            separating = false;
+        }
+        if characters == 512 {
+            break;
+        }
+        excerpt.push(character);
+        characters += 1;
+    }
+
+    (!excerpt.is_empty()).then_some(excerpt)
+}
+
+fn append_stderr(reason: String, stderr: &[u8]) -> String {
+    match stderr_excerpt(stderr) {
+        Some(excerpt) => format!("{reason}; stderr: {excerpt}"),
+        None => reason,
+    }
+}
+
+async fn collect_process(
+    child: &mut Child,
+    mut stdout_receiver: oneshot::Receiver<io::Result<CapturedStdout>>,
+    tasks: &mut ProcessTasks,
+) -> Result<ProtocolOutcome, String> {
+    let wait = child.wait();
+    tokio::pin!(wait);
+
+    let (status, stdout) = tokio::select! {
+        stdout = &mut stdout_receiver => {
+            let stdout = stdout.map_err(|_| "stdout reader stopped unexpectedly".to_string())?;
+            if matches!(stdout, Ok(CapturedStdout::LimitExceeded)) {
+                return Ok(ProtocolOutcome::StdoutLimitExceeded);
+            }
+            let status = wait
+                .await
+                .map_err(|error| format!("could not wait for completion: {error}"))?;
+            (status, stdout)
+        }
+        status = &mut wait => {
+            let status = status
+                .map_err(|error| format!("could not wait for completion: {error}"))?;
+            let stdout = stdout_receiver
+                .await
+                .map_err(|_| "stdout reader stopped unexpectedly".to_string())?;
+            if matches!(stdout, Ok(CapturedStdout::LimitExceeded)) {
+                return Ok(ProtocolOutcome::StdoutLimitExceeded);
+            }
+            (status, stdout)
+        }
+    };
+
+    let stdin = (&mut tasks.stdin)
+        .await
+        .map_err(|error| format!("stdin writer task failed: {error}"))?;
+    (&mut tasks.stdout)
+        .await
+        .map_err(|error| format!("stdout reader task failed: {error}"))?;
+    let stderr = (&mut tasks.stderr)
+        .await
+        .map_err(|error| format!("stderr reader task failed: {error}"))?;
+
+    Ok(ProtocolOutcome::Complete(CollectedProcess {
+        status,
+        stdout,
+        stderr,
+        stdin,
+    }))
+}
+
+async fn kill_and_reap(child: &mut Child) -> Result<(), String> {
+    let kill_error = child.kill().await.err();
+    let wait_error = child.wait().await.err();
+    match (kill_error, wait_error) {
+        (None, None) => Ok(()),
+        (Some(kill), None) if kill.kind() == io::ErrorKind::InvalidInput => Ok(()),
+        (Some(kill), None) => Err(format!("could not kill child: {kill}")),
+        (None, Some(wait)) => Err(format!("could not reap child: {wait}")),
+        (Some(kill), Some(wait)) => Err(format!(
+            "could not kill child: {kill}; could not reap child: {wait}"
+        )),
+    }
+}
+
+fn append_cleanup(reason: String, cleanup: Result<(), String>) -> String {
+    match cleanup {
+        Ok(()) => reason,
+        Err(error) => format!("{reason}; cleanup failed: {error}"),
+    }
+}
+
+fn abort_tasks(tasks: ProcessTasks) {
+    tasks.stdin.abort();
+    tasks.stdout.abort();
+    tasks.stderr.abort();
+}
+
+async fn join_or_abort_tasks(mut tasks: ProcessTasks) {
+    let joined = tokio::time::timeout(Duration::from_millis(100), async {
+        let _ = (&mut tasks.stdin).await;
+        let _ = (&mut tasks.stdout).await;
+        let _ = (&mut tasks.stderr).await;
+    })
+    .await;
+    if joined.is_err() {
+        abort_tasks(tasks);
+    }
+}
+
+impl AnnotationProvider for CommandProvider {
+    fn refresh<'a>(&'a mut self, context: &'a AnnotationRefreshContext) -> ProviderFuture<'a> {
+        Box::pin(self.run(context))
+    }
+}
 
 #[derive(Serialize)]
 struct CommandRequest {
@@ -48,9 +363,55 @@ fn parse_stdout(
 #[cfg(test)]
 mod tests {
     use chrono::{DateTime, Utc};
+    use std::path::{Path, PathBuf};
+    use std::sync::OnceLock;
+    use std::time::Duration;
 
-    use super::{encode_request, parse_stdout};
-    use crate::annotations::AnnotationRefreshContext;
+    use super::{
+        CommandProvider, MAX_STDERR_BYTES, MAX_STDOUT_BYTES, encode_request, parse_stdout,
+    };
+    use crate::annotations::{
+        AnnotationCommandConfig, AnnotationProvider, AnnotationRefreshContext, ProviderPoll,
+    };
+
+    fn compiled_fixture() -> PathBuf {
+        static FIXTURE: OnceLock<PathBuf> = OnceLock::new();
+        FIXTURE
+            .get_or_init(|| {
+                let source = Path::new(env!("CARGO_MANIFEST_DIR"))
+                    .join("tests/fixtures/annotation_provider.rs");
+                let output = std::env::temp_dir().join(format!(
+                    "grafatui-annotation-provider-fixture-{}{}",
+                    std::process::id(),
+                    std::env::consts::EXE_SUFFIX,
+                ));
+                let rustc = std::env::var("RUSTC").unwrap_or_else(|_| "rustc".into());
+                let status = std::process::Command::new(rustc)
+                    .arg(source)
+                    .arg("-o")
+                    .arg(&output)
+                    .status()
+                    .expect("compile annotation provider fixture");
+                assert!(status.success());
+                output
+            })
+            .clone()
+    }
+
+    fn fixture_config<const N: usize>(
+        args: [&str; N],
+        timeout: Duration,
+    ) -> AnnotationCommandConfig {
+        AnnotationCommandConfig {
+            program: compiled_fixture().to_string_lossy().into_owned(),
+            args: args.into_iter().map(str::to_string).collect(),
+            timeout,
+        }
+    }
+
+    fn fixture_provider<const N: usize>(args: [&str; N], timeout: Duration) -> CommandProvider {
+        CommandProvider::new(fixture_config(args, timeout))
+    }
 
     fn fixed_context() -> AnnotationRefreshContext {
         AnnotationRefreshContext {
@@ -112,5 +473,167 @@ mod tests {
 
         let utf8 = parse_stdout("./provider", &[0xff]).unwrap_err();
         assert!(utf8.to_string().contains("valid UTF-8"));
+    }
+
+    #[tokio::test]
+    async fn command_provider_writes_request_closes_stdin_and_parses_stdout() {
+        let mut provider = fixture_provider(["echo-request"], Duration::from_secs(2));
+        let context = fixed_context();
+
+        let ProviderPoll::Loaded(snapshot) = provider.refresh(&context).await else {
+            panic!("expected a loaded snapshot");
+        };
+        assert_eq!(
+            snapshot.events()[0].text,
+            String::from_utf8(encode_request(&context).unwrap()).unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn command_provider_preserves_args_cwd_and_environment() {
+        let inherited_key = "PATH";
+        let inherited_value = std::env::var(inherited_key).expect("test process must have PATH");
+        let expected_cwd = std::env::current_dir().unwrap();
+        let mut provider = fixture_provider(
+            ["show-context", "--environment", "prod", inherited_key],
+            Duration::from_secs(2),
+        );
+
+        let ProviderPoll::Loaded(snapshot) = provider.refresh(&fixed_context()).await else {
+            panic!("expected a loaded snapshot");
+        };
+        let text = &snapshot.events()[0].text;
+        assert!(text.contains("--environment|prod"));
+        assert!(text.contains(&expected_cwd.display().to_string()));
+        assert!(text.contains(&inherited_value));
+    }
+
+    #[tokio::test]
+    async fn command_provider_loads_empty_snapshot_from_empty_stdout() {
+        let mut provider = fixture_provider(["empty"], Duration::from_secs(2));
+
+        let ProviderPoll::Loaded(snapshot) = provider.refresh(&fixed_context()).await else {
+            panic!("expected a loaded snapshot");
+        };
+        assert_eq!(snapshot.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn command_provider_times_out_and_reaps_child() {
+        let mut provider = fixture_provider(["sleep", "5000"], Duration::from_millis(50));
+        let started = std::time::Instant::now();
+        let ProviderPoll::Failed(error) = provider.refresh(&fixed_context()).await else {
+            panic!("expected timeout failure");
+        };
+        assert!(started.elapsed() < Duration::from_secs(2));
+        assert!(error.to_string().contains("timed out after 50ms"));
+    }
+
+    #[tokio::test]
+    async fn command_provider_rejects_oversized_stdout() {
+        let stdout_bytes = (MAX_STDOUT_BYTES + 1).to_string();
+        let mut provider =
+            fixture_provider(["stdout-bytes", &stdout_bytes], Duration::from_secs(2));
+        let ProviderPoll::Failed(error) = provider.refresh(&fixed_context()).await else {
+            panic!("expected stdout limit failure");
+        };
+        assert!(error.to_string().contains("10 MiB stdout limit"));
+    }
+
+    #[tokio::test]
+    async fn command_provider_bounds_and_normalizes_failure_stderr() {
+        let stderr_bytes = (MAX_STDERR_BYTES + 1024).to_string();
+        let mut provider =
+            fixture_provider(["stderr-bytes", &stderr_bytes, "7"], Duration::from_secs(2));
+        let ProviderPoll::Failed(error) = provider.refresh(&fixed_context()).await else {
+            panic!("expected exit failure");
+        };
+        let message = error.to_string();
+        assert!(message.contains("exited with status 7"));
+        assert!(message.contains("eeeeeeee"));
+        assert!(!message.contains('\n'));
+        assert!(message.len() < 1024);
+    }
+
+    #[tokio::test]
+    async fn command_provider_normalizes_multiline_exit_diagnostic_and_discards_stdout() {
+        let mut provider = fixture_provider(["exit", "9"], Duration::from_secs(2));
+
+        let ProviderPoll::Failed(error) = provider.refresh(&fixed_context()).await else {
+            panic!("expected exit failure");
+        };
+        let message = error.to_string();
+        assert!(message.contains("exited with status 9"));
+        assert!(message.contains("first diagnostic line second diagnostic line"));
+        assert!(!message.contains("invalid annotation JSONL"));
+        assert!(!message.contains('\n'));
+    }
+
+    #[tokio::test]
+    async fn command_provider_ignores_stderr_after_successful_exit() {
+        let mut provider = fixture_provider(["stderr-bytes", "32", "0"], Duration::from_secs(2));
+
+        let ProviderPoll::Loaded(snapshot) = provider.refresh(&fixed_context()).await else {
+            panic!("expected successful empty snapshot");
+        };
+        assert_eq!(snapshot.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn command_provider_reports_spawn_failure_without_arguments() {
+        let secret = "secret-looking-argument-never-report-this";
+        let missing = std::env::temp_dir()
+            .join(format!("grafatui-missing-provider-{}", std::process::id()))
+            .to_string_lossy()
+            .into_owned();
+        let mut provider = CommandProvider::new(AnnotationCommandConfig {
+            program: missing.clone(),
+            args: vec![secret.to_string()],
+            timeout: Duration::from_secs(2),
+        });
+
+        let ProviderPoll::Failed(error) = provider.refresh(&fixed_context()).await else {
+            panic!("expected spawn failure");
+        };
+        let message = error.to_string();
+        assert!(message.contains(&format!("annotation command {missing}")));
+        assert!(message.contains("could not start"));
+        assert!(!message.contains(secret));
+    }
+
+    #[tokio::test]
+    async fn command_provider_reports_nonzero_exit_without_arguments() {
+        let secret = "secret-looking-argument-never-report-this";
+        let mut config = fixture_config(["exit", "7"], Duration::from_secs(2));
+        config.args.push(secret.to_string());
+        let mut provider = CommandProvider::new(config);
+
+        let ProviderPoll::Failed(error) = provider.refresh(&fixed_context()).await else {
+            panic!("expected exit failure");
+        };
+        let message = error.to_string();
+        assert!(message.contains("exited with status 7"));
+        assert!(!message.contains(secret));
+    }
+
+    #[tokio::test]
+    async fn command_provider_reports_malformed_jsonl() {
+        let mut provider = fixture_provider(["invalid"], Duration::from_secs(2));
+
+        let ProviderPoll::Failed(error) = provider.refresh(&fixed_context()).await else {
+            panic!("expected malformed JSONL failure");
+        };
+        assert!(error.to_string().contains("annotation command"));
+        assert!(error.to_string().contains(":1"));
+    }
+
+    #[tokio::test]
+    async fn command_provider_reports_invalid_utf8() {
+        let mut provider = fixture_provider(["invalid", "utf8"], Duration::from_secs(2));
+
+        let ProviderPoll::Failed(error) = provider.refresh(&fixed_context()).await else {
+            panic!("expected invalid UTF-8 failure");
+        };
+        assert!(error.to_string().contains("stdout must be valid UTF-8"));
     }
 }

--- a/src/annotations/command.rs
+++ b/src/annotations/command.rs
@@ -1,0 +1,116 @@
+use chrono::SecondsFormat;
+use serde::Serialize;
+
+use super::{
+    AnnotationProviderError, AnnotationRefreshContext, AnnotationSnapshot, jsonl::parse_jsonl,
+};
+
+#[derive(Serialize)]
+struct CommandRequest {
+    version: u8,
+    range: CommandRange,
+}
+
+#[derive(Serialize)]
+struct CommandRange {
+    from: String,
+    to: String,
+}
+
+fn encode_request(context: &AnnotationRefreshContext) -> Result<Vec<u8>, AnnotationProviderError> {
+    let mut encoded = serde_json::to_vec(&CommandRequest {
+        version: 1,
+        range: CommandRange {
+            from: context.from.to_rfc3339_opts(SecondsFormat::AutoSi, true),
+            to: context.to.to_rfc3339_opts(SecondsFormat::AutoSi, true),
+        },
+    })
+    .map_err(|error| {
+        AnnotationProviderError::new(format!("could not encode annotation request: {error}"))
+    })?;
+    encoded.push(b'\n');
+    Ok(encoded)
+}
+
+fn parse_stdout(
+    program: &str,
+    stdout: &[u8],
+) -> Result<AnnotationSnapshot, AnnotationProviderError> {
+    let input = std::str::from_utf8(stdout).map_err(|error| {
+        AnnotationProviderError::new(format!(
+            "annotation command {program}: stdout must be valid UTF-8: {error}"
+        ))
+    })?;
+    parse_jsonl(&format!("annotation command {program}"), input)
+        .map_err(|error| AnnotationProviderError::new(error.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::{DateTime, Utc};
+
+    use super::{encode_request, parse_stdout};
+    use crate::annotations::AnnotationRefreshContext;
+
+    fn fixed_context() -> AnnotationRefreshContext {
+        AnnotationRefreshContext {
+            from: DateTime::parse_from_rfc3339("2026-08-12T10:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+            to: DateTime::parse_from_rfc3339("2026-08-12T10:05:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+        }
+    }
+
+    #[test]
+    fn encodes_exact_version_one_request_with_trailing_newline() {
+        let context = fixed_context();
+
+        let encoded = encode_request(&context).unwrap();
+        assert_eq!(
+            String::from_utf8(encoded.clone()).unwrap(),
+            concat!(
+                r#"{"version":1,"range":{"from":"2026-08-12T10:00:00Z","to":"2026-08-12T10:05:00Z"}}"#,
+                "\n"
+            )
+        );
+
+        let request: serde_json::Value = serde_json::from_slice(&encoded).unwrap();
+        let request = request.as_object().unwrap();
+        assert_eq!(request.len(), 2);
+        assert!(request.contains_key("version"));
+        assert!(request.contains_key("range"));
+
+        let range = request["range"].as_object().unwrap();
+        assert_eq!(range.len(), 2);
+        assert!(range.contains_key("from"));
+        assert!(range.contains_key("to"));
+    }
+
+    #[test]
+    fn parses_valid_and_empty_command_snapshots() {
+        let valid = parse_stdout(
+            "./provider",
+            br#"{"time":"2026-08-12T10:02:13.125Z","text":"deploy","tags":["prod"]}
+"#,
+        )
+        .unwrap();
+        assert_eq!(valid.len(), 1);
+        assert_eq!(valid.events()[0].time.timestamp_subsec_millis(), 125);
+        assert_eq!(parse_stdout("./provider", b"").unwrap().len(), 0);
+    }
+
+    #[test]
+    fn command_parse_errors_identify_program_and_line() {
+        let error = parse_stdout("./provider", b"{invalid}\n").unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("annotation command ./provider:1")
+        );
+
+        let utf8 = parse_stdout("./provider", &[0xff]).unwrap_err();
+        assert!(utf8.to_string().contains("valid UTF-8"));
+    }
+}

--- a/src/annotations/command.rs
+++ b/src/annotations/command.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code)] // Command providers are implemented here before runtime wiring.
+#![allow(dead_code)]
 
 use chrono::SecondsFormat;
 use serde::Serialize;

--- a/src/annotations/jsonl.rs
+++ b/src/annotations/jsonl.rs
@@ -1,10 +1,13 @@
 use std::fmt;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use chrono::{DateTime, Utc};
 use serde::Deserialize;
 
-use super::{AnnotationEvent, AnnotationSnapshot, AnnotationTarget};
+use super::{
+    AnnotationEvent, AnnotationProvider, AnnotationProviderError, AnnotationRefreshContext,
+    AnnotationSnapshot, AnnotationTarget, ProviderFuture, ProviderPoll,
+};
 
 #[derive(Deserialize)]
 struct RawAnnotationEvent {
@@ -27,7 +30,7 @@ enum RawPanelTitles {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct AnnotationLoadError {
-    path: PathBuf,
+    source: String,
     line: Option<usize>,
     reason: String,
 }
@@ -38,9 +41,9 @@ impl AnnotationLoadError {
         self.line
     }
 
-    fn at_line(path: &Path, line: usize, reason: impl Into<String>) -> Self {
+    fn at_line(source: &str, line: usize, reason: impl Into<String>) -> Self {
         Self {
-            path: path.to_path_buf(),
+            source: source.to_string(),
             line: Some(line),
             reason: reason.into(),
         }
@@ -50,8 +53,8 @@ impl AnnotationLoadError {
 impl fmt::Display for AnnotationLoadError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.line {
-            Some(line) => write!(formatter, "{}:{line}: {}", self.path.display(), self.reason),
-            None => write!(formatter, "{}: {}", self.path.display(), self.reason),
+            Some(line) => write!(formatter, "{}:{line}: {}", self.source, self.reason),
+            None => write!(formatter, "{}: {}", self.source, self.reason),
         }
     }
 }
@@ -59,7 +62,7 @@ impl fmt::Display for AnnotationLoadError {
 impl std::error::Error for AnnotationLoadError {}
 
 pub(crate) fn parse_jsonl(
-    path: &Path,
+    source: &str,
     input: &str,
 ) -> Result<AnnotationSnapshot, AnnotationLoadError> {
     let mut events = Vec::new();
@@ -72,7 +75,7 @@ pub(crate) fn parse_jsonl(
         let line_number = index + 1;
         let raw: RawAnnotationEvent = serde_json::from_str(line).map_err(|error| {
             AnnotationLoadError::at_line(
-                path,
+                source,
                 line_number,
                 format!(
                     "invalid annotation event (time, text, tags, and panel_titles must have valid types): {error}"
@@ -82,7 +85,7 @@ pub(crate) fn parse_jsonl(
         let time = DateTime::parse_from_rfc3339(&raw.time)
             .map_err(|error| {
                 AnnotationLoadError::at_line(
-                    path,
+                    source,
                     line_number,
                     format!("time must be an RFC 3339 timestamp: {error}"),
                 )
@@ -91,14 +94,14 @@ pub(crate) fn parse_jsonl(
 
         if raw.text.trim().is_empty() {
             return Err(AnnotationLoadError::at_line(
-                path,
+                source,
                 line_number,
                 "text must not be empty",
             ));
         }
         if raw.tags.iter().any(|tag| tag.trim().is_empty()) {
             return Err(AnnotationLoadError::at_line(
-                path,
+                source,
                 line_number,
                 "tags must not contain empty strings",
             ));
@@ -108,14 +111,14 @@ pub(crate) fn parse_jsonl(
             RawPanelTitles::Missing => AnnotationTarget::All,
             RawPanelTitles::Null(()) => {
                 return Err(AnnotationLoadError::at_line(
-                    path,
+                    source,
                     line_number,
                     "panel_titles must not be null",
                 ));
             }
             RawPanelTitles::Titles(titles) if titles.is_empty() => {
                 return Err(AnnotationLoadError::at_line(
-                    path,
+                    source,
                     line_number,
                     "panel_titles must contain at least one title",
                 ));
@@ -124,7 +127,7 @@ pub(crate) fn parse_jsonl(
                 if titles.iter().any(|title| title.trim().is_empty()) =>
             {
                 return Err(AnnotationLoadError::at_line(
-                    path,
+                    source,
                     line_number,
                     "panel_titles must not contain blank strings",
                 ));
@@ -155,19 +158,12 @@ enum SourceFingerprint {
 }
 
 #[derive(Debug)]
-pub(crate) enum SourcePoll {
-    Unchanged,
-    Loaded(AnnotationSnapshot),
-    Failed(AnnotationLoadError),
-}
-
-#[derive(Debug)]
-pub(crate) struct JsonlFileSource {
+pub(crate) struct JsonlFileProvider {
     path: PathBuf,
     last_seen: Option<SourceFingerprint>,
 }
 
-impl JsonlFileSource {
+impl JsonlFileProvider {
     pub(crate) fn new(path: PathBuf) -> Self {
         Self {
             path,
@@ -175,65 +171,82 @@ impl JsonlFileSource {
         }
     }
 
-    pub(crate) async fn poll(&mut self) -> SourcePoll {
+    async fn poll_file(&mut self) -> ProviderPoll {
         let fingerprint = match tokio::fs::metadata(&self.path).await {
             Ok(metadata) => match metadata.modified() {
                 Ok(modified) => SourceFingerprint::Present {
                     len: metadata.len(),
                     modified,
                 },
-                Err(error) => return SourcePoll::Failed(self.io_error(error)),
+                Err(error) => return ProviderPoll::Failed(self.io_error(error)),
             },
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
                 SourceFingerprint::Missing
             }
-            Err(error) => return SourcePoll::Failed(self.io_error(error)),
+            Err(error) => return ProviderPoll::Failed(self.io_error(error)),
         };
 
         if self.last_seen.as_ref() == Some(&fingerprint) {
-            return SourcePoll::Unchanged;
+            return ProviderPoll::Unchanged;
         }
 
         match fingerprint {
             SourceFingerprint::Missing => {
                 self.last_seen = Some(SourceFingerprint::Missing);
-                SourcePoll::Failed(AnnotationLoadError {
-                    path: self.path.clone(),
-                    line: None,
-                    reason: "annotation file does not exist".to_string(),
-                })
+                ProviderPoll::Failed(AnnotationProviderError::new(
+                    AnnotationLoadError {
+                        source: self.path.display().to_string(),
+                        line: None,
+                        reason: "annotation file does not exist".to_string(),
+                    }
+                    .to_string(),
+                ))
             }
             SourceFingerprint::Present { len, modified } => {
                 match tokio::fs::read_to_string(&self.path).await {
                     Ok(input) => {
                         self.last_seen = Some(SourceFingerprint::Present { len, modified });
-                        match parse_jsonl(&self.path, &input) {
-                            Ok(snapshot) => SourcePoll::Loaded(snapshot),
-                            Err(error) => SourcePoll::Failed(error),
+                        match parse_jsonl(&self.path.display().to_string(), &input) {
+                            Ok(snapshot) => ProviderPoll::Loaded(snapshot),
+                            Err(error) => ProviderPoll::Failed(AnnotationProviderError::new(
+                                error.to_string(),
+                            )),
                         }
                     }
-                    Err(error) => SourcePoll::Failed(self.io_error(error)),
+                    Err(error) => ProviderPoll::Failed(self.io_error(error)),
                 }
             }
         }
     }
 
-    fn io_error(&self, error: std::io::Error) -> AnnotationLoadError {
-        AnnotationLoadError {
-            path: self.path.clone(),
-            line: None,
-            reason: format!("could not read annotation file: {error}"),
-        }
+    fn io_error(&self, error: std::io::Error) -> AnnotationProviderError {
+        AnnotationProviderError::new(
+            AnnotationLoadError {
+                source: self.path.display().to_string(),
+                line: None,
+                reason: format!("could not read annotation file: {error}"),
+            }
+            .to_string(),
+        )
+    }
+}
+
+impl AnnotationProvider for JsonlFileProvider {
+    fn refresh<'a>(&'a mut self, _context: &'a AnnotationRefreshContext) -> ProviderFuture<'a> {
+        Box::pin(async move { self.poll_file().await })
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::path::{Path, PathBuf};
+    use std::path::PathBuf;
+    use std::time::Duration;
 
-    use crate::annotations::AnnotationTarget;
+    use crate::annotations::{
+        AnnotationProvider, AnnotationRefreshContext, AnnotationTarget, ProviderPoll,
+    };
 
-    use super::{JsonlFileSource, SourcePoll, parse_jsonl};
+    use super::{JsonlFileProvider, parse_jsonl};
 
     fn temp_path(name: &str) -> PathBuf {
         let suffix = std::time::SystemTime::now()
@@ -246,6 +259,10 @@ mod tests {
         ))
     }
 
+    fn refresh_context() -> AnnotationRefreshContext {
+        AnnotationRefreshContext::from_unix_window(200, Duration::from_secs(100))
+    }
+
     #[test]
     fn parses_valid_jsonl_and_ignores_blank_lines_and_unknown_fields() {
         let input = concat!(
@@ -256,7 +273,7 @@ mod tests {
             "\n",
         );
 
-        let snapshot = parse_jsonl(Path::new("events.jsonl"), input).unwrap();
+        let snapshot = parse_jsonl("events.jsonl", input).unwrap();
 
         assert_eq!(snapshot.len(), 2);
         assert_eq!(snapshot.events()[0].text, "deploy");
@@ -267,7 +284,7 @@ mod tests {
     #[test]
     fn parses_optional_panel_titles_and_deduplicates_them() {
         let snapshot = parse_jsonl(
-            Path::new("events.jsonl"),
+            "events.jsonl",
             concat!(
                 r#"{"time":"2026-08-11T14:30:00Z","text":"global"}"#,
                 "\n",
@@ -293,7 +310,7 @@ mod tests {
             r#"{"time":"2026-08-11T14:30:00Z","text":"x","panel_titles":[]}"#,
             r#"{"time":"2026-08-11T14:30:00Z","text":"x","panel_titles":["  "]}"#,
         ] {
-            let error = parse_jsonl(Path::new("events.jsonl"), input).unwrap_err();
+            let error = parse_jsonl("events.jsonl", input).unwrap_err();
             assert_eq!(error.line(), Some(1));
             assert!(error.to_string().contains("panel_titles"));
         }
@@ -302,7 +319,7 @@ mod tests {
     #[test]
     fn rejects_null_panel_titles_with_line_number() {
         let error = parse_jsonl(
-            Path::new("events.jsonl"),
+            "events.jsonl",
             r#"{"time":"2026-08-11T14:30:00Z","text":"x","panel_titles":null}"#,
         )
         .unwrap_err();
@@ -314,7 +331,7 @@ mod tests {
     #[test]
     fn rejects_invalid_required_fields_with_line_number() {
         let error = parse_jsonl(
-            Path::new("events.jsonl"),
+            "events.jsonl",
             "{\"time\":1700000000000,\"text\":\"deploy\"}\n",
         )
         .unwrap_err();
@@ -327,14 +344,14 @@ mod tests {
     #[test]
     fn rejects_blank_text_and_tags() {
         let blank_text = parse_jsonl(
-            Path::new("events.jsonl"),
+            "events.jsonl",
             r#"{"time":"2026-07-23T14:30:00Z","text":"  "}"#,
         )
         .unwrap_err();
         assert!(blank_text.to_string().contains("text must not be empty"));
 
         let blank_tag = parse_jsonl(
-            Path::new("events.jsonl"),
+            "events.jsonl",
             r#"{"time":"2026-07-23T14:30:00Z","text":"deploy","tags":[""]}"#,
         )
         .unwrap_err();
@@ -354,13 +371,21 @@ mod tests {
         )
         .await
         .unwrap();
-        let mut source = JsonlFileSource::new(path.clone());
+        let mut provider = JsonlFileProvider::new(path.clone());
+        let context = refresh_context();
 
-        assert!(matches!(source.poll().await, SourcePoll::Loaded(snapshot) if snapshot.len() == 1));
-        assert!(matches!(source.poll().await, SourcePoll::Unchanged));
+        assert!(
+            matches!(provider.refresh(&context).await, ProviderPoll::Loaded(snapshot) if snapshot.len() == 1)
+        );
+        assert!(matches!(
+            provider.refresh(&context).await,
+            ProviderPoll::Unchanged
+        ));
 
         tokio::fs::write(&path, "").await.unwrap();
-        assert!(matches!(source.poll().await, SourcePoll::Loaded(snapshot) if snapshot.len() == 0));
+        assert!(
+            matches!(provider.refresh(&context).await, ProviderPoll::Loaded(snapshot) if snapshot.len() == 0)
+        );
 
         tokio::fs::remove_file(path).await.unwrap();
     }
@@ -368,10 +393,17 @@ mod tests {
     #[tokio::test]
     async fn reports_missing_then_loads_when_file_appears() {
         let path = temp_path("appears");
-        let mut source = JsonlFileSource::new(path.clone());
+        let mut provider = JsonlFileProvider::new(path.clone());
+        let context = refresh_context();
 
-        assert!(matches!(source.poll().await, SourcePoll::Failed(_)));
-        assert!(matches!(source.poll().await, SourcePoll::Unchanged));
+        assert!(matches!(
+            provider.refresh(&context).await,
+            ProviderPoll::Failed(_)
+        ));
+        assert!(matches!(
+            provider.refresh(&context).await,
+            ProviderPoll::Unchanged
+        ));
 
         tokio::fs::write(
             &path,
@@ -379,7 +411,9 @@ mod tests {
         )
         .await
         .unwrap();
-        assert!(matches!(source.poll().await, SourcePoll::Loaded(snapshot) if snapshot.len() == 1));
+        assert!(
+            matches!(provider.refresh(&context).await, ProviderPoll::Loaded(snapshot) if snapshot.len() == 1)
+        );
 
         tokio::fs::remove_file(path).await.unwrap();
     }
@@ -393,12 +427,22 @@ mod tests {
         )
         .await
         .unwrap();
-        let mut source = JsonlFileSource::new(path.clone());
-        assert!(matches!(source.poll().await, SourcePoll::Loaded(_)));
+        let mut provider = JsonlFileProvider::new(path.clone());
+        let context = refresh_context();
+        assert!(matches!(
+            provider.refresh(&context).await,
+            ProviderPoll::Loaded(_)
+        ));
 
         tokio::fs::write(&path, "{\"time\":").await.unwrap();
-        assert!(matches!(source.poll().await, SourcePoll::Failed(_)));
-        assert!(matches!(source.poll().await, SourcePoll::Unchanged));
+        assert!(matches!(
+            provider.refresh(&context).await,
+            ProviderPoll::Failed(_)
+        ));
+        assert!(matches!(
+            provider.refresh(&context).await,
+            ProviderPoll::Unchanged
+        ));
 
         tokio::fs::remove_file(path).await.unwrap();
     }
@@ -416,10 +460,11 @@ mod tests {
         tokio::fs::write(&path, invalid_utf8).await.unwrap();
         let initial_metadata = tokio::fs::metadata(&path).await.unwrap();
         let initial_modified = initial_metadata.modified().unwrap();
-        let mut source = JsonlFileSource::new(path.clone());
+        let mut provider = JsonlFileProvider::new(path.clone());
+        let context = refresh_context();
 
         assert!(
-            matches!(source.poll().await, SourcePoll::Failed(error) if error.to_string().contains("could not read annotation file"))
+            matches!(provider.refresh(&context).await, ProviderPoll::Failed(error) if error.to_string().contains("could not read annotation file"))
         );
 
         tokio::fs::write(&path, valid).await.unwrap();
@@ -434,8 +479,8 @@ mod tests {
         assert_eq!(recovered_metadata.modified().unwrap(), initial_modified);
 
         assert!(matches!(
-            source.poll().await,
-            SourcePoll::Loaded(snapshot) if snapshot.len() == 1
+            provider.refresh(&context).await,
+            ProviderPoll::Loaded(snapshot) if snapshot.len() == 1
         ));
 
         tokio::fs::remove_file(path).await.unwrap();

--- a/src/annotations/mod.rs
+++ b/src/annotations/mod.rs
@@ -15,7 +15,7 @@ pub(crate) use diagnostics::{AnnotationTargetWarning, target_warnings};
 #[cfg(test)]
 pub(crate) use filter::tag_catalogue;
 pub(crate) use filter::{TagCatalogueEntry, TagFilter};
-pub(crate) use jsonl::{JsonlFileSource, SourcePoll};
+pub(crate) use jsonl::JsonlFileProvider;
 pub(crate) use modal::TagFilterModalState;
 pub(crate) use modal::{AnnotationModal, ClusterModalState, visible_range};
 pub(crate) use model::{
@@ -23,7 +23,8 @@ pub(crate) use model::{
 };
 pub(crate) use projection::{AnnotationCluster, cluster_events_by};
 pub(crate) use provider::{
-    AnnotationCommandConfig, AnnotationSourceConfig, DEFAULT_COMMAND_TIMEOUT,
+    AnnotationCommandConfig, AnnotationProvider, AnnotationProviderError, AnnotationRefreshContext,
+    AnnotationSourceConfig, DEFAULT_COMMAND_TIMEOUT, ProviderFuture, ProviderPoll,
 };
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -37,7 +38,7 @@ pub(crate) struct AnnotationStatus {
 pub(crate) enum AnnotationState {
     Disabled,
     Active {
-        source: Option<JsonlFileSource>,
+        provider: Option<Box<dyn AnnotationProvider>>,
         snapshot: AnnotationSnapshot,
         filter: TagFilter,
         visible: bool,
@@ -46,10 +47,10 @@ pub(crate) enum AnnotationState {
 }
 
 impl AnnotationState {
-    pub(crate) fn from_path(path: Option<PathBuf>) -> Self {
-        match path {
-            Some(path) => Self::Active {
-                source: Some(JsonlFileSource::new(path)),
+    pub(crate) fn from_provider(provider: Option<Box<dyn AnnotationProvider>>) -> Self {
+        match provider {
+            Some(provider) => Self::Active {
+                provider: Some(provider),
                 snapshot: AnnotationSnapshot::new(Vec::new()),
                 filter: TagFilter::default(),
                 visible: true,
@@ -59,13 +60,19 @@ impl AnnotationState {
         }
     }
 
-    pub(crate) async fn refresh_if_changed(&mut self) -> bool {
+    pub(crate) fn from_path(path: Option<PathBuf>) -> Self {
+        Self::from_provider(
+            path.map(|path| Box::new(JsonlFileProvider::new(path)) as Box<dyn AnnotationProvider>),
+        )
+    }
+
+    pub(crate) async fn refresh(&mut self, context: &AnnotationRefreshContext) -> bool {
         let poll = match self {
             Self::Active {
-                source: Some(source),
+                provider: Some(provider),
                 ..
-            } => source.poll().await,
-            Self::Disabled | Self::Active { source: None, .. } => return false,
+            } => provider.refresh(context).await,
+            Self::Disabled | Self::Active { provider: None, .. } => return false,
         };
 
         match (self, poll) {
@@ -73,21 +80,21 @@ impl AnnotationState {
                 Self::Active {
                     snapshot, status, ..
                 },
-                SourcePoll::Loaded(next_snapshot),
+                ProviderPoll::Loaded(next_snapshot),
             ) => {
                 *snapshot = next_snapshot;
                 status.loaded_events = snapshot.len();
                 status.source_warning = None;
                 true
             }
-            (Self::Active { status, .. }, SourcePoll::Failed(error)) => {
+            (Self::Active { status, .. }, ProviderPoll::Failed(error)) => {
                 status.source_warning = Some(format!(
                     "{error}; using {} previous event(s)",
                     status.loaded_events
                 ));
                 false
             }
-            (_, SourcePoll::Unchanged) | (Self::Disabled, _) => false,
+            (_, ProviderPoll::Unchanged) | (Self::Disabled, _) => false,
         }
     }
 
@@ -201,7 +208,7 @@ impl AnnotationState {
         let snapshot = AnnotationSnapshot::new(events);
         let event_count = snapshot.len();
         Self::Active {
-            source: None,
+            provider: None,
             snapshot,
             filter: TagFilter::default(),
             visible: true,
@@ -215,7 +222,7 @@ impl AnnotationState {
     #[cfg(test)]
     pub(crate) fn warning_for_test(message: &str) -> Self {
         Self::Active {
-            source: None,
+            provider: None,
             snapshot: AnnotationSnapshot::new(Vec::new()),
             filter: TagFilter::default(),
             visible: true,
@@ -240,9 +247,42 @@ pub(crate) fn test_event_at(timestamp_secs: f64, text: &str) -> AnnotationEvent 
 
 #[cfg(test)]
 mod tests {
+    use std::collections::VecDeque;
     use std::path::PathBuf;
+    use std::time::Duration;
 
-    use super::{AnnotationPanelContext, AnnotationState, AnnotationTarget, TagFilter};
+    use super::{
+        AnnotationPanelContext, AnnotationProvider, AnnotationProviderError,
+        AnnotationRefreshContext, AnnotationSnapshot, AnnotationState, AnnotationTarget,
+        ProviderFuture, ProviderPoll, TagFilter,
+    };
+
+    #[derive(Debug)]
+    struct ScriptedProvider {
+        outcomes: VecDeque<ProviderPoll>,
+    }
+
+    impl ScriptedProvider {
+        fn new(outcomes: Vec<ProviderPoll>) -> Self {
+            Self {
+                outcomes: outcomes.into(),
+            }
+        }
+    }
+
+    impl AnnotationProvider for ScriptedProvider {
+        fn refresh<'a>(&'a mut self, _context: &'a AnnotationRefreshContext) -> ProviderFuture<'a> {
+            Box::pin(async move { self.outcomes.pop_front().unwrap_or(ProviderPoll::Unchanged) })
+        }
+    }
+
+    fn snapshot_with(text: &str) -> AnnotationSnapshot {
+        AnnotationSnapshot::new(vec![super::test_event_at(100.0, text)])
+    }
+
+    fn refresh_context() -> AnnotationRefreshContext {
+        AnnotationRefreshContext::from_unix_window(200, Duration::from_secs(100))
+    }
 
     fn temp_path(name: &str) -> PathBuf {
         let suffix = std::time::SystemTime::now()
@@ -257,22 +297,19 @@ mod tests {
 
     #[tokio::test]
     async fn state_retains_last_valid_snapshot_and_clears_warning_on_recovery() {
-        let path = temp_path("state-recovery");
-        tokio::fs::write(
-            &path,
-            "{\"time\":\"2026-07-23T14:30:00Z\",\"text\":\"deploy\"}\n",
-        )
-        .await
-        .unwrap();
-        let mut state = AnnotationState::from_path(Some(path.clone()));
+        let context = AnnotationRefreshContext::from_unix_window(200, Duration::from_secs(100));
+        let provider = ScriptedProvider::new(vec![
+            ProviderPoll::Loaded(snapshot_with("deploy")),
+            ProviderPoll::Failed(AnnotationProviderError::new("temporary failure")),
+            ProviderPoll::Loaded(AnnotationSnapshot::new(Vec::new())),
+        ]);
+        let mut state = AnnotationState::from_provider(Some(Box::new(provider)));
 
-        assert!(state.refresh_if_changed().await);
+        assert!(state.refresh(&context).await);
         assert_eq!(state.snapshot().unwrap().len(), 1);
         assert!(state.footer_status().is_none());
-        assert!(!state.refresh_if_changed().await);
 
-        tokio::fs::write(&path, "{\"time\":").await.unwrap();
-        state.refresh_if_changed().await;
+        state.refresh(&context).await;
         assert_eq!(state.snapshot().unwrap().len(), 1);
         assert!(
             state
@@ -281,12 +318,9 @@ mod tests {
                 .contains("using 1 previous event")
         );
 
-        tokio::fs::write(&path, "").await.unwrap();
-        state.refresh_if_changed().await;
+        assert!(state.refresh(&context).await);
         assert_eq!(state.snapshot().unwrap().len(), 0);
         assert!(state.footer_status().is_none());
-
-        tokio::fs::remove_file(path).await.unwrap();
     }
 
     #[tokio::test]
@@ -302,8 +336,9 @@ mod tests {
         .await
         .unwrap();
         let mut state = AnnotationState::from_path(Some(path.clone()));
+        let context = refresh_context();
 
-        assert!(state.refresh_if_changed().await);
+        assert!(state.refresh(&context).await);
         state.reconcile_targets(&["CPU".to_string(), "CPU".to_string()]);
         assert_eq!(
             state.footer_status(),
@@ -314,7 +349,7 @@ mod tests {
         );
 
         tokio::fs::write(&path, "{").await.unwrap();
-        assert!(!state.refresh_if_changed().await);
+        assert!(!state.refresh(&context).await);
         let source_first_status = state.footer_status().unwrap();
         assert!(source_first_status.starts_with(&format!("{}:1:", path.display())));
         assert!(source_first_status.contains("using 1 previous event(s)"));
@@ -329,7 +364,7 @@ mod tests {
         )
         .await
         .unwrap();
-        assert!(state.refresh_if_changed().await);
+        assert!(state.refresh(&context).await);
         state.reconcile_targets(&["Memory".to_string()]);
         assert_eq!(state.footer_status(), None);
 
@@ -355,14 +390,15 @@ mod tests {
         .await
         .unwrap();
         let mut state = AnnotationState::from_path(Some(path.clone()));
+        let context = refresh_context();
         state.toggle_visibility();
 
-        state.refresh_if_changed().await;
+        state.refresh(&context).await;
         assert_eq!(state.snapshot().unwrap().len(), 1);
         assert!(!state.is_visible());
 
         tokio::fs::remove_file(&path).await.unwrap();
-        state.refresh_if_changed().await;
+        state.refresh(&context).await;
         assert_eq!(state.snapshot().unwrap().len(), 1);
         assert!(
             state
@@ -375,11 +411,12 @@ mod tests {
     #[tokio::test]
     async fn disabled_state_has_no_source_work_or_visibility() {
         let mut state = AnnotationState::from_path(None);
+        let context = refresh_context();
         assert!(!state.is_configured());
         assert!(!state.is_visible());
         assert!(state.snapshot().is_none());
         assert!(state.footer_status().is_none());
-        assert!(!state.refresh_if_changed().await);
+        assert!(!state.refresh(&context).await);
         state.toggle_visibility();
         assert!(!state.is_visible());
     }

--- a/src/annotations/mod.rs
+++ b/src/annotations/mod.rs
@@ -7,6 +7,7 @@ mod jsonl;
 mod modal;
 mod model;
 mod projection;
+mod provider;
 
 pub(crate) use details::format_cluster_detail_lines;
 pub(crate) use details::format_event_time;
@@ -21,6 +22,9 @@ pub(crate) use model::{
     AnnotationEvent, AnnotationPanelContext, AnnotationSnapshot, AnnotationTarget,
 };
 pub(crate) use projection::{AnnotationCluster, cluster_events_by};
+pub(crate) use provider::{
+    AnnotationCommandConfig, AnnotationSourceConfig, DEFAULT_COMMAND_TIMEOUT,
+};
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct AnnotationStatus {

--- a/src/annotations/mod.rs
+++ b/src/annotations/mod.rs
@@ -16,7 +16,6 @@ pub(crate) use diagnostics::{AnnotationTargetWarning, target_warnings};
 #[cfg(test)]
 pub(crate) use filter::tag_catalogue;
 pub(crate) use filter::{TagCatalogueEntry, TagFilter};
-pub(crate) use jsonl::JsonlFileProvider;
 pub(crate) use modal::TagFilterModalState;
 pub(crate) use modal::{AnnotationModal, ClusterModalState, visible_range};
 pub(crate) use model::{
@@ -25,7 +24,7 @@ pub(crate) use model::{
 pub(crate) use projection::{AnnotationCluster, cluster_events_by};
 pub(crate) use provider::{
     AnnotationCommandConfig, AnnotationProvider, AnnotationProviderError, AnnotationRefreshContext,
-    AnnotationSourceConfig, DEFAULT_COMMAND_TIMEOUT, ProviderFuture, ProviderPoll,
+    AnnotationSourceConfig, DEFAULT_COMMAND_TIMEOUT, ProviderFuture, ProviderPoll, build_provider,
 };
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -61,10 +60,12 @@ impl AnnotationState {
         }
     }
 
+    pub(crate) fn from_source(source: Option<AnnotationSourceConfig>) -> Self {
+        Self::from_provider(source.map(build_provider))
+    }
+
     pub(crate) fn from_path(path: Option<PathBuf>) -> Self {
-        Self::from_provider(
-            path.map(|path| Box::new(JsonlFileProvider::new(path)) as Box<dyn AnnotationProvider>),
-        )
+        Self::from_source(path.map(AnnotationSourceConfig::File))
     }
 
     pub(crate) async fn refresh(&mut self, context: &AnnotationRefreshContext) -> bool {
@@ -250,6 +251,7 @@ pub(crate) fn test_event_at(timestamp_secs: f64, text: &str) -> AnnotationEvent 
 mod tests {
     use std::collections::VecDeque;
     use std::path::PathBuf;
+    use std::sync::{Arc, Mutex};
     use std::time::Duration;
 
     use super::{
@@ -261,19 +263,33 @@ mod tests {
     #[derive(Debug)]
     struct ScriptedProvider {
         outcomes: VecDeque<ProviderPoll>,
+        refresh_count: Option<Arc<Mutex<usize>>>,
     }
 
     impl ScriptedProvider {
         fn new(outcomes: Vec<ProviderPoll>) -> Self {
             Self {
                 outcomes: outcomes.into(),
+                refresh_count: None,
+            }
+        }
+
+        fn recording(outcomes: Vec<ProviderPoll>, refresh_count: Arc<Mutex<usize>>) -> Self {
+            Self {
+                outcomes: outcomes.into(),
+                refresh_count: Some(refresh_count),
             }
         }
     }
 
     impl AnnotationProvider for ScriptedProvider {
         fn refresh<'a>(&'a mut self, _context: &'a AnnotationRefreshContext) -> ProviderFuture<'a> {
-            Box::pin(async move { self.outcomes.pop_front().unwrap_or(ProviderPoll::Unchanged) })
+            Box::pin(async move {
+                if let Some(refresh_count) = &self.refresh_count {
+                    *refresh_count.lock().unwrap() += 1;
+                }
+                self.outcomes.pop_front().unwrap_or(ProviderPoll::Unchanged)
+            })
         }
     }
 
@@ -297,17 +313,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn state_retains_last_valid_snapshot_and_clears_warning_on_recovery() {
-        let context = AnnotationRefreshContext::from_unix_window(200, Duration::from_secs(100));
+    async fn command_state_retains_snapshot_on_failure_and_clears_warning_on_recovery() {
+        let context = refresh_context();
         let provider = ScriptedProvider::new(vec![
-            ProviderPoll::Loaded(snapshot_with("deploy")),
-            ProviderPoll::Failed(AnnotationProviderError::new("temporary failure")),
+            ProviderPoll::Loaded(snapshot_with("initial")),
+            ProviderPoll::Failed(AnnotationProviderError::new("command failed")),
             ProviderPoll::Loaded(AnnotationSnapshot::new(Vec::new())),
         ]);
         let mut state = AnnotationState::from_provider(Some(Box::new(provider)));
 
         assert!(state.refresh(&context).await);
         assert_eq!(state.snapshot().unwrap().len(), 1);
+        assert_eq!(state.snapshot().unwrap().events()[0].text, "initial");
         assert!(state.footer_status().is_none());
 
         state.refresh(&context).await;
@@ -322,6 +339,41 @@ mod tests {
         assert!(state.refresh(&context).await);
         assert_eq!(state.snapshot().unwrap().len(), 0);
         assert!(state.footer_status().is_none());
+    }
+
+    #[tokio::test]
+    async fn hidden_state_refreshes_provider_every_time() {
+        let refresh_count = Arc::new(Mutex::new(0));
+        let provider = ScriptedProvider::recording(
+            vec![ProviderPoll::Unchanged, ProviderPoll::Unchanged],
+            Arc::clone(&refresh_count),
+        );
+        let mut state = AnnotationState::from_provider(Some(Box::new(provider)));
+        state.toggle_visibility();
+
+        state.refresh(&refresh_context()).await;
+        state.refresh(&refresh_context()).await;
+
+        assert!(!state.is_visible());
+        assert_eq!(*refresh_count.lock().unwrap(), 2);
+    }
+
+    #[tokio::test]
+    async fn state_from_file_source_loads_snapshot() {
+        let path = temp_path("source-construction");
+        tokio::fs::write(
+            &path,
+            "{\"time\":\"2026-08-12T10:00:00Z\",\"text\":\"source\"}\n",
+        )
+        .await
+        .unwrap();
+        let mut state =
+            AnnotationState::from_source(Some(super::AnnotationSourceConfig::File(path.clone())));
+
+        assert!(state.refresh(&refresh_context()).await);
+        assert_eq!(state.snapshot().unwrap().events()[0].text, "source");
+
+        tokio::fs::remove_file(path).await.unwrap();
     }
 
     #[tokio::test]

--- a/src/annotations/mod.rs
+++ b/src/annotations/mod.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+mod command;
 mod details;
 mod diagnostics;
 mod filter;

--- a/src/annotations/provider.rs
+++ b/src/annotations/provider.rs
@@ -101,8 +101,8 @@ mod tests {
     use std::time::Duration;
 
     use super::{
-        AnnotationProvider, AnnotationRefreshContext, AnnotationSourceConfig, ProviderFuture,
-        ProviderPoll, build_provider,
+        AnnotationCommandConfig, AnnotationProvider, AnnotationRefreshContext,
+        AnnotationSourceConfig, ProviderFuture, ProviderPoll, build_provider,
     };
     use crate::annotations::AnnotationSnapshot;
 
@@ -154,5 +154,29 @@ mod tests {
         assert_eq!(snapshot.events()[0].text, "deploy");
 
         tokio::fs::remove_file(path).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn builds_command_provider_that_identifies_spawn_failure() {
+        let missing_program = std::env::temp_dir()
+            .join(format!(
+                "grafatui-missing-provider-factory-{}",
+                std::process::id()
+            ))
+            .to_string_lossy()
+            .into_owned();
+        let mut provider =
+            build_provider(AnnotationSourceConfig::Command(AnnotationCommandConfig {
+                program: missing_program.clone(),
+                args: Vec::new(),
+                timeout: Duration::from_secs(1),
+            }));
+        let context = AnnotationRefreshContext::from_unix_window(200, Duration::from_secs(10));
+
+        let ProviderPoll::Failed(error) = provider.refresh(&context).await else {
+            panic!("expected command provider spawn failure");
+        };
+        assert!(error.to_string().contains(&missing_program));
+        assert!(error.to_string().contains("could not start"));
     }
 }

--- a/src/annotations/provider.rs
+++ b/src/annotations/provider.rs
@@ -52,6 +52,11 @@ impl AnnotationProviderError {
     pub(crate) fn new(message: impl Into<String>) -> Self {
         Self(message.into())
     }
+
+    #[allow(dead_code)] // Used by command providers before they are runtime-wired.
+    pub(crate) fn command(program: &str, reason: impl fmt::Display) -> Self {
+        Self(format!("annotation command {program}: {reason}"))
+    }
 }
 
 impl fmt::Display for AnnotationProviderError {

--- a/src/annotations/provider.rs
+++ b/src/annotations/provider.rs
@@ -1,6 +1,12 @@
+use chrono::{DateTime, TimeDelta, Utc};
 use serde::{Deserialize, Deserializer};
+use std::fmt;
+use std::future::Future;
 use std::path::PathBuf;
+use std::pin::Pin;
 use std::time::Duration;
+
+use super::AnnotationSnapshot;
 
 pub(crate) const DEFAULT_COMMAND_TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -23,6 +29,48 @@ pub(crate) enum AnnotationSourceConfig {
     Command(AnnotationCommandConfig),
 }
 
+pub(crate) type ProviderFuture<'a> = Pin<Box<dyn Future<Output = ProviderPoll> + Send + 'a>>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AnnotationRefreshContext {
+    pub(crate) from: DateTime<Utc>,
+    pub(crate) to: DateTime<Utc>,
+}
+
+impl AnnotationRefreshContext {
+    pub(crate) fn from_unix_window(end_ts: i64, range: Duration) -> Self {
+        let to = DateTime::<Utc>::from_timestamp(end_ts, 0).expect("valid Unix timestamp");
+        let from = to - TimeDelta::from_std(range).expect("supported dashboard range");
+        Self { from, to }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AnnotationProviderError(String);
+
+impl AnnotationProviderError {
+    pub(crate) fn new(message: impl Into<String>) -> Self {
+        Self(message.into())
+    }
+}
+
+impl fmt::Display for AnnotationProviderError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum ProviderPoll {
+    Unchanged,
+    Loaded(AnnotationSnapshot),
+    Failed(AnnotationProviderError),
+}
+
+pub(crate) trait AnnotationProvider: fmt::Debug + Send {
+    fn refresh<'a>(&'a mut self, context: &'a AnnotationRefreshContext) -> ProviderFuture<'a>;
+}
+
 fn default_command_timeout() -> Duration {
     DEFAULT_COMMAND_TIMEOUT
 }
@@ -33,4 +81,31 @@ where
 {
     let value = String::deserialize(deserializer)?;
     humantime::parse_duration(&value).map_err(serde::de::Error::custom)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::{AnnotationProvider, AnnotationRefreshContext, ProviderFuture, ProviderPoll};
+    use crate::annotations::AnnotationSnapshot;
+
+    #[derive(Debug)]
+    struct StaticProvider;
+
+    impl AnnotationProvider for StaticProvider {
+        fn refresh<'a>(&'a mut self, _context: &'a AnnotationRefreshContext) -> ProviderFuture<'a> {
+            Box::pin(async { ProviderPoll::Loaded(AnnotationSnapshot::new(Vec::new())) })
+        }
+    }
+
+    #[tokio::test]
+    async fn provider_contract_is_object_safe() {
+        let mut provider: Box<dyn AnnotationProvider> = Box::new(StaticProvider);
+        let context = AnnotationRefreshContext::from_unix_window(100, Duration::from_secs(10));
+        assert!(matches!(
+            provider.refresh(&context).await,
+            ProviderPoll::Loaded(snapshot) if snapshot.len() == 0
+        ));
+    }
 }

--- a/src/annotations/provider.rs
+++ b/src/annotations/provider.rs
@@ -1,0 +1,36 @@
+use serde::{Deserialize, Deserializer};
+use std::path::PathBuf;
+use std::time::Duration;
+
+pub(crate) const DEFAULT_COMMAND_TIMEOUT: Duration = Duration::from_secs(10);
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub(crate) struct AnnotationCommandConfig {
+    pub(crate) program: String,
+    #[serde(default)]
+    pub(crate) args: Vec<String>,
+    #[serde(
+        default = "default_command_timeout",
+        deserialize_with = "deserialize_duration"
+    )]
+    pub(crate) timeout: Duration,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(dead_code)]
+pub(crate) enum AnnotationSourceConfig {
+    File(PathBuf),
+    Command(AnnotationCommandConfig),
+}
+
+fn default_command_timeout() -> Duration {
+    DEFAULT_COMMAND_TIMEOUT
+}
+
+fn deserialize_duration<'de, D>(deserializer: D) -> Result<Duration, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = String::deserialize(deserializer)?;
+    humantime::parse_duration(&value).map_err(serde::de::Error::custom)
+}

--- a/src/annotations/provider.rs
+++ b/src/annotations/provider.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 use std::pin::Pin;
 use std::time::Duration;
 
-use super::AnnotationSnapshot;
+use super::{AnnotationSnapshot, command::CommandProvider, jsonl::JsonlFileProvider};
 
 pub(crate) const DEFAULT_COMMAND_TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -76,6 +76,13 @@ pub(crate) trait AnnotationProvider: fmt::Debug + Send {
     fn refresh<'a>(&'a mut self, context: &'a AnnotationRefreshContext) -> ProviderFuture<'a>;
 }
 
+pub(crate) fn build_provider(source: AnnotationSourceConfig) -> Box<dyn AnnotationProvider> {
+    match source {
+        AnnotationSourceConfig::File(path) => Box::new(JsonlFileProvider::new(path)),
+        AnnotationSourceConfig::Command(config) => Box::new(CommandProvider::new(config)),
+    }
+}
+
 fn default_command_timeout() -> Duration {
     DEFAULT_COMMAND_TIMEOUT
 }
@@ -90,9 +97,13 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
     use std::time::Duration;
 
-    use super::{AnnotationProvider, AnnotationRefreshContext, ProviderFuture, ProviderPoll};
+    use super::{
+        AnnotationProvider, AnnotationRefreshContext, AnnotationSourceConfig, ProviderFuture,
+        ProviderPoll, build_provider,
+    };
     use crate::annotations::AnnotationSnapshot;
 
     #[derive(Debug)]
@@ -112,5 +123,36 @@ mod tests {
             provider.refresh(&context).await,
             ProviderPoll::Loaded(snapshot) if snapshot.len() == 0
         ));
+    }
+
+    fn temp_path(name: &str) -> PathBuf {
+        let suffix = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "grafatui-provider-{name}-{}-{suffix}.jsonl",
+            std::process::id()
+        ))
+    }
+
+    #[tokio::test]
+    async fn builds_file_provider_that_loads_jsonl() {
+        let path = temp_path("construction");
+        tokio::fs::write(
+            &path,
+            "{\"time\":\"2026-08-12T10:00:00Z\",\"text\":\"deploy\"}\n",
+        )
+        .await
+        .unwrap();
+        let mut provider = build_provider(AnnotationSourceConfig::File(path.clone()));
+        let context = AnnotationRefreshContext::from_unix_window(200, Duration::from_secs(10));
+
+        let ProviderPoll::Loaded(snapshot) = provider.refresh(&context).await else {
+            panic!("expected file provider to load a snapshot");
+        };
+        assert_eq!(snapshot.events()[0].text, "deploy");
+
+        tokio::fs::remove_file(path).await.unwrap();
     }
 }

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -506,7 +506,14 @@ impl AppState {
     }
 
     pub(crate) async fn refresh(&mut self) -> Result<()> {
-        let annotations_changed = self.annotations.refresh_if_changed().await;
+        let range = self.range;
+        let step = self.step;
+
+        // Calculate end timestamp: "now" minus time_offset
+        let end_ts = chrono::Utc::now().timestamp() - self.time_offset.as_secs() as i64;
+        let annotation_context =
+            crate::annotations::AnnotationRefreshContext::from_unix_window(end_ts, range);
+        let annotations_changed = self.annotations.refresh(&annotation_context).await;
         if annotations_changed {
             let eligible_titles = self
                 .panels
@@ -516,12 +523,6 @@ impl AppState {
                 .collect::<Vec<_>>();
             self.annotations.reconcile_targets(&eligible_titles);
         }
-
-        let range = self.range;
-        let step = self.step;
-
-        // Calculate end timestamp: "now" minus time_offset
-        let end_ts = chrono::Utc::now().timestamp() - self.time_offset.as_secs() as i64;
 
         let _ = refresh_query_variables(
             &self.prometheus,

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -513,32 +513,47 @@ impl AppState {
         let end_ts = chrono::Utc::now().timestamp() - self.time_offset.as_secs() as i64;
         let annotation_context =
             crate::annotations::AnnotationRefreshContext::from_unix_window(end_ts, range);
-        let annotations_changed = self.annotations.refresh(&annotation_context).await;
-        if annotations_changed {
-            let eligible_titles = self
-                .panels
-                .iter()
-                .filter(|panel| panel.panel_type == PanelType::Graph)
-                .map(|panel| panel.title.clone())
-                .collect::<Vec<_>>();
-            self.annotations.reconcile_targets(&eligible_titles);
-        }
+        let eligible_titles = self
+            .panels
+            .iter()
+            .filter(|panel| panel.panel_type == PanelType::Graph)
+            .map(|panel| panel.title.clone())
+            .collect::<Vec<_>>();
 
-        let _ = refresh_query_variables(
+        let annotation_refresh = self.annotations.refresh(&annotation_context);
+        let prometheus_refresh = Self::refresh_prometheus_data(
             &self.prometheus,
             &self.query_vars,
             range,
             step,
             end_ts,
             &mut self.vars,
-        )
-        .await;
+            &mut self.panels,
+        );
+        let (annotations_changed, ()) = tokio::join!(annotation_refresh, prometheus_refresh);
 
-        let prometheus = &self.prometheus;
-        let vars = &self.vars;
+        if annotations_changed {
+            self.annotations.reconcile_targets(&eligible_titles);
+        }
+
+        self.view_end_ts = end_ts;
+        self.last_refresh = Instant::now();
+        Ok(())
+    }
+
+    async fn refresh_prometheus_data(
+        prometheus: &prom::PromClient,
+        query_vars: &[TemplateQueryVar],
+        range: Duration,
+        step: Duration,
+        end_ts: i64,
+        vars: &mut HashMap<String, String>,
+        panels: &mut [PanelState],
+    ) {
+        let _ = refresh_query_variables(prometheus, query_vars, range, step, end_ts, vars).await;
 
         // Create a stream of futures for fetching panel data
-        let mut futures = futures::stream::iter(self.panels.iter_mut())
+        let mut futures = futures::stream::iter(panels.iter_mut())
             .map(|p| Self::fetch_single_panel_data(prometheus, p, range, step, vars, end_ts))
             .buffer_unordered(4); // Max 4 concurrent panel refreshes
 
@@ -550,10 +565,6 @@ impl AppState {
             }
             p.last_error = err;
         }
-
-        self.view_end_ts = end_ts;
-        self.last_refresh = Instant::now();
-        Ok(())
     }
 
     async fn fetch_single_panel_data<'a>(
@@ -655,6 +666,14 @@ impl AppState {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::annotations::{
+        AnnotationProvider, AnnotationRefreshContext, AnnotationSnapshot, ProviderFuture,
+        ProviderPoll,
+    };
+    use std::sync::{Arc, Mutex};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+    use tokio::sync::Notify;
 
     fn temp_annotation_path(name: &str) -> std::path::PathBuf {
         let suffix = std::time::SystemTime::now()
@@ -704,6 +723,40 @@ mod tests {
         }
     }
 
+    #[derive(Debug)]
+    struct RecordingProvider {
+        captured: Arc<Mutex<Option<AnnotationRefreshContext>>>,
+    }
+
+    impl AnnotationProvider for RecordingProvider {
+        fn refresh<'a>(&'a mut self, context: &'a AnnotationRefreshContext) -> ProviderFuture<'a> {
+            let captured = Arc::clone(&self.captured);
+            let context = context.clone();
+            Box::pin(async move {
+                *captured.lock().unwrap() = Some(context);
+                ProviderPoll::Loaded(AnnotationSnapshot::new(Vec::new()))
+            })
+        }
+    }
+
+    #[derive(Debug)]
+    struct HandshakeProvider {
+        provider_started: Arc<Notify>,
+        metrics_started: Arc<Notify>,
+    }
+
+    impl AnnotationProvider for HandshakeProvider {
+        fn refresh<'a>(&'a mut self, _context: &'a AnnotationRefreshContext) -> ProviderFuture<'a> {
+            let provider_started = Arc::clone(&self.provider_started);
+            let metrics_started = Arc::clone(&self.metrics_started);
+            Box::pin(async move {
+                provider_started.notify_one();
+                metrics_started.notified().await;
+                ProviderPoll::Loaded(AnnotationSnapshot::new(Vec::new()))
+            })
+        }
+    }
+
     #[tokio::test]
     async fn test_empty_panels() {
         let mut app = create_test_app();
@@ -731,6 +784,72 @@ mod tests {
 
         assert_eq!(app.annotations.snapshot().unwrap().len(), 1);
         std::fs::remove_file(path).unwrap();
+    }
+
+    #[tokio::test]
+    async fn refresh_uses_same_window_for_annotations_and_rendered_data() {
+        let captured = Arc::new(Mutex::new(None));
+        let mut app = create_test_app();
+        app.annotations =
+            crate::annotations::AnnotationState::from_provider(Some(Box::new(RecordingProvider {
+                captured: Arc::clone(&captured),
+            })));
+
+        app.refresh().await.unwrap();
+
+        let captured = captured.lock().unwrap().clone().unwrap();
+        assert_eq!(captured.to.timestamp(), app.view_end_ts);
+        assert_eq!(captured.from, captured.to - chrono::TimeDelta::hours(1));
+    }
+
+    #[tokio::test]
+    async fn refresh_starts_annotation_and_prometheus_work_concurrently() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let provider_started = Arc::new(Notify::new());
+        let metrics_started = Arc::new(Notify::new());
+        let http_provider_started = Arc::clone(&provider_started);
+        let http_metrics_started = Arc::clone(&metrics_started);
+        let http_task = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = Vec::new();
+            let mut chunk = [0_u8; 1024];
+            while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+                let read = socket.read(&mut chunk).await.unwrap();
+                assert!(read > 0, "connection closed before request headers");
+                request.extend_from_slice(&chunk[..read]);
+            }
+            http_metrics_started.notify_one();
+            http_provider_started.notified().await;
+
+            let body = r#"{"status":"success","data":{"resultType":"matrix","result":[]}}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body,
+            );
+            socket.write_all(response.as_bytes()).await.unwrap();
+        });
+
+        let mut app = create_test_app();
+        app.prometheus = prom::PromClient::new(format!("http://{address}"));
+        let mut panel = test_panel("Up", PanelType::Graph);
+        panel.exprs = vec!["up".to_string()];
+        panel.legends = vec![None];
+        panel.query_modes = vec![QueryMode::Range];
+        app.panels = vec![panel];
+        app.annotations =
+            crate::annotations::AnnotationState::from_provider(Some(Box::new(HandshakeProvider {
+                provider_started,
+                metrics_started,
+            })));
+
+        tokio::time::timeout(Duration::from_secs(2), app.refresh())
+            .await
+            .expect("annotation and Prometheus refresh did not start concurrently")
+            .unwrap();
+        http_task.await.unwrap();
+        assert!(app.panels[0].last_error.is_none());
     }
 
     #[tokio::test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -42,8 +42,33 @@ pub(crate) struct Args {
     pub(crate) grafana_json: Option<PathBuf>,
 
     /// Optional JSONL point-event file to overlay on graph panels.
-    #[arg(long, value_name = "FILE")]
+    #[arg(
+        long,
+        value_name = "FILE",
+        conflicts_with_all = [
+            "annotations_command",
+            "annotations_command_arg",
+            "annotations_command_timeout"
+        ]
+    )]
     pub(crate) annotations_file: Option<PathBuf>,
+
+    /// Optional executable annotation provider.
+    #[arg(long, value_name = "PROGRAM", conflicts_with = "annotations_file")]
+    pub(crate) annotations_command: Option<String>,
+
+    /// Argument passed to --annotations-command; repeat to preserve argument order.
+    #[arg(
+        long,
+        value_name = "ARG",
+        requires = "annotations_command",
+        allow_hyphen_values = true
+    )]
+    pub(crate) annotations_command_arg: Vec<String>,
+
+    /// Maximum annotation-command runtime (for example, 500ms or 10s).
+    #[arg(long, value_name = "DURATION", requires = "annotations_command")]
+    pub(crate) annotations_command_timeout: Option<String>,
 
     /// Validate a Grafana dashboard import without starting the TUI
     #[arg(long)]
@@ -173,5 +198,38 @@ mod tests {
     fn test_parse_annotations_file() {
         let args = Args::parse_from(["grafatui", "--annotations-file", "events.jsonl"]);
         assert_eq!(args.annotations_file, Some(PathBuf::from("events.jsonl")));
+    }
+
+    #[test]
+    fn parses_annotation_command_with_ordered_hyphen_arguments() {
+        let args = Args::try_parse_from([
+            "grafatui",
+            "--annotations-command",
+            "./provider",
+            "--annotations-command-arg=--environment",
+            "--annotations-command-arg=prod",
+            "--annotations-command-timeout",
+            "750ms",
+        ])
+        .unwrap();
+
+        assert_eq!(args.annotations_command.as_deref(), Some("./provider"));
+        assert_eq!(args.annotations_command_arg, ["--environment", "prod"]);
+        assert_eq!(args.annotations_command_timeout.as_deref(), Some("750ms"));
+    }
+
+    #[test]
+    fn rejects_partial_or_conflicting_annotation_command_flags() {
+        assert!(Args::try_parse_from(["grafatui", "--annotations-command-arg=x"]).is_err());
+        assert!(
+            Args::try_parse_from([
+                "grafatui",
+                "--annotations-file",
+                "events.jsonl",
+                "--annotations-command",
+                "./provider"
+            ])
+            .is_err()
+        );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,6 +30,8 @@ pub(crate) struct Config {
     pub(crate) theme: Option<String>,
     pub(crate) grafana_json: Option<PathBuf>,
     pub(crate) annotations_file: Option<PathBuf>,
+    #[allow(dead_code)]
+    pub(crate) annotations_command: Option<crate::annotations::AnnotationCommandConfig>,
     pub(crate) threshold_marker: Option<String>,
     pub(crate) export_dir: Option<PathBuf>,
     pub(crate) export_format: Option<crate::export::ExportFormat>,
@@ -95,6 +97,7 @@ pub(crate) fn expand_path(path: &std::path::Path) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::Duration;
 
     #[test]
     fn test_config_deserialization() {
@@ -120,6 +123,40 @@ mod tests {
         assert_eq!(
             config.annotations_file,
             Some(PathBuf::from("~/events.jsonl"))
+        );
+    }
+
+    #[test]
+    fn parses_annotation_command_table_and_defaults() {
+        let config: Config = toml::from_str(
+            r#"
+            [annotations_command]
+            program = "./provider"
+            args = ["--environment", "prod"]
+            "#,
+        )
+        .unwrap();
+
+        let command = config.annotations_command.unwrap();
+        assert_eq!(command.program, "./provider");
+        assert_eq!(command.args, ["--environment", "prod"]);
+        assert_eq!(command.timeout, Duration::from_secs(10));
+    }
+
+    #[test]
+    fn parses_annotation_command_human_timeout() {
+        let config: Config = toml::from_str(
+            r#"
+            [annotations_command]
+            program = "./provider"
+            timeout = "750ms"
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            config.annotations_command.unwrap().timeout,
+            Duration::from_millis(750)
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,10 +69,7 @@ async fn main() -> Result<()> {
     }
 
     // Load config
-    let config = match args.config.clone() {
-        Some(path) => Config::load(Some(path))?,
-        None => Config::load(None).unwrap_or_default(),
-    };
+    let config = load_startup_config(args.config.clone())?;
     let dashboard_path = args
         .grafana_json
         .clone()
@@ -258,6 +255,10 @@ async fn main() -> Result<()> {
     terminal.show_cursor()?;
 
     res
+}
+
+fn load_startup_config(path: Option<std::path::PathBuf>) -> Result<Config> {
+    Config::load(path)
 }
 
 fn resolve_refresh_rate_ms(
@@ -457,6 +458,32 @@ fn print_validation_summary(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn temp_config_path(name: &str) -> std::path::PathBuf {
+        let suffix = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "grafatui-{name}-{}-{suffix}.toml",
+            std::process::id()
+        ))
+    }
+
+    #[test]
+    fn startup_config_loader_propagates_parse_errors() {
+        let path = temp_config_path("malformed-startup-config");
+        std::fs::write(
+            &path,
+            "[annotations_command]\nprogram = \"./provider\"\ntimeout = \"soon\"\n",
+        )
+        .unwrap();
+
+        let result = load_startup_config(Some(path.clone()));
+
+        std::fs::remove_file(path).unwrap();
+        assert!(result.is_err());
+    }
 
     #[test]
     fn test_resolve_refresh_rate_precedence() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,7 +89,16 @@ async fn main() -> Result<()> {
         return Ok(());
     }
 
-    let annotations_path = resolve_annotations_path(args.annotations_file, config.annotations_file);
+    let annotation_source = resolve_annotation_source(
+        AnnotationCliSource {
+            file: args.annotations_file,
+            program: args.annotations_command,
+            args: args.annotations_command_arg,
+            timeout: args.annotations_command_timeout,
+        },
+        config.annotations_file,
+        config.annotations_command,
+    )?;
 
     let prometheus_url = args
         .prometheus_url
@@ -214,7 +223,7 @@ async fn main() -> Result<()> {
         }
         .validate()?,
     );
-    state.annotations = annotations::AnnotationState::from_path(annotations_path);
+    state.annotations = annotations::AnnotationState::from_source(annotation_source);
     state.autogrid_enabled = autogrid_enabled;
     state.autogrid_color = autogrid_color;
     state.vars = vars; // <— pass variables into the app
@@ -262,17 +271,7 @@ fn resolve_refresh_rate_ms(
         .unwrap_or(1000)
 }
 
-fn resolve_annotations_path(
-    cli_path: Option<std::path::PathBuf>,
-    config_path: Option<std::path::PathBuf>,
-) -> Option<std::path::PathBuf> {
-    cli_path
-        .or(config_path)
-        .map(|path| config::expand_path(&path))
-}
-
 #[derive(Debug, Default)]
-#[allow(dead_code)]
 struct AnnotationCliSource {
     file: Option<std::path::PathBuf>,
     program: Option<String>,
@@ -280,7 +279,6 @@ struct AnnotationCliSource {
     timeout: Option<String>,
 }
 
-#[allow(dead_code)]
 fn resolve_annotation_source(
     cli: AnnotationCliSource,
     config_file: Option<std::path::PathBuf>,
@@ -324,7 +322,6 @@ fn resolve_annotation_source(
     Ok(config_file.map(|path| AnnotationSourceConfig::File(config::expand_path(&path))))
 }
 
-#[allow(dead_code)]
 fn validate_annotation_command(program: &str, timeout: Duration) -> Result<()> {
     if program.trim().is_empty() {
         bail!("annotation command program must not be empty");
@@ -470,15 +467,6 @@ mod tests {
         assert_eq!(resolve_refresh_rate_ms(None, Some(3000), Some(4000)), 3000);
         assert_eq!(resolve_refresh_rate_ms(None, None, Some(4000)), 4000);
         assert_eq!(resolve_refresh_rate_ms(None, None, None), 1000);
-    }
-
-    #[test]
-    fn test_resolve_annotations_path_prefers_cli_and_expands_selected_path() {
-        let resolved = resolve_annotations_path(
-            Some(std::path::PathBuf::from("./cli.jsonl")),
-            Some(std::path::PathBuf::from("./config.jsonl")),
-        );
-        assert_eq!(resolved, Some(std::path::PathBuf::from("./cli.jsonl")));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,7 @@ use theme::Theme;
 
 mod cli;
 
+use annotations::{AnnotationCommandConfig, AnnotationSourceConfig};
 use cli::Args;
 
 /// Main entry point for the Grafatui application.
@@ -270,6 +271,70 @@ fn resolve_annotations_path(
         .map(|path| config::expand_path(&path))
 }
 
+#[derive(Debug, Default)]
+#[allow(dead_code)]
+struct AnnotationCliSource {
+    file: Option<std::path::PathBuf>,
+    program: Option<String>,
+    args: Vec<String>,
+    timeout: Option<String>,
+}
+
+#[allow(dead_code)]
+fn resolve_annotation_source(
+    cli: AnnotationCliSource,
+    config_file: Option<std::path::PathBuf>,
+    config_command: Option<AnnotationCommandConfig>,
+) -> Result<Option<AnnotationSourceConfig>> {
+    if config_file.is_some() && config_command.is_some() {
+        bail!("annotations_file and annotations_command cannot both be configured");
+    }
+    if cli.file.is_some() && cli.program.is_some() {
+        bail!("--annotations-file and --annotations-command cannot be combined");
+    }
+    if cli.program.is_none() && (!cli.args.is_empty() || cli.timeout.is_some()) {
+        bail!("annotation command arguments and timeout require --annotations-command");
+    }
+
+    if let Some(path) = cli.file {
+        return Ok(Some(AnnotationSourceConfig::File(config::expand_path(
+            &path,
+        ))));
+    }
+    if let Some(program) = cli.program {
+        let timeout = match cli.timeout {
+            Some(value) => humantime::parse_duration(&value)
+                .with_context(|| "--annotations-command-timeout")?,
+            None => annotations::DEFAULT_COMMAND_TIMEOUT,
+        };
+        validate_annotation_command(&program, timeout)?;
+        return Ok(Some(AnnotationSourceConfig::Command(
+            AnnotationCommandConfig {
+                program,
+                args: cli.args,
+                timeout,
+            },
+        )));
+    }
+
+    if let Some(command) = config_command {
+        validate_annotation_command(&command.program, command.timeout)?;
+        return Ok(Some(AnnotationSourceConfig::Command(command)));
+    }
+    Ok(config_file.map(|path| AnnotationSourceConfig::File(config::expand_path(&path))))
+}
+
+#[allow(dead_code)]
+fn validate_annotation_command(program: &str, timeout: Duration) -> Result<()> {
+    if program.trim().is_empty() {
+        bail!("annotation command program must not be empty");
+    }
+    if timeout.is_zero() {
+        bail!("annotation command timeout must be greater than zero");
+    }
+    Ok(())
+}
+
 #[derive(Debug)]
 struct ImportContext {
     vars: HashMap<String, String>,
@@ -414,6 +479,135 @@ mod tests {
             Some(std::path::PathBuf::from("./config.jsonl")),
         );
         assert_eq!(resolved, Some(std::path::PathBuf::from("./cli.jsonl")));
+    }
+
+    #[test]
+    fn annotation_source_cli_command_replaces_complete_toml_source() {
+        let resolved = resolve_annotation_source(
+            AnnotationCliSource {
+                program: Some("./cli-provider".into()),
+                args: vec!["cli".into()],
+                timeout: Some("2s".into()),
+                ..AnnotationCliSource::default()
+            },
+            Some("config.jsonl".into()),
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(
+            resolved,
+            Some(annotations::AnnotationSourceConfig::Command(
+                annotations::AnnotationCommandConfig {
+                    program: "./cli-provider".into(),
+                    args: vec!["cli".into()],
+                    timeout: Duration::from_secs(2),
+                },
+            ))
+        );
+    }
+
+    #[test]
+    fn annotation_source_rejects_invalid_same_layer_configuration() {
+        let toml_command = annotations::AnnotationCommandConfig {
+            program: "./config-provider".into(),
+            args: vec![],
+            timeout: Duration::from_secs(10),
+        };
+        assert!(
+            resolve_annotation_source(
+                AnnotationCliSource::default(),
+                Some("events.jsonl".into()),
+                Some(toml_command),
+            )
+            .is_err()
+        );
+        assert!(
+            resolve_annotation_source(
+                AnnotationCliSource {
+                    program: Some("   ".into()),
+                    ..AnnotationCliSource::default()
+                },
+                None,
+                None,
+            )
+            .is_err()
+        );
+        assert!(
+            resolve_annotation_source(
+                AnnotationCliSource {
+                    program: Some("./provider".into()),
+                    timeout: Some("0s".into()),
+                    ..AnnotationCliSource::default()
+                },
+                None,
+                None,
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn annotation_source_returns_none_when_unconfigured() {
+        assert_eq!(
+            resolve_annotation_source(AnnotationCliSource::default(), None, None).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn annotation_source_cli_file_replaces_toml_command() {
+        let resolved = resolve_annotation_source(
+            AnnotationCliSource {
+                file: Some("cli.jsonl".into()),
+                ..AnnotationCliSource::default()
+            },
+            None,
+            Some(annotations::AnnotationCommandConfig {
+                program: "./config-provider".into(),
+                args: vec!["config".into()],
+                timeout: Duration::from_secs(10),
+            }),
+        )
+        .unwrap();
+
+        assert_eq!(
+            resolved,
+            Some(annotations::AnnotationSourceConfig::File(
+                "cli.jsonl".into()
+            ))
+        );
+    }
+
+    #[test]
+    fn annotation_source_uses_toml_command_without_cli_source() {
+        let command = annotations::AnnotationCommandConfig {
+            program: "./config-provider".into(),
+            args: vec!["config".into()],
+            timeout: Duration::from_secs(3),
+        };
+
+        assert_eq!(
+            resolve_annotation_source(AnnotationCliSource::default(), None, Some(command.clone()))
+                .unwrap(),
+            Some(annotations::AnnotationSourceConfig::Command(command))
+        );
+    }
+
+    #[test]
+    fn annotation_source_rejects_malformed_cli_timeout() {
+        assert!(
+            resolve_annotation_source(
+                AnnotationCliSource {
+                    program: Some("./provider".into()),
+                    timeout: Some("soon".into()),
+                    ..AnnotationCliSource::default()
+                },
+                None,
+                None,
+            )
+            .is_err()
+        );
     }
 
     #[test]

--- a/tests/fixtures/annotation_provider.rs
+++ b/tests/fixtures/annotation_provider.rs
@@ -1,0 +1,93 @@
+use std::env;
+use std::io::{self, Read, Write};
+use std::thread;
+use std::time::Duration;
+
+fn write_json_string(mut output: impl Write, bytes: &[u8]) -> io::Result<()> {
+    output.write_all(b"\"")?;
+    for &byte in bytes {
+        match byte {
+            b'"' => output.write_all(br#"\""#)?,
+            b'\\' => output.write_all(br#"\\"#)?,
+            b'\n' => output.write_all(br#"\n"#)?,
+            b'\r' => output.write_all(br#"\r"#)?,
+            b'\t' => output.write_all(br#"\t"#)?,
+            0x08 => output.write_all(br#"\b"#)?,
+            0x0c => output.write_all(br#"\f"#)?,
+            0x00..=0x1f => write!(output, "\\u{byte:04x}")?,
+            _ => output.write_all(&[byte])?,
+        }
+    }
+    output.write_all(b"\"")
+}
+
+fn write_event(text: &[u8]) -> io::Result<()> {
+    let mut stdout = io::stdout().lock();
+    stdout.write_all(b"{\"time\":\"2026-08-12T10:02:00Z\",\"text\":")?;
+    write_json_string(&mut stdout, text)?;
+    stdout.write_all(b"}\n")
+}
+
+fn write_repeated(mut output: impl Write, count: usize, byte: u8) -> io::Result<()> {
+    let chunk = [byte; 8192];
+    let mut remaining = count;
+    while remaining > 0 {
+        let amount = remaining.min(chunk.len());
+        output.write_all(&chunk[..amount])?;
+        remaining -= amount;
+    }
+    Ok(())
+}
+
+fn main() -> io::Result<()> {
+    let args = env::args().skip(1).collect::<Vec<_>>();
+    let mut request = Vec::new();
+    io::stdin().read_to_end(&mut request)?;
+
+    match args.first().map(String::as_str) {
+        Some("echo-request") => write_event(&request)?,
+        Some("show-context") => {
+            let inherited_key = args.last().expect("environment key");
+            let text = format!(
+                "args={} cwd={} env={}",
+                args[1..].join("|"),
+                env::current_dir()?.display(),
+                env::var(inherited_key).unwrap_or_default(),
+            );
+            write_event(text.as_bytes())?;
+        }
+        Some("empty") => {}
+        Some("invalid") if args.get(1).map(String::as_str) == Some("utf8") => {
+            io::stdout().write_all(&[0xff])?;
+        }
+        Some("invalid") => io::stdout().write_all(b"{invalid}\n")?,
+        Some("exit") => {
+            io::stdout().write_all(b"{invalid}\n")?;
+            eprintln!("first diagnostic line");
+            eprintln!("second diagnostic line");
+            std::process::exit(args[1].parse().expect("exit code"));
+        }
+        Some("sleep") => {
+            thread::sleep(Duration::from_millis(
+                args[1].parse().expect("sleep milliseconds"),
+            ));
+            write_event(b"awake")?;
+        }
+        Some("stdout-bytes") => write_repeated(
+            io::stdout().lock(),
+            args[1].parse().expect("stdout byte count"),
+            b'x',
+        )?,
+        Some("stderr-bytes") => {
+            write_repeated(
+                io::stderr().lock(),
+                args[1].parse().expect("stderr byte count"),
+                b'e',
+            )?;
+            std::process::exit(args[2].parse().expect("exit code"));
+        }
+        _ => panic!("unknown fixture mode"),
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Description

Adds Iteration 3 of external annotations: a command-backed provider protocol that lets Grafatui fetch or compute point events for the current visible time window without embedding vendor-specific integrations.

The implementation keeps annotations optional and read-only, preserves the existing JSONL file source, and routes command results through the same targeting, filtering, clustering, inspection, export, and recording pipeline.

### What changed

- Added a crate-private provider boundary shared by file and command sources.
- Added a versioned JSON stdin request and existing JSONL event output contract.
- Added direct, shell-free command execution with structured arguments.
- Added a configurable timeout, 10 MiB stdout cap, 64 KiB stderr capture, child cleanup, and last-valid snapshot retention.
- Runs annotation and Prometheus work concurrently within one refresh cycle.
- Added CLI/TOML configuration with deterministic whole-source precedence.
- Added a practical Git provider example and CI/CD integration guidance.
- Updated the provider ecosystem roadmap, including future Rust/Python APIs and community plugins.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have checked whether the user guide needs an update
- [x] My changes generate no new warnings
- [x] I have added tests that prove the feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have used Conventional Commits for my commit messages

## Validation

- `cargo fmt -- --check`
- `cargo check --all-targets`
- `cargo test --all` — 226 tests passed
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check refs/remotes/origin/main..HEAD`
