### PR TITLE
feat: add Ratatui TUI testing skill

### DIFF
--- a/.agents/skills/testing-ratatui-tuis/SKILL.md
+++ b/.agents/skills/testing-ratatui-tuis/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: testing-ratatui-tuis
+description: Use when implementing, reviewing, or debugging Ratatui/Crossterm terminal interfaces where layout, keyboard or mouse interaction, terminal lifecycle, screenshots, or visual regressions must be validated.
+---
+
+# Testing Ratatui TUIs
+
+## Core principle
+
+Build change-specific, deterministic evidence before accepting TUI behavior. Combine state and input assertions, actual Ratatui buffers, semantic image review, and real-terminal checks where the scenario crosses that boundary.
+
+## Workflow
+
+1. Inspect the request, diff, bindings, and existing tests.
+2. Write scenario expectations for each changed behavior: deterministic precondition, fixed viewport, ordered inputs, exact state, expected screen, and required evidence. Use the [visual validation contract](references/visual-validation.md) to select a risk-based scenario matrix.
+3. Establish deterministic fixtures, time, theme, dimensions, and application state; add the smallest test seam needed.
+4. Assert state transitions and input behavior. Render the asserted state with `TestBackend`, serialize the actual buffer, and follow the [Ratatui harness](references/ratatui-harness.md) for capture and normalization.
+5. Run `scripts/render-buffer` on each relevant capture and inspect its resulting image with the available image viewer against the written expectations.
+6. Run `scripts/pty-smoke` for critical lifecycle or interaction flows, with fixed dimensions, scripted input, bounded timeout, and retained diagnostics.
+7. Diagnose every failure, add a failing regression test before the fix, then rerun affected scenarios and proportionate broader checks. Persist only compact tests and approved baselines that add durable value.
+
+## Evidence requirements
+
+Mark a scenario `pass` only with passing state/input assertions, matching deterministic buffers, semantic inspection of new or changed screenshots, no unexplained approved-baseline differences, successful critical PTY flows, clean exit and terminal restoration, and relevant proportionate broader tests. Classify unavailable or unstable required evidence as `inconclusive`, never `pass`.
+
+## Fix loop
+
+Preserve failure artifacts, identify the unmet written expectation, fix the state, layout, style, or input cause, and repeat state assertions, capture, image inspection, and applicable PTY flow. Update a baseline only after the revised scenario expectation and all evidence agree.
+
+## Completion report
+
+| Scenario | Evidence | Result | Persisted coverage |
+| --- | --- | --- | --- |
+| `<name>` | state, buffer, image, PTY, broader checks | pass, fail, or inconclusive | test or approved baseline |
+
+Remaining uncertainty: state unavailable capabilities, unstable evidence, and their retained diagnostics.
+
+## Common mistakes
+
+- Starting validation without written scenario expectations.
+- Stopping at deterministic-state checks, visible-content assertions, or a PTY lifecycle check instead of assembling applicable evidence layers.
+- Omitting a model-inspected buffer-derived screenshot.
+- Leaving uncertainty unstated after reporting a result.

--- a/.agents/skills/testing-ratatui-tuis/SKILL.md
+++ b/.agents/skills/testing-ratatui-tuis/SKILL.md
@@ -38,6 +38,6 @@ Remaining uncertainty: state unavailable capabilities, unstable evidence, and th
 ## Common mistakes
 
 - Starting validation without written scenario expectations.
-- Stopping at deterministic-state checks, visible-content assertions, or a PTY lifecycle check instead of assembling applicable evidence layers.
+- Assemble all applicable evidence layers: deterministic state/input assertions, visible buffer checks, model-inspected screenshots, and critical PTY coverage.
 - Omitting a model-inspected buffer-derived screenshot.
 - Leaving uncertainty unstated after reporting a result.

--- a/.agents/skills/testing-ratatui-tuis/SKILL.md
+++ b/.agents/skills/testing-ratatui-tuis/SKILL.md
@@ -17,11 +17,12 @@ Build change-specific, deterministic evidence before accepting TUI behavior. Com
 4. Assert state transitions and input behavior. Render the asserted state with `TestBackend`, serialize the actual buffer, and follow the [Ratatui harness](references/ratatui-harness.md) for capture and normalization.
 5. For every visual state named in the saved scenario contract, run `scripts/render-buffer` on its capture and inspect the resulting image with the available image viewer against the written expectations.
 6. Run `scripts/pty-smoke` for critical lifecycle or interaction flows, reproducing the contract's ordered inputs with fixed dimensions, bounded timeout, and retained diagnostics.
-7. Diagnose every failure, add a failing regression test before the fix, then rerun affected scenarios and proportionate broader checks. Persist only compact tests and approved baselines that add durable value.
+7. Diagnose every failure, add a failing regression test before the fix, then rerun affected scenarios and proportionate broader checks.
+8. Run the final evidence audit in the [visual validation contract](references/visual-validation.md). Persist only focused tests and approved baselines, not capture helpers.
 
 ## Evidence requirements
 
-Before classification, map every contracted action and visual state to its artifact path; missing or mismatched evidence is `fail` or `inconclusive`. Mark a scenario `pass` only with passing state/input assertions, matching deterministic buffers, semantic inspection of new or changed screenshots, no unexplained approved-baseline differences, successful critical PTY flows, clean exit and terminal restoration, and relevant proportionate broader tests. Classify unavailable or unstable required evidence as `inconclusive`, never `pass`.
+Map every contracted action and visual state to an artifact; mismatches are `fail`, unavailable evidence is `inconclusive`. Mark `pass` only after all required assertions, buffers, images, PTY flows, lifecycle checks, and broader commands exit successfully.
 
 ## Fix loop
 

--- a/.agents/skills/testing-ratatui-tuis/SKILL.md
+++ b/.agents/skills/testing-ratatui-tuis/SKILL.md
@@ -12,22 +12,24 @@ Build change-specific, deterministic evidence before accepting TUI behavior. Com
 ## Workflow
 
 1. Inspect the request, diff, bindings, and existing tests.
-2. Write scenario expectations for each changed behavior: deterministic precondition, fixed viewport, ordered inputs, exact state, expected screen, and required evidence. Use the [visual validation contract](references/visual-validation.md) to select a risk-based scenario matrix.
+2. Before any test, implementation, capture, or PTY command, save each scenario's expectations under its artifact directory using the required record in the [visual validation contract](references/visual-validation.md). Record the path and ordering, then leave this contract unchanged; save outcomes separately.
 3. Establish deterministic fixtures, time, theme, dimensions, and application state; add the smallest test seam needed.
 4. Assert state transitions and input behavior. Render the asserted state with `TestBackend`, serialize the actual buffer, and follow the [Ratatui harness](references/ratatui-harness.md) for capture and normalization.
-5. Run `scripts/render-buffer` on each relevant capture and inspect its resulting image with the available image viewer against the written expectations.
-6. Run `scripts/pty-smoke` for critical lifecycle or interaction flows, with fixed dimensions, scripted input, bounded timeout, and retained diagnostics.
+5. For every visual state named in the saved scenario contract, run `scripts/render-buffer` on its capture and inspect the resulting image with the available image viewer against the written expectations.
+6. Run `scripts/pty-smoke` for critical lifecycle or interaction flows, reproducing the contract's ordered inputs with fixed dimensions, bounded timeout, and retained diagnostics.
 7. Diagnose every failure, add a failing regression test before the fix, then rerun affected scenarios and proportionate broader checks. Persist only compact tests and approved baselines that add durable value.
 
 ## Evidence requirements
 
-Mark a scenario `pass` only with passing state/input assertions, matching deterministic buffers, semantic inspection of new or changed screenshots, no unexplained approved-baseline differences, successful critical PTY flows, clean exit and terminal restoration, and relevant proportionate broader tests. Classify unavailable or unstable required evidence as `inconclusive`, never `pass`.
+Before classification, map every contracted action and visual state to its artifact path; missing or mismatched evidence is `fail` or `inconclusive`. Mark a scenario `pass` only with passing state/input assertions, matching deterministic buffers, semantic inspection of new or changed screenshots, no unexplained approved-baseline differences, successful critical PTY flows, clean exit and terminal restoration, and relevant proportionate broader tests. Classify unavailable or unstable required evidence as `inconclusive`, never `pass`.
 
 ## Fix loop
 
-Preserve failure artifacts, identify the unmet written expectation, fix the state, layout, style, or input cause, and repeat state assertions, capture, image inspection, and applicable PTY flow. Update a baseline only after the revised scenario expectation and all evidence agree.
+Before editing production code, save `<scenario>.red.txt` with `Command: ...`, `Exit: ...`, then raw combined stdout/stderr. If RED is impossible, save the reason to `<scenario>.red-impossible.txt`. Save later results separately. Fix the unmet expectation, then repeat state assertions, capture, image inspection, and applicable PTY flow. Update a baseline only after all evidence agrees.
 
 ## Completion report
+
+Save exactly this table, one row per scenario, followed immediately by `Remaining uncertainty`, to `<artifact-root>/report.md`; end the final response with the same content verbatim:
 
 | Scenario | Evidence | Result | Persisted coverage |
 | --- | --- | --- | --- |

--- a/.agents/skills/testing-ratatui-tuis/agents/openai.yaml
+++ b/.agents/skills/testing-ratatui-tuis/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Testing Ratatui TUIs"
+  short_description: "Test Ratatui TUIs with screenshots and PTYs"
+  default_prompt: "Use $testing-ratatui-tuis to validate this Ratatui TUI change with deterministic screenshots and PTY interactions."

--- a/.agents/skills/testing-ratatui-tuis/references/ratatui-harness.md
+++ b/.agents/skills/testing-ratatui-tuis/references/ratatui-harness.md
@@ -1,0 +1,304 @@
+# Ratatui 0.30 buffer capture harness
+
+Use this harness for deterministic, structural visual evidence. It converts a
+Ratatui `TestBackend` buffer to the version-1 JSON input accepted by
+`scripts/render-buffer`; it is not a replacement for behavioral assertions or
+real-terminal smoke coverage.
+
+## Determinism prerequisites
+
+Before constructing the state, fix every input that can change a frame:
+
+- time and timezone;
+- fixture data, ordering, IDs, and network responses;
+- viewport dimensions;
+- selected, focused, scroll, overlay, and mode state; and
+- the complete theme, including the colors used for `Color::Reset`.
+
+Use named, checked-in fixtures that make the intended condition obvious. Do
+not obtain data from a live service, system clock, random source, locale, or
+terminal during a capture. A capture should be byte-stable when re-run with
+the same fixture.
+
+## Render with TestBackend
+
+Create `Terminal<TestBackend>` at the scenario's fixed dimensions and render
+one fully prepared `AppState`. Capture only after `Terminal::draw` returns:
+that is when Ratatui has applied the frame to the backend. Do not mutate the
+backend directly.
+
+## Assert behavior before appearance
+
+First exercise the app's reducer, command, or event handler and assert the
+expected state transition exactly. Then render that asserted state and compare
+the resulting buffer. A visually plausible frame cannot prove that the right
+selection, query, mode, or data was produced.
+
+For example, a test should establish `selected_row == 3` and
+`overlay == Overlay::Help` before it captures the focused help frame. Keep a
+state assertion and a focused buffer assertion even when a rendered PNG is
+also retained.
+
+## Normalized capture schema
+
+`render-buffer` accepts this JSON object. All colors are lowercase `#rrggbb`.
+Cells are exhaustive and ordered row-major; modifiers appear in this fixed
+order when present: `bold`, `dim`, `italic`, `underlined`, `reversed`,
+`crossed_out`.
+
+```json
+{
+  "version": 1,
+  "width": 80,
+  "height": 24,
+  "cell_width": 8,
+  "cell_height": 16,
+  "default_fg": "#d0d0d0",
+  "default_bg": "#101010",
+  "cells": [
+    {
+      "x": 0,
+      "y": 0,
+      "symbol": "G",
+      "fg": "#d0d0d0",
+      "bg": "#101010",
+      "modifiers": ["bold"]
+    }
+  ],
+  "cursor": { "x": 0, "y": 0 }
+}
+```
+
+`cursor` is `null` when hidden; otherwise it is the visible backend cursor
+position. Choose one fixed cell size, font, and renderer configuration for a
+baseline family. Create an SVG (and, where Chromium is available, PNG) from a
+capture with:
+
+```bash
+.agents/skills/testing-ratatui-tuis/scripts/render-buffer \
+  --input artifacts/capture.json \
+  --svg artifacts/capture.svg \
+  --png artifacts/capture.png
+```
+
+## Complete Rust capture example
+
+This self-contained Ratatui 0.30.1 example has a deliberately small
+`AppState`; replace its `render` implementation with the application render
+entry point while preserving the capture code. It needs `serde` with `derive`
+and `serde_json` in addition to `ratatui`.
+
+```rust
+use std::{error::Error, io::Write};
+
+use ratatui::{
+    backend::TestBackend,
+    style::{Color, Modifier, Style},
+    widgets::Paragraph,
+    Frame, Terminal,
+};
+use serde::Serialize;
+
+const DEFAULT_FG: &str = "#d0d0d0";
+const DEFAULT_BG: &str = "#101010";
+
+struct AppState {
+    title: String,
+    focused: bool,
+}
+
+impl AppState {
+    fn render(&self, frame: &mut Frame) {
+        let style = if self.focused {
+            Style::default().fg(Color::LightCyan).add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(Color::Gray)
+        };
+        frame.render_widget(Paragraph::new(self.title.as_str()).style(style), frame.area());
+        if self.focused {
+            frame.set_cursor_position((0, 0));
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct Capture {
+    version: u8,
+    width: u16,
+    height: u16,
+    cell_width: u16,
+    cell_height: u16,
+    default_fg: &'static str,
+    default_bg: &'static str,
+    cells: Vec<CapturedCell>,
+    cursor: Option<Cursor>,
+}
+
+#[derive(Serialize)]
+struct CapturedCell {
+    x: u16,
+    y: u16,
+    symbol: String,
+    fg: String,
+    bg: String,
+    modifiers: Vec<&'static str>,
+}
+
+#[derive(Serialize)]
+struct Cursor {
+    x: u16,
+    y: u16,
+}
+
+fn color_to_hex(color: Color, reset: &str) -> String {
+    let (red, green, blue) = match color {
+        Color::Reset => return reset.to_owned(),
+        Color::Black => (0, 0, 0),
+        Color::Red => (128, 0, 0),
+        Color::Green => (0, 128, 0),
+        Color::Yellow => (128, 128, 0),
+        Color::Blue => (0, 0, 128),
+        Color::Magenta => (128, 0, 128),
+        Color::Cyan => (0, 128, 128),
+        Color::Gray => (192, 192, 192),
+        Color::DarkGray => (128, 128, 128),
+        Color::LightRed => (255, 0, 0),
+        Color::LightGreen => (0, 255, 0),
+        Color::LightYellow => (255, 255, 0),
+        Color::LightBlue => (0, 0, 255),
+        Color::LightMagenta => (255, 0, 255),
+        Color::LightCyan => (0, 255, 255),
+        Color::White => (255, 255, 255),
+        Color::Rgb(red, green, blue) => (red, green, blue),
+        Color::Indexed(index) => indexed_to_rgb(index),
+    };
+    format!("#{red:02x}{green:02x}{blue:02x}")
+}
+
+fn indexed_to_rgb(index: u8) -> (u8, u8, u8) {
+    const ANSI: [(u8, u8, u8); 16] = [
+        (0, 0, 0), (128, 0, 0), (0, 128, 0), (128, 128, 0),
+        (0, 0, 128), (128, 0, 128), (0, 128, 128), (192, 192, 192),
+        (128, 128, 128), (255, 0, 0), (0, 255, 0), (255, 255, 0),
+        (0, 0, 255), (255, 0, 255), (0, 255, 255), (255, 255, 255),
+    ];
+    match index {
+        0..=15 => ANSI[index as usize],
+        16..=231 => {
+            const LEVELS: [u8; 6] = [0, 95, 135, 175, 215, 255];
+            let cube = index - 16;
+            (
+                LEVELS[(cube / 36) as usize],
+                LEVELS[((cube / 6) % 6) as usize],
+                LEVELS[(cube % 6) as usize],
+            )
+        }
+        232..=255 => {
+            let gray = 8 + (index - 232) * 10;
+            (gray, gray, gray)
+        }
+    }
+}
+
+fn modifiers(modifier: Modifier) -> Vec<&'static str> {
+    [
+        (Modifier::BOLD, "bold"),
+        (Modifier::DIM, "dim"),
+        (Modifier::ITALIC, "italic"),
+        (Modifier::UNDERLINED, "underlined"),
+        (Modifier::REVERSED, "reversed"),
+        (Modifier::CROSSED_OUT, "crossed_out"),
+    ]
+    .into_iter()
+    .filter_map(|(flag, name)| modifier.contains(flag).then_some(name))
+    .collect()
+}
+
+fn capture(app: &AppState, width: u16, height: u16) -> Result<Capture, Box<dyn Error>> {
+    let backend = TestBackend::new(width, height);
+    let mut terminal: Terminal<TestBackend> = Terminal::new(backend)?;
+    terminal.draw(|frame| app.render(frame))?;
+
+    let buffer = terminal.backend().buffer();
+    let mut cells = Vec::with_capacity(width as usize * height as usize);
+    for y in 0..height {
+        for x in 0..width {
+            let cell = buffer.cell((x, y)).expect("TestBackend cell is in bounds");
+            cells.push(CapturedCell {
+                x,
+                y,
+                symbol: cell.symbol().to_owned(),
+                fg: color_to_hex(cell.fg, DEFAULT_FG),
+                bg: color_to_hex(cell.bg, DEFAULT_BG),
+                modifiers: modifiers(cell.modifier),
+            });
+        }
+    }
+
+    let backend = terminal.backend();
+    let position = backend.cursor_position();
+    let cursor = backend.cursor_visible()
+        && position.x < width
+        && position.y < height;
+    Ok(Capture {
+        version: 1,
+        width,
+        height,
+        cell_width: 8,
+        cell_height: 16,
+        default_fg: DEFAULT_FG,
+        default_bg: DEFAULT_BG,
+        cells,
+        cursor: cursor.then_some(Cursor { x: position.x, y: position.y }),
+    })
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let app = AppState { title: "Grafatui".to_owned(), focused: true };
+    let capture = capture(&app, 80, 24)?;
+    let stdout = std::io::stdout();
+    let mut output = stdout.lock();
+    serde_json::to_writer_pretty(&mut output, &capture)?;
+    writeln!(output)?;
+    Ok(())
+}
+```
+
+The conversion deliberately maps every Ratatui `Color` variant. `Reset` is
+converted to the fixed foreground or background default passed by the caller;
+`Rgb` is emitted directly; indexed `16..=231` uses the xterm 6x6x6 color cube,
+and `232..=255` uses its grayscale ramp. Indexed `0..=15` uses the same ANSI
+palette as the named variants. Unsupported display modifiers are intentionally
+not serialized because the shared renderer schema accepts only the six listed
+above; assert them separately if they matter to behavior.
+
+### API verification
+
+Grafatui's `ratatui = 0.30.1` resolves to `ratatui-core 0.1.1`. The capture
+pattern was checked against the installed source with:
+
+```bash
+rg -n 'pub const fn buffer|pub fn symbol|pub fg:|pub bg:|pub modifier:' \
+  "$HOME/.cargo/registry/src"/index.crates.io-*/ratatui-core-0.1.1/src
+```
+
+It uses the verified `TestBackend::buffer()`, `Buffer::cell((x, y))`,
+`Cell::symbol()`, and public `Cell::fg`, `Cell::bg`, and `Cell::modifier`
+fields.
+
+## Viewport selection
+
+Use the generated scenario matrix to select viewports. The default is the
+representative normal viewport. Add a narrow or short viewport only when the
+scenario says it exercises a relevant threshold, clipping risk, layout branch,
+or interaction path. Record the exact columns x rows with every artifact;
+never let the host terminal choose it.
+
+## Live-service boundary
+
+The TestBackend capture is a unit/integration harness, not evidence that the
+interactive binary is terminal-safe. Keep services behind deterministic
+fixtures here. Validate terminal initialization, alternate-screen behavior,
+keypress wiring, resize handling, and shutdown separately through
+`scripts/pty-smoke` and an explicitly bounded PTY scenario. Mark unavailable
+external capabilities as inconclusive rather than fabricating visual evidence.

--- a/.agents/skills/testing-ratatui-tuis/references/ratatui-harness.md
+++ b/.agents/skills/testing-ratatui-tuis/references/ratatui-harness.md
@@ -41,10 +41,18 @@ also retained.
 
 ## Normalized capture schema
 
-`render-buffer` accepts this JSON object. All colors are lowercase `#rrggbb`.
-Cells are exhaustive and ordered row-major; modifiers appear in this fixed
-order when present: `bold`, `dim`, `italic`, `underlined`, `reversed`,
-`crossed_out`.
+This full `TestBackend` harness/snapshot format is a producer-side
+canonicalization of the JSON accepted by `render-buffer`. All colors are
+lowercase `#rrggbb`. Its producer must emit exhaustive cells in row-major
+order, and each cell's supported modifiers in this fixed, unique order when
+present: `bold`, `dim`, `italic`, `underlined`, `reversed`, `crossed_out`.
+
+These stricter requirements make full-terminal snapshots byte-stable and
+comparable. They are not renderer restrictions: `render-buffer` accepts any
+unique, in-bounds cells, validates that modifiers are supported, and sorts
+cells before rendering. A sparse capture can therefore be rendered, but it is
+not valid evidence of a complete terminal state and must not be used as this
+harness's full-screen snapshot.
 
 ```json
 {

--- a/.agents/skills/testing-ratatui-tuis/references/visual-validation.md
+++ b/.agents/skills/testing-ratatui-tuis/references/visual-validation.md
@@ -96,6 +96,7 @@ deterministic buffer assertion.
 
 The PTY steps must reproduce the scenario contract's exact ordered inputs. A
 quit-only run proves lifecycle only; it cannot support a keyboard-flow claim.
+List cleanup inputs such as the final `q` in the contract's Actions field.
 If the required live state cannot be seeded deterministically, mark that PTY
 interaction evidence inapplicable or inconclusive and explain the boundary.
 For terminal-restoration claims, compare the relevant terminal attributes
@@ -118,6 +119,28 @@ the scenario and dimensions.
 Before responding, write the required completion table and `Remaining
 uncertainty` line once to `report.md`, then paste that file verbatim into the
 final response instead of reconstructing the table.
+
+## Final evidence audit
+
+Run this gate after producing every artifact and before writing `report.md`:
+
+- Re-read the immutable contract. Check that each expected visual state is
+  present in its buffer/image and that wording matches the actual screen.
+- Capture every material intermediate state after an input, including search
+  popups before acceptance; a final-state image cannot stand in for it.
+- Compare the contract's precondition and ordered actions with the state test
+  and PTY scenario. Extra setup belongs in the precondition; omitted,
+  substituted, or extra interaction makes that evidence fail.
+- Read every command's exit status and output. A formatting, test, renderer,
+  or PTY failure prevents `pass`, even when another layer succeeds.
+- After the final production or test edit, regenerate every GREEN buffer,
+  image, PTY result, and broader-check log. Preserve command, exit status, and
+  output; then write `report.md` last.
+- Persist focused behavioral tests. Keep capture generators and exploratory
+  artifacts temporary unless the repository explicitly benefits from them.
+  Serialize actual Ratatui cell colors/modifiers; never fabricate style fields.
+- Use `fail` when evidence contradicts an expectation; reserve
+  `inconclusive` for required evidence that cannot be obtained reliably.
 
 Avoid artifact bloat: do not commit duplicate visual states, full recordings,
 or transient files that add no diagnostic value. Retain failed or inconclusive

--- a/.agents/skills/testing-ratatui-tuis/references/visual-validation.md
+++ b/.agents/skills/testing-ratatui-tuis/references/visual-validation.md
@@ -1,0 +1,120 @@
+# Visual validation contract
+
+Visual validation supplies positive, reviewable evidence for a known behavior.
+It joins state assertions, normalized Ratatui buffers, rendered screenshots,
+and—only at the interactive boundary—PTY evidence. Do not begin by taking a
+screenshot and inventing a reason it looks acceptable.
+
+## Scenario contract
+
+Write each scenario before driving the app, using this required record:
+
+```text
+Scenario: concise behavior name
+Precondition: deterministic app state and fixture
+Viewport: columns × rows
+Actions: ordered inputs
+Expected state: exact state assertions
+Expected screen: text, focus, layout, and style expectations
+Evidence: state test, buffer assertion, screenshot, PTY as applicable
+Result: pass, fail, or inconclusive with artifact paths
+```
+
+The expected screen must be concrete enough to review: identify required and
+forbidden text, focus or selection owner, geometry or clipping boundaries,
+hierarchy, and meaningful style/contrast. A new screenshot is judged against
+these prewritten expectations, not against an improvised visual impression.
+
+## Generate a risk-based scenario matrix
+
+For each change, consider:
+
+- initial state and every material post-input state;
+- reversible actions and repeated inputs;
+- boundaries, including first/last selection and empty limits;
+- populated, empty, loading, and error states when applicable;
+- representative normal, narrow, and short viewports;
+- affected focus, selection, scrolling, overlays, and mode transitions; and
+- nearby code that shares the changed layout or input path.
+
+Choose representative pairs based on risk instead of producing a full
+state × input × viewport cross-product. For example, test a narrow viewport
+with an open overlay when that combination shares the changed split layout;
+do not test every state at every size without a stated risk.
+
+## Evidence and semantic screenshot inspection
+
+Always assert the exact state transition before rendering. Then use a
+normalized buffer assertion for stable text, cells, focus styling, cursor, and
+layout evidence. Render the same capture with `scripts/render-buffer` when a
+human-readable image clarifies the result.
+
+Inspect every required screenshot semantically for:
+
+- clipping, overlap, alignment, and missing content;
+- incorrect focus, selection, cursor, or interaction affordance;
+- hierarchy and grouping failures;
+- contrast or other style mistakes; and
+- unexpected artifacts, stale content, or renderer noise.
+
+Screenshots show evidence; they are not an oracle by themselves. Pair them
+with state and cell-level checks wherever possible.
+
+## Golden policy
+
+Use a hybrid policy:
+
+- Prefer normalized JSON/cell snapshots for the stable golden because they
+  expose semantic diffs and do not depend on font rasterization.
+- A screenshot golden may be approved only after it passes the semantic review
+  described in the prewritten scenario contract.
+- Standardize font, renderer, viewport, theme, timezone/time, and fixture
+  data before accepting any image baseline.
+- Keep a single golden for each distinct visual state. Do not retain duplicate
+  screenshots that represent the same state at the same viewport.
+- Update a golden only with an intentional behavior or visual change, an
+  updated scenario expectation, a review of the diff, and fresh passing state
+  and buffer evidence. Never update merely to hide a failure.
+
+## Viewport matrix
+
+Define explicit dimensions rather than relying on the operator's terminal.
+Start with the product's representative normal viewport. Add one narrow case
+for width-sensitive layout and one short case for height-sensitive scrolling,
+footer, overlay, or clipping risks. Record each chosen `columns × rows` in the
+scenario contract and the capture filename. The risk-based matrix determines
+whether normal, narrow, or short is relevant.
+
+## PTY boundary
+
+TestBackend proves an in-memory rendered buffer, not a live terminal session.
+Use `scripts/pty-smoke` only for an integration claim such as startup,
+alternate-screen entry/exit, input encoding, resize, or clean shutdown. Give
+the PTY scenario a fixed size, ordered inputs, positive bounded timeout, and
+raw ANSI/result artifact paths. Do not make a PTY transcript substitute for a
+deterministic buffer assertion.
+
+If Chromium is missing for PNG rendering, PTY support is unavailable, a
+bounded action times out, or input remains nondeterministic, record the result
+as `inconclusive`, retain its diagnostics, and do not approve or update a
+golden from it.
+
+## Artifacts, retention, and iteration
+
+Keep artifacts under a scenario-specific, reviewable location (for example,
+`artifacts/<scenario>/<viewport>/`): the normalized JSON capture, compact
+state/buffer assertion output, and only the rendered SVG/PNG or PTY ANSI and
+result files needed to explain the outcome. Name files deterministically from
+the scenario and dimensions.
+
+Avoid artifact bloat: do not commit duplicate visual states, full recordings,
+or transient files that add no diagnostic value. Retain failed or inconclusive
+artifacts long enough to diagnose and review the outcome; remove superseded
+temporary runs once the replacement evidence is accepted according to project
+retention practice.
+
+On a failure: preserve the artifacts, identify which written expectation
+failed, fix the state/layout/style/input cause, and rerun the same scenario.
+Reassert state, recapture the buffer, inspect the fresh screenshot, and repeat
+until the scenario passes or is honestly recorded as inconclusive. Do not
+replace the baseline before this fix-and-retest loop succeeds.

--- a/.agents/skills/testing-ratatui-tuis/references/visual-validation.md
+++ b/.agents/skills/testing-ratatui-tuis/references/visual-validation.md
@@ -94,6 +94,14 @@ the PTY scenario a fixed size, ordered inputs, positive bounded timeout, and
 raw ANSI/result artifact paths. Do not make a PTY transcript substitute for a
 deterministic buffer assertion.
 
+The PTY steps must reproduce the scenario contract's exact ordered inputs. A
+quit-only run proves lifecycle only; it cannot support a keyboard-flow claim.
+If the required live state cannot be seeded deterministically, mark that PTY
+interaction evidence inapplicable or inconclusive and explain the boundary.
+For terminal-restoration claims, compare the relevant terminal attributes
+before startup and after exit; cleanup escape sequences or a successful
+`disable_raw_mode` call alone do not prove restoration.
+
 If Chromium is missing for PNG rendering, PTY support is unavailable, a
 bounded action times out, or input remains nondeterministic, record the result
 as `inconclusive`, retain its diagnostics, and do not approve or update a
@@ -106,6 +114,10 @@ Keep artifacts under a scenario-specific, reviewable location (for example,
 state/buffer assertion output, and only the rendered SVG/PNG or PTY ANSI and
 result files needed to explain the outcome. Name files deterministically from
 the scenario and dimensions.
+
+Before responding, write the required completion table and `Remaining
+uncertainty` line once to `report.md`, then paste that file verbatim into the
+final response instead of reconstructing the table.
 
 Avoid artifact bloat: do not commit duplicate visual states, full recordings,
 or transient files that add no diagnostic value. Retain failed or inconclusive

--- a/.agents/skills/testing-ratatui-tuis/scripts/pty-smoke
+++ b/.agents/skills/testing-ratatui-tuis/scripts/pty-smoke
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""Run a command in a fixed-size PTY and capture its ANSI lifecycle."""
+
+import argparse
+import errno
+import fcntl
+import json
+import os
+import pathlib
+import pty
+import select
+import signal
+import struct
+import sys
+import termios
+import time
+
+
+KEYS = {
+    "enter": b"\r",
+    "esc": b"\x1b",
+    "up": b"\x1b[A",
+    "down": b"\x1b[B",
+    "right": b"\x1b[C",
+    "left": b"\x1b[D",
+    "ctrl-e": b"\x05",
+}
+
+
+class ScenarioError(ValueError):
+    """Raised when a PTY smoke scenario is not valid."""
+
+
+def positive_integer(value, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ScenarioError(f"{name} must be a positive integer")
+    return value
+
+
+def encode_step(step: dict) -> bytes:
+    if not isinstance(step, dict):
+        raise ScenarioError("step must be an object")
+    has_send = "send" in step
+    has_key = "key" in step
+    if has_send == has_key:
+        raise ScenarioError("step must contain exactly one of send or key")
+    if has_send:
+        send = step["send"]
+        if not isinstance(send, str):
+            raise ScenarioError("step send must be a string")
+        return send.encode("utf-8")
+    key = step["key"]
+    if not isinstance(key, str) or key not in KEYS:
+        raise ScenarioError(f"unknown key: {key!r}")
+    return KEYS[key]
+
+
+def validate_scenario(scenario: dict) -> None:
+    if not isinstance(scenario, dict):
+        raise ScenarioError("scenario must be a JSON object")
+    positive_integer(scenario.get("cols"), "cols")
+    positive_integer(scenario.get("rows"), "rows")
+    positive_integer(scenario.get("timeout_ms"), "timeout_ms")
+    steps = scenario.get("steps")
+    if not isinstance(steps, list):
+        raise ScenarioError("steps must be a list")
+    previous_after_ms = 0
+    for step in steps:
+        if not isinstance(step, dict):
+            raise ScenarioError("step must be an object")
+        after_ms = step.get("after_ms")
+        if isinstance(after_ms, bool) or not isinstance(after_ms, int) or after_ms < 0:
+            raise ScenarioError("step after_ms must be a nonnegative integer")
+        if after_ms < previous_after_ms:
+            raise ScenarioError("step after_ms values must be nondecreasing")
+        previous_after_ms = after_ms
+        encode_step(step)
+    if "expect_exit" in scenario and (
+        isinstance(scenario["expect_exit"], bool)
+        or not isinstance(scenario["expect_exit"], int)
+    ):
+        raise ScenarioError("expect_exit must be an integer")
+    if "require_alternate_screen" in scenario and not isinstance(
+        scenario["require_alternate_screen"], bool
+    ):
+        raise ScenarioError("require_alternate_screen must be a boolean")
+
+
+def load_scenario(path: pathlib.Path) -> dict:
+    with path.open(encoding="utf-8") as source:
+        scenario = json.load(source)
+    validate_scenario(scenario)
+    return scenario
+
+
+def set_window_size(fd: int, rows: int, cols: int) -> None:
+    fcntl.ioctl(
+        fd,
+        termios.TIOCSWINSZ,
+        struct.pack("HHHH", rows, cols, 0, 0),
+    )
+
+
+def set_single_key_input(fd: int) -> None:
+    attributes = termios.tcgetattr(fd)
+    attributes[3] &= ~(termios.ICANON | termios.ECHO)
+    attributes[6][termios.VMIN] = 1
+    attributes[6][termios.VTIME] = 0
+    termios.tcsetattr(fd, termios.TCSANOW, attributes)
+
+
+def read_available(fd: int, output: bytearray) -> bool:
+    """Drain nonblocking PTY data; return False when the PTY is closed."""
+    while True:
+        try:
+            chunk = os.read(fd, 65536)
+        except BlockingIOError:
+            return True
+        except OSError as error:
+            if error.errno == errno.EIO:
+                return False
+            raise
+        if not chunk:
+            return False
+        output.extend(chunk)
+
+
+def status_exit_code(status: int) -> int:
+    if os.WIFEXITED(status):
+        return os.WEXITSTATUS(status)
+    if os.WIFSIGNALED(status):
+        return 128 + os.WTERMSIG(status)
+    return 1
+
+
+def run_scenario(scenario: dict, command: list[str]) -> tuple[bytes, dict]:
+    validate_scenario(scenario)
+    if not command or not all(isinstance(argument, str) and argument for argument in command):
+        raise ScenarioError("command must be nonempty")
+
+    rows = scenario["rows"]
+    cols = scenario["cols"]
+    timeout_seconds = scenario["timeout_ms"] / 1000
+    steps = scenario["steps"]
+    pid, master_fd = pty.fork()
+    if pid == 0:
+        try:
+            set_window_size(sys.stdin.fileno(), rows, cols)
+            os.execvp(command[0], command)
+        except BaseException:
+            os._exit(127)
+
+    if pid <= 0:
+        raise RuntimeError("pty.fork returned an invalid child PID")
+
+    output = bytearray()
+    start = time.monotonic()
+    deadline = start + timeout_seconds
+    step_index = 0
+    pending = bytearray()
+    child_status = None
+    timed_out = False
+    terminate_deadline = None
+    master_open = True
+
+    try:
+        set_window_size(master_fd, rows, cols)
+        set_single_key_input(master_fd)
+        flags = fcntl.fcntl(master_fd, fcntl.F_GETFL)
+        fcntl.fcntl(master_fd, fcntl.F_SETFL, flags | os.O_NONBLOCK)
+
+        while child_status is None or master_open:
+            now = time.monotonic()
+            while step_index < len(steps) and now >= start + steps[step_index]["after_ms"] / 1000:
+                pending.extend(encode_step(steps[step_index]))
+                step_index += 1
+
+            if child_status is None and not timed_out and now >= deadline:
+                timed_out = True
+                os.kill(pid, signal.SIGTERM)
+                terminate_deadline = now + 1
+            elif (
+                child_status is None
+                and timed_out
+                and terminate_deadline is not None
+                and now >= terminate_deadline
+            ):
+                os.kill(pid, signal.SIGKILL)
+                terminate_deadline = None
+
+            waited_pid, status = os.waitpid(pid, os.WNOHANG)
+            if waited_pid == pid:
+                child_status = status
+
+            if child_status is not None:
+                if master_open:
+                    master_open = read_available(master_fd, output)
+                if not master_open:
+                    break
+
+            next_times = [deadline]
+            if step_index < len(steps):
+                next_times.append(start + steps[step_index]["after_ms"] / 1000)
+            if terminate_deadline is not None:
+                next_times.append(terminate_deadline)
+            wait_seconds = max(0.0, min(0.05, min(next_times) - time.monotonic()))
+            readable, writable, _ = select.select(
+                [master_fd] if master_open else [],
+                [master_fd] if pending and master_open else [],
+                [],
+                wait_seconds,
+            )
+            if master_fd in readable:
+                master_open = read_available(master_fd, output)
+            if master_fd in writable and pending:
+                written = os.write(master_fd, pending)
+                del pending[:written]
+    finally:
+        if child_status is None:
+            waited_pid, status = os.waitpid(pid, os.WNOHANG)
+            if waited_pid == 0:
+                os.kill(pid, signal.SIGKILL)
+                _, status = os.waitpid(pid, 0)
+            child_status = status
+        os.close(master_fd)
+
+    duration_ms = int((time.monotonic() - start) * 1000)
+    raw = bytes(output)
+    result = {
+        "exit_code": status_exit_code(child_status),
+        "timed_out": timed_out,
+        "saw_enter_alternate_screen": b"\x1b[?1049h" in raw,
+        "saw_leave_alternate_screen": b"\x1b[?1049l" in raw,
+        "cols": cols,
+        "rows": rows,
+        "duration_ms": duration_ms,
+    }
+    return raw, result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--scenario", type=pathlib.Path, required=True)
+    parser.add_argument("--output-ansi", type=pathlib.Path, required=True)
+    parser.add_argument("--output-result", type=pathlib.Path, required=True)
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    arguments = parser.parse_args()
+
+    try:
+        scenario = load_scenario(arguments.scenario)
+        command = arguments.command[1:] if arguments.command[:1] == ["--"] else arguments.command
+        raw, result = run_scenario(scenario, command)
+        arguments.output_ansi.write_bytes(raw)
+        arguments.output_result.write_text(
+            json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+    except (OSError, ScenarioError, ValueError, json.JSONDecodeError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+
+    if result["timed_out"]:
+        return 124
+    if result["exit_code"] != scenario.get("expect_exit", result["exit_code"]):
+        print(
+            f"error: expected exit {scenario['expect_exit']}, got {result['exit_code']}",
+            file=sys.stderr,
+        )
+        return 1
+    if scenario.get("require_alternate_screen", False) and not (
+        result["saw_enter_alternate_screen"] and result["saw_leave_alternate_screen"]
+    ):
+        print("error: alternate-screen lifecycle was incomplete", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/testing-ratatui-tuis/scripts/pty-smoke
+++ b/.agents/skills/testing-ratatui-tuis/scripts/pty-smoke
@@ -11,7 +11,6 @@ import pty
 import select
 import signal
 import struct
-import subprocess
 import sys
 import termios
 import time
@@ -28,6 +27,9 @@ KEYS = {
 }
 # Keep ANSI transcripts deterministic and bounded even when a child writes forever.
 MAX_TRANSCRIPT_BYTES = 1_048_576
+# Yield to deadline and child-status handling after a deterministic read slice.
+MAX_READS_PER_ITERATION = 4
+MAX_READ_BYTES_PER_ITERATION = 65_536
 
 
 class ScenarioError(ValueError):
@@ -126,11 +128,13 @@ def append_transcript(output: bytearray, chunk: bytes) -> bool:
 
 
 def read_available(fd: int, output: bytearray) -> tuple[bool, bool]:
-    """Drain nonblocking PTY data; return (is_open, transcript_truncated)."""
+    """Read one bounded nonblocking PTY slice and report its state."""
     truncated = False
-    while True:
+    reads = 0
+    remaining_bytes = MAX_READ_BYTES_PER_ITERATION
+    while reads < MAX_READS_PER_ITERATION and remaining_bytes > 0:
         try:
-            chunk = os.read(fd, 65536)
+            chunk = os.read(fd, min(65536, remaining_bytes))
         except BlockingIOError:
             return True, truncated
         except OSError as error:
@@ -139,67 +143,23 @@ def read_available(fd: int, output: bytearray) -> tuple[bool, bool]:
             raise
         if not chunk:
             return False, truncated
+        reads += 1
+        remaining_bytes -= len(chunk)
         truncated = append_transcript(output, chunk) or truncated
 
-
-def descendant_pids(root_pid: int) -> list[int]:
-    """Return only processes whose current parent chain leads to root_pid."""
-    if root_pid <= 0:
-        return []
-    process_table = subprocess.run(
-        ["ps", "-axo", "pid=,ppid="],
-        check=False,
-        capture_output=True,
-        text=True,
-    )
-    if process_table.returncode != 0:
-        return []
-    children = {}
-    for line in process_table.stdout.splitlines():
-        fields = line.split()
-        if len(fields) != 2:
-            continue
-        try:
-            pid, parent_pid = (int(field) for field in fields)
-        except ValueError:
-            continue
-        if pid > 0 and parent_pid > 0:
-            children.setdefault(parent_pid, []).append(pid)
-
-    descendants = []
-    pending = [root_pid]
-    seen = {root_pid}
-    while pending:
-        parent_pid = pending.pop()
-        for child_pid in children.get(parent_pid, []):
-            if child_pid in seen:
-                continue
-            seen.add(child_pid)
-            descendants.append(child_pid)
-            pending.append(child_pid)
-    return descendants
+    return True, truncated
 
 
-def signal_timeout_targets(root_pid: int, signal_number: int) -> None:
-    """Signal the live child group and its currently verified descendant tree."""
+def signal_child_process_group(root_pid: int, signal_number: int) -> None:
+    """Signal only the live PTY child session; detached daemons are excluded."""
     if root_pid <= 0:
         raise RuntimeError("invalid child PID")
-    # Snapshot immediately before signalling: every individual target has a
-    # current parent chain to root_pid, while killpg is safe because root_pid
-    # is still the live PTY child's process-group leader.
-    descendants = descendant_pids(root_pid)
-    for descendant_pid in reversed(descendants):
-        try:
-            os.kill(descendant_pid, signal_number)
-        except ProcessLookupError:
-            pass
     try:
+        if os.getsid(root_pid) != root_pid or os.getpgid(root_pid) != root_pid:
+            raise RuntimeError("PTY child is not its session and process-group leader")
         os.killpg(root_pid, signal_number)
     except ProcessLookupError:
-        try:
-            os.kill(root_pid, signal_number)
-        except ProcessLookupError:
-            pass
+        pass
 
 
 def status_exit_code(status: int) -> int:
@@ -255,7 +215,7 @@ def run_scenario(scenario: dict, command: list[str]) -> tuple[bytes, dict]:
 
             if child_status is None and not timed_out and now >= deadline:
                 timed_out = True
-                signal_timeout_targets(pid, signal.SIGTERM)
+                signal_child_process_group(pid, signal.SIGTERM)
                 terminate_deadline = now + 1
             elif (
                 child_status is None
@@ -263,7 +223,7 @@ def run_scenario(scenario: dict, command: list[str]) -> tuple[bytes, dict]:
                 and terminate_deadline is not None
                 and now >= terminate_deadline
             ):
-                signal_timeout_targets(pid, signal.SIGKILL)
+                signal_child_process_group(pid, signal.SIGKILL)
                 terminate_deadline = None
 
             waited_pid, status = os.waitpid(pid, os.WNOHANG)
@@ -299,7 +259,7 @@ def run_scenario(scenario: dict, command: list[str]) -> tuple[bytes, dict]:
         if child_status is None:
             waited_pid, status = os.waitpid(pid, os.WNOHANG)
             if waited_pid == 0:
-                os.kill(pid, signal.SIGKILL)
+                signal_child_process_group(pid, signal.SIGKILL)
                 _, status = os.waitpid(pid, 0)
             child_status = status
         os.close(master_fd)

--- a/.agents/skills/testing-ratatui-tuis/scripts/pty-smoke
+++ b/.agents/skills/testing-ratatui-tuis/scripts/pty-smoke
@@ -11,6 +11,7 @@ import pty
 import select
 import signal
 import struct
+import subprocess
 import sys
 import termios
 import time
@@ -25,6 +26,8 @@ KEYS = {
     "left": b"\x1b[D",
     "ctrl-e": b"\x05",
 }
+# Keep ANSI transcripts deterministic and bounded even when a child writes forever.
+MAX_TRANSCRIPT_BYTES = 1_048_576
 
 
 class ScenarioError(ValueError):
@@ -103,26 +106,100 @@ def set_window_size(fd: int, rows: int, cols: int) -> None:
 
 def set_single_key_input(fd: int) -> None:
     attributes = termios.tcgetattr(fd)
-    attributes[3] &= ~(termios.ICANON | termios.ECHO)
+    attributes[0] = 0
+    attributes[1] = 0
+    attributes[2] &= ~termios.CSIZE
+    attributes[2] |= termios.CS8
+    attributes[3] = 0
     attributes[6][termios.VMIN] = 1
     attributes[6][termios.VTIME] = 0
     termios.tcsetattr(fd, termios.TCSANOW, attributes)
 
 
-def read_available(fd: int, output: bytearray) -> bool:
-    """Drain nonblocking PTY data; return False when the PTY is closed."""
+def append_transcript(output: bytearray, chunk: bytes) -> bool:
+    """Append up to MAX_TRANSCRIPT_BYTES and report dropped transcript bytes."""
+    remaining = MAX_TRANSCRIPT_BYTES - len(output)
+    if remaining <= 0:
+        return bool(chunk)
+    output.extend(chunk[:remaining])
+    return len(chunk) > remaining
+
+
+def read_available(fd: int, output: bytearray) -> tuple[bool, bool]:
+    """Drain nonblocking PTY data; return (is_open, transcript_truncated)."""
+    truncated = False
     while True:
         try:
             chunk = os.read(fd, 65536)
         except BlockingIOError:
-            return True
+            return True, truncated
         except OSError as error:
             if error.errno == errno.EIO:
-                return False
+                return False, truncated
             raise
         if not chunk:
-            return False
-        output.extend(chunk)
+            return False, truncated
+        truncated = append_transcript(output, chunk) or truncated
+
+
+def descendant_pids(root_pid: int) -> list[int]:
+    """Return only processes whose current parent chain leads to root_pid."""
+    if root_pid <= 0:
+        return []
+    process_table = subprocess.run(
+        ["ps", "-axo", "pid=,ppid="],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if process_table.returncode != 0:
+        return []
+    children = {}
+    for line in process_table.stdout.splitlines():
+        fields = line.split()
+        if len(fields) != 2:
+            continue
+        try:
+            pid, parent_pid = (int(field) for field in fields)
+        except ValueError:
+            continue
+        if pid > 0 and parent_pid > 0:
+            children.setdefault(parent_pid, []).append(pid)
+
+    descendants = []
+    pending = [root_pid]
+    seen = {root_pid}
+    while pending:
+        parent_pid = pending.pop()
+        for child_pid in children.get(parent_pid, []):
+            if child_pid in seen:
+                continue
+            seen.add(child_pid)
+            descendants.append(child_pid)
+            pending.append(child_pid)
+    return descendants
+
+
+def signal_timeout_targets(root_pid: int, signal_number: int) -> None:
+    """Signal the live child group and its currently verified descendant tree."""
+    if root_pid <= 0:
+        raise RuntimeError("invalid child PID")
+    # Snapshot immediately before signalling: every individual target has a
+    # current parent chain to root_pid, while killpg is safe because root_pid
+    # is still the live PTY child's process-group leader.
+    descendants = descendant_pids(root_pid)
+    for descendant_pid in reversed(descendants):
+        try:
+            os.kill(descendant_pid, signal_number)
+        except ProcessLookupError:
+            pass
+    try:
+        os.killpg(root_pid, signal_number)
+    except ProcessLookupError:
+        try:
+            os.kill(root_pid, signal_number)
+        except ProcessLookupError:
+            pass
 
 
 def status_exit_code(status: int) -> int:
@@ -162,6 +239,7 @@ def run_scenario(scenario: dict, command: list[str]) -> tuple[bytes, dict]:
     timed_out = False
     terminate_deadline = None
     master_open = True
+    transcript_truncated = False
 
     try:
         set_window_size(master_fd, rows, cols)
@@ -177,7 +255,7 @@ def run_scenario(scenario: dict, command: list[str]) -> tuple[bytes, dict]:
 
             if child_status is None and not timed_out and now >= deadline:
                 timed_out = True
-                os.kill(pid, signal.SIGTERM)
+                signal_timeout_targets(pid, signal.SIGTERM)
                 terminate_deadline = now + 1
             elif (
                 child_status is None
@@ -185,7 +263,7 @@ def run_scenario(scenario: dict, command: list[str]) -> tuple[bytes, dict]:
                 and terminate_deadline is not None
                 and now >= terminate_deadline
             ):
-                os.kill(pid, signal.SIGKILL)
+                signal_timeout_targets(pid, signal.SIGKILL)
                 terminate_deadline = None
 
             waited_pid, status = os.waitpid(pid, os.WNOHANG)
@@ -194,7 +272,8 @@ def run_scenario(scenario: dict, command: list[str]) -> tuple[bytes, dict]:
 
             if child_status is not None:
                 if master_open:
-                    master_open = read_available(master_fd, output)
+                    master_open, truncated = read_available(master_fd, output)
+                    transcript_truncated = transcript_truncated or truncated
                 if not master_open:
                     break
 
@@ -211,7 +290,8 @@ def run_scenario(scenario: dict, command: list[str]) -> tuple[bytes, dict]:
                 wait_seconds,
             )
             if master_fd in readable:
-                master_open = read_available(master_fd, output)
+                master_open, truncated = read_available(master_fd, output)
+                transcript_truncated = transcript_truncated or truncated
             if master_fd in writable and pending:
                 written = os.write(master_fd, pending)
                 del pending[:written]
@@ -226,14 +306,18 @@ def run_scenario(scenario: dict, command: list[str]) -> tuple[bytes, dict]:
 
     duration_ms = int((time.monotonic() - start) * 1000)
     raw = bytes(output)
+    child_exit_code = status_exit_code(child_status)
     result = {
-        "exit_code": status_exit_code(child_status),
+        "exit_code": 124 if timed_out else child_exit_code,
+        "child_exit_code": child_exit_code,
         "timed_out": timed_out,
         "saw_enter_alternate_screen": b"\x1b[?1049h" in raw,
         "saw_leave_alternate_screen": b"\x1b[?1049l" in raw,
         "cols": cols,
         "rows": rows,
         "duration_ms": duration_ms,
+        "transcript_limit_bytes": MAX_TRANSCRIPT_BYTES,
+        "transcript_truncated": transcript_truncated,
     }
     return raw, result
 

--- a/.agents/skills/testing-ratatui-tuis/scripts/render-buffer
+++ b/.agents/skills/testing-ratatui-tuis/scripts/render-buffer
@@ -46,11 +46,27 @@ def require_color(value, name: str) -> str:
     return value
 
 
+def forbidden_xml_character(value: str) -> Optional[int]:
+    for character in value:
+        codepoint = ord(character)
+        if codepoint in (0x09, 0x0A, 0x0D):
+            continue
+        if 0x20 <= codepoint <= 0xD7FF:
+            continue
+        if 0xE000 <= codepoint <= 0xFFFD:
+            continue
+        if 0x10000 <= codepoint <= 0x10FFFF:
+            continue
+        return codepoint
+    return None
+
+
 def validate_capture(capture: dict) -> None:
     if not isinstance(capture, dict):
         raise CaptureError("capture must be an object")
-    if capture.get("version") != 1:
-        raise CaptureError("version must be 1")
+    version = capture.get("version")
+    if isinstance(version, bool) or not isinstance(version, int) or version != 1:
+        raise CaptureError("version must be integer 1")
 
     width = require_positive_integer(capture.get("width"), "width")
     height = require_positive_integer(capture.get("height"), "height")
@@ -75,8 +91,15 @@ def validate_capture(capture: dict) -> None:
         if coordinate in coordinates:
             raise CaptureError(f"duplicate cell coordinate: ({x}, {y})")
         coordinates.add(coordinate)
-        if not isinstance(cell.get("symbol"), str):
+        symbol = cell.get("symbol")
+        if not isinstance(symbol, str):
             raise CaptureError("cell symbol must be a string")
+        codepoint = forbidden_xml_character(symbol)
+        if codepoint is not None:
+            raise CaptureError(
+                "cell symbol contains XML 1.0-forbidden character: "
+                f"U+{codepoint:04X}"
+            )
         require_color(cell.get("fg"), "cell fg")
         require_color(cell.get("bg"), "cell bg")
         modifiers = cell.get("modifiers")

--- a/.agents/skills/testing-ratatui-tuis/scripts/render-buffer
+++ b/.agents/skills/testing-ratatui-tuis/scripts/render-buffer
@@ -4,6 +4,7 @@
 import argparse
 import html
 import json
+import os
 import pathlib
 import re
 import shutil
@@ -14,6 +15,11 @@ from typing import Optional
 
 COLOR = re.compile(r"#[0-9a-fA-F]{6}\Z")
 MODIFIERS = {"bold", "dim", "italic", "underlined", "reversed", "crossed_out"}
+CHROMIUM_PROBE_TIMEOUT_SECONDS = 3
+MACOS_CHROMIUM_PATHS = (
+    pathlib.Path("/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"),
+    pathlib.Path("/Applications/Chromium.app/Contents/MacOS/Chromium"),
+)
 
 
 class CaptureError(ValueError):
@@ -187,13 +193,35 @@ def render_capture(capture: dict, font_family: str) -> str:
     return "\n".join(lines) + "\n"
 
 
+def chromium_is_functional(chromium: str) -> bool:
+    try:
+        result = subprocess.run(
+            [chromium, "--version"],
+            check=False,
+            timeout=CHROMIUM_PROBE_TIMEOUT_SECONDS,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return result.returncode == 0
+
+
 def find_chromium(explicit: Optional[str]) -> Optional[str]:
     if explicit:
         return shutil.which(explicit)
     for name in ("chromium", "chromium-browser", "google-chrome"):
         chromium = shutil.which(name)
-        if chromium:
+        if chromium and chromium_is_functional(chromium):
             return chromium
+    for chromium in MACOS_CHROMIUM_PATHS:
+        executable = str(chromium)
+        if (
+            chromium.is_file()
+            and os.access(chromium, os.X_OK)
+            and chromium_is_functional(executable)
+        ):
+            return executable
     return None
 
 

--- a/.agents/skills/testing-ratatui-tuis/scripts/render-buffer
+++ b/.agents/skills/testing-ratatui-tuis/scripts/render-buffer
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Render a normalized Ratatui buffer capture as deterministic SVG or PNG."""
+
+import argparse
+import html
+import json
+import pathlib
+import re
+import shutil
+import subprocess
+import sys
+from typing import Optional
+
+
+COLOR = re.compile(r"#[0-9a-fA-F]{6}\Z")
+MODIFIERS = {"bold", "dim", "italic", "underlined", "reversed", "crossed_out"}
+
+
+class CaptureError(ValueError):
+    """Raised when a capture does not meet the normalized buffer contract."""
+
+
+def load_capture(path: pathlib.Path) -> dict:
+    with path.open(encoding="utf-8") as source:
+        capture = json.load(source)
+    if not isinstance(capture, dict):
+        raise CaptureError("capture must be a JSON object")
+    return capture
+
+
+def require_positive_integer(value, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise CaptureError(f"{name} must be a positive integer")
+    return value
+
+
+def require_coordinate(value, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise CaptureError(f"{name} must be an integer")
+    return value
+
+
+def require_color(value, name: str) -> str:
+    if not isinstance(value, str) or not COLOR.fullmatch(value):
+        raise CaptureError(f"{name} must be a #rrggbb color")
+    return value
+
+
+def validate_capture(capture: dict) -> None:
+    if not isinstance(capture, dict):
+        raise CaptureError("capture must be an object")
+    if capture.get("version") != 1:
+        raise CaptureError("version must be 1")
+
+    width = require_positive_integer(capture.get("width"), "width")
+    height = require_positive_integer(capture.get("height"), "height")
+    require_positive_integer(capture.get("cell_width"), "cell_width")
+    require_positive_integer(capture.get("cell_height"), "cell_height")
+    require_color(capture.get("default_fg"), "default_fg")
+    require_color(capture.get("default_bg"), "default_bg")
+
+    cells = capture.get("cells")
+    if not isinstance(cells, list):
+        raise CaptureError("cells must be a list")
+
+    coordinates = set()
+    for cell in cells:
+        if not isinstance(cell, dict):
+            raise CaptureError("cell must be an object")
+        x = require_coordinate(cell.get("x"), "cell x")
+        y = require_coordinate(cell.get("y"), "cell y")
+        coordinate = (x, y)
+        if not 0 <= x < width or not 0 <= y < height:
+            raise CaptureError(f"cell coordinate out of bounds: ({x}, {y})")
+        if coordinate in coordinates:
+            raise CaptureError(f"duplicate cell coordinate: ({x}, {y})")
+        coordinates.add(coordinate)
+        if not isinstance(cell.get("symbol"), str):
+            raise CaptureError("cell symbol must be a string")
+        require_color(cell.get("fg"), "cell fg")
+        require_color(cell.get("bg"), "cell bg")
+        modifiers = cell.get("modifiers")
+        if not isinstance(modifiers, list) or any(
+            not isinstance(modifier, str) or modifier not in MODIFIERS
+            for modifier in modifiers
+        ):
+            raise CaptureError("cell modifiers must contain only supported modifiers")
+
+    cursor = capture.get("cursor")
+    if cursor is not None:
+        if not isinstance(cursor, dict):
+            raise CaptureError("cursor must be an object")
+        x = require_coordinate(cursor.get("x"), "cursor x")
+        y = require_coordinate(cursor.get("y"), "cursor y")
+        if not 0 <= x < width or not 0 <= y < height:
+            raise CaptureError(f"cursor coordinate out of bounds: ({x}, {y})")
+
+
+def text_attributes(cell: dict) -> str:
+    modifiers = set(cell["modifiers"])
+    foreground = cell["fg"]
+    background = cell["bg"]
+    if "reversed" in modifiers:
+        foreground, background = background, foreground
+    attributes = [f'fill="{foreground}"']
+    if "bold" in modifiers:
+        attributes.append('font-weight="bold"')
+    if "dim" in modifiers:
+        attributes.append('opacity="0.6"')
+    if "italic" in modifiers:
+        attributes.append('font-style="italic"')
+    decorations = []
+    if "underlined" in modifiers:
+        decorations.append("underline")
+    if "crossed_out" in modifiers:
+        decorations.append("line-through")
+    if decorations:
+        attributes.append(f'text-decoration="{" ".join(decorations)}"')
+    return " ".join(attributes)
+
+
+def render_capture(capture: dict, font_family: str) -> str:
+    validate_capture(capture)
+    width = capture["width"]
+    height = capture["height"]
+    cell_width = capture["cell_width"]
+    cell_height = capture["cell_height"]
+    pixel_width = width * cell_width
+    pixel_height = height * cell_height
+    font = html.escape(font_family, quote=True)
+    lines = [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        (
+            f'<svg xmlns="http://www.w3.org/2000/svg" width="{pixel_width}" '
+            f'height="{pixel_height}" viewBox="0 0 {pixel_width} {pixel_height}">'
+        ),
+        f'<rect x="0" y="0" width="{pixel_width}" height="{pixel_height}" fill="{capture["default_bg"]}"/>',
+        f'<g font-family="{font}" font-size="{cell_height}" xml:space="preserve">',
+    ]
+    for cell in sorted(capture["cells"], key=lambda item: (item["y"], item["x"])):
+        x = cell["x"] * cell_width
+        y = cell["y"] * cell_height
+        foreground = cell["fg"]
+        background = cell["bg"]
+        if "reversed" in cell["modifiers"]:
+            foreground, background = background, foreground
+        lines.append(
+            f'<rect x="{x}" y="{y}" width="{cell_width}" height="{cell_height}" fill="{background}"/>'
+        )
+        lines.append(
+            f'<text x="{x}" y="{(cell["y"] + 1) * cell_height - 4}" '
+            f'{text_attributes(cell)}>{html.escape(cell["symbol"], quote=True)}</text>'
+        )
+    lines.append("</g>")
+    cursor = capture.get("cursor")
+    if cursor is not None:
+        lines.append(
+            f'<rect class="cursor" x="{cursor["x"] * cell_width + 0.5}" '
+            f'y="{cursor["y"] * cell_height + 0.5}" width="{cell_width - 1}" '
+            f'height="{cell_height - 1}" fill="none" stroke="{capture["default_fg"]}" '
+            'stroke-width="1"/>'
+        )
+    lines.append("</svg>")
+    return "\n".join(lines) + "\n"
+
+
+def find_chromium(explicit: Optional[str]) -> Optional[str]:
+    if explicit:
+        return shutil.which(explicit)
+    for name in ("chromium", "chromium-browser", "google-chrome"):
+        chromium = shutil.which(name)
+        if chromium:
+            return chromium
+    return None
+
+
+def rasterize(
+    svg_path: pathlib.Path,
+    png_path: pathlib.Path,
+    chromium: str,
+    width: int,
+    height: int,
+) -> None:
+    subprocess.run(
+        [
+            chromium,
+            "--headless",
+            "--disable-gpu",
+            "--hide-scrollbars",
+            "--force-device-scale-factor=1",
+            f"--window-size={width},{height}",
+            f"--screenshot={png_path.resolve()}",
+            svg_path.resolve().as_uri(),
+        ],
+        check=True,
+        timeout=30,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", type=pathlib.Path, required=True)
+    parser.add_argument("--svg", type=pathlib.Path, required=True)
+    parser.add_argument("--png", type=pathlib.Path)
+    parser.add_argument("--chromium")
+    parser.add_argument("--font-family", default="DejaVu Sans Mono, monospace")
+    arguments = parser.parse_args()
+
+    try:
+        capture = load_capture(arguments.input)
+        validate_capture(capture)
+        arguments.svg.write_text(
+            render_capture(capture, arguments.font_family), encoding="utf-8"
+        )
+        if arguments.png:
+            chromium = find_chromium(arguments.chromium)
+            if chromium is None:
+                raise CaptureError("Chromium executable not found; cannot write PNG")
+            rasterize(
+                arguments.svg,
+                arguments.png,
+                chromium,
+                capture["width"] * capture["cell_width"],
+                capture["height"] * capture["cell_height"],
+            )
+    except (
+        CaptureError,
+        OSError,
+        json.JSONDecodeError,
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+    ) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/testing-ratatui-tuis/scripts/tests/test_pty_smoke.py
+++ b/.agents/skills/testing-ratatui-tuis/scripts/tests/test_pty_smoke.py
@@ -1,0 +1,118 @@
+import importlib.machinery
+import importlib.util
+import json
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+SCRIPT = pathlib.Path(__file__).resolve().parents[1] / "pty-smoke"
+CHILD = r'''
+import fcntl, os, struct, sys, termios
+rows, cols, _, _ = struct.unpack("HHHH", fcntl.ioctl(sys.stdin.fileno(), termios.TIOCGWINSZ, b"\0" * 8))
+sys.stdout.write(f"SIZE={cols}x{rows}\n\x1b[?1049hREADY\n")
+sys.stdout.flush()
+received = os.read(sys.stdin.fileno(), 1)
+sys.stdout.write(f"KEY={received.decode()}\n\x1b[?1049l")
+sys.stdout.flush()
+'''
+
+
+def load_runner_module():
+    loader = importlib.machinery.SourceFileLoader("pty_smoke", str(SCRIPT))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+class PtySmokeTests(unittest.TestCase):
+    def write_scenario(self, directory, scenario):
+        path = pathlib.Path(directory) / "scenario.json"
+        path.write_text(json.dumps(scenario), encoding="utf-8")
+        return path
+
+    def run_runner(self, scenario_path, output_ansi, output_result, command):
+        return subprocess.run(
+            [
+                str(SCRIPT),
+                "--scenario",
+                str(scenario_path),
+                "--output-ansi",
+                str(output_ansi),
+                "--output-result",
+                str(output_result),
+                "--",
+                *command,
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_runs_child_at_requested_size_and_records_ansi_lifecycle(self):
+        scenario = {
+            "cols": 91,
+            "rows": 27,
+            "timeout_ms": 3000,
+            "steps": [{"after_ms": 100, "send": "q"}],
+            "expect_exit": 0,
+            "require_alternate_screen": True,
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            scenario_path = self.write_scenario(directory, scenario)
+            output_ansi = pathlib.Path(directory) / "session.ansi"
+            output_result = pathlib.Path(directory) / "result.json"
+            result = self.run_runner(
+                scenario_path, output_ansi, output_result, [sys.executable, "-c", CHILD]
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            raw = output_ansi.read_bytes()
+            recorded = json.loads(output_result.read_text(encoding="utf-8"))
+
+        self.assertIn(b"SIZE=91x27", raw)
+        self.assertIn(b"READY", raw)
+        self.assertIn(b"KEY=q", raw)
+        self.assertTrue(recorded["saw_enter_alternate_screen"])
+        self.assertTrue(recorded["saw_leave_alternate_screen"])
+        self.assertFalse(recorded["timed_out"])
+
+    def test_times_out_sleeping_child(self):
+        scenario = {"cols": 80, "rows": 24, "timeout_ms": 100, "steps": []}
+        with tempfile.TemporaryDirectory() as directory:
+            scenario_path = self.write_scenario(directory, scenario)
+            output_ansi = pathlib.Path(directory) / "session.ansi"
+            output_result = pathlib.Path(directory) / "result.json"
+            result = self.run_runner(
+                scenario_path,
+                output_ansi,
+                output_result,
+                [sys.executable, "-c", "import time; time.sleep(10)"],
+            )
+            recorded = json.loads(output_result.read_text(encoding="utf-8"))
+
+        self.assertEqual(result.returncode, 124, result.stderr)
+        self.assertTrue(recorded["timed_out"])
+
+    def test_encodes_named_keys(self):
+        runner = load_runner_module()
+        expected = {
+            "enter": b"\r",
+            "esc": b"\x1b",
+            "up": b"\x1b[A",
+            "down": b"\x1b[B",
+            "left": b"\x1b[D",
+            "right": b"\x1b[C",
+            "ctrl-e": b"\x05",
+        }
+
+        for key, encoded in expected.items():
+            with self.subTest(key=key):
+                self.assertEqual(runner.encode_step({"after_ms": 0, "key": key}), encoded)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/skills/testing-ratatui-tuis/scripts/tests/test_pty_smoke.py
+++ b/.agents/skills/testing-ratatui-tuis/scripts/tests/test_pty_smoke.py
@@ -31,7 +31,6 @@ import pathlib, subprocess, sys, time
 pid_path = pathlib.Path(sys.argv[1])
 descendant = subprocess.Popen(
     [sys.executable, "-c", "import time; time.sleep(30)"],
-    start_new_session=True,
 )
 pid_path.write_text(str(descendant.pid), encoding="utf-8")
 time.sleep(30)
@@ -77,7 +76,7 @@ class PtySmokeTests(unittest.TestCase):
         path.write_text(json.dumps(scenario), encoding="utf-8")
         return path
 
-    def run_runner(self, scenario_path, output_ansi, output_result, command):
+    def run_runner(self, scenario_path, output_ansi, output_result, command, timeout=None):
         return subprocess.run(
             [
                 str(SCRIPT),
@@ -93,6 +92,7 @@ class PtySmokeTests(unittest.TestCase):
             check=False,
             capture_output=True,
             text=True,
+            timeout=timeout,
         )
 
     def test_runs_child_at_requested_size_and_records_ansi_lifecycle(self):
@@ -165,7 +165,7 @@ class PtySmokeTests(unittest.TestCase):
 
         self.assertIn(b"BYTE=13", raw)
 
-    def test_timeout_terminates_new_session_descendant(self):
+    def test_timeout_terminates_process_group_descendant(self):
         scenario = {"cols": 80, "rows": 24, "timeout_ms": 300, "steps": []}
         with tempfile.TemporaryDirectory() as directory:
             scenario_path = self.write_scenario(directory, scenario)
@@ -189,6 +189,42 @@ class PtySmokeTests(unittest.TestCase):
             finally:
                 terminate_pid(descendant_pid)
 
+    def test_timeout_is_not_starved_by_continuous_pty_output(self):
+        scenario = {"cols": 80, "rows": 24, "timeout_ms": 250, "steps": []}
+        with tempfile.TemporaryDirectory() as directory:
+            scenario_path = self.write_scenario(directory, scenario)
+            output_ansi = pathlib.Path(directory) / "session.ansi"
+            output_result = pathlib.Path(directory) / "result.json"
+            child_pid_path = pathlib.Path(directory) / "writer.pid"
+            started = time.monotonic()
+            try:
+                result = self.run_runner(
+                    scenario_path,
+                    output_ansi,
+                    output_result,
+                    [
+                        "/bin/sh",
+                        "-c",
+                        'echo "$$" > "$1"; exec yes',
+                        "pty-writer",
+                        str(child_pid_path),
+                    ],
+                    timeout=1.5,
+                )
+            except subprocess.TimeoutExpired:
+                self.fail("runner did not return while the PTY remained readable")
+            finally:
+                if child_pid_path.exists():
+                    terminate_pid(int(child_pid_path.read_text(encoding="utf-8")))
+            duration = time.monotonic() - started
+
+            self.assertEqual(result.returncode, 124, result.stderr)
+            recorded = json.loads(output_result.read_text(encoding="utf-8"))
+
+        self.assertLess(duration, 1.0)
+        self.assertTrue(recorded["timed_out"])
+        self.assertTrue(recorded["transcript_truncated"])
+
     def test_truncates_noisy_transcript_at_documented_limit(self):
         runner = load_runner_module()
         scenario = {"cols": 80, "rows": 24, "timeout_ms": 3000, "steps": []}
@@ -210,6 +246,28 @@ class PtySmokeTests(unittest.TestCase):
         self.assertTrue(recorded["transcript_truncated"])
         self.assertEqual(len(raw), runner.MAX_TRANSCRIPT_BYTES)
 
+    def test_limits_reads_per_iteration_when_pty_stays_readable(self):
+        runner = load_runner_module()
+        reads = 0
+        original_read = runner.os.read
+
+        def readable_until_budget(fd, size):
+            nonlocal reads
+            reads += 1
+            if reads > 10:
+                raise BlockingIOError()
+            return b"x" * min(size, 1024)
+
+        runner.os.read = readable_until_budget
+        try:
+            is_open, truncated = runner.read_available(1, bytearray())
+        finally:
+            runner.os.read = original_read
+
+        self.assertTrue(is_open)
+        self.assertFalse(truncated)
+        self.assertLessEqual(reads, 4)
+
     def test_encodes_named_keys(self):
         runner = load_runner_module()
         expected = {
@@ -225,6 +283,12 @@ class PtySmokeTests(unittest.TestCase):
         for key, encoded in expected.items():
             with self.subTest(key=key):
                 self.assertEqual(runner.encode_step({"after_ms": 0, "key": key}), encoded)
+
+    def test_does_not_import_process_table_for_timeout_cleanup(self):
+        runner = load_runner_module()
+
+        self.assertFalse(hasattr(runner, "descendant_pids"))
+        self.assertFalse(hasattr(runner, "subprocess"))
 
 
 if __name__ == "__main__":

--- a/.agents/skills/testing-ratatui-tuis/scripts/tests/test_pty_smoke.py
+++ b/.agents/skills/testing-ratatui-tuis/scripts/tests/test_pty_smoke.py
@@ -1,10 +1,12 @@
 import importlib.machinery
 import importlib.util
 import json
+import os
 import pathlib
 import subprocess
 import sys
 import tempfile
+import time
 import unittest
 
 
@@ -18,6 +20,27 @@ received = os.read(sys.stdin.fileno(), 1)
 sys.stdout.write(f"KEY={received.decode()}\n\x1b[?1049l")
 sys.stdout.flush()
 '''
+BYTE_CHILD = r'''
+import os, sys
+received = os.read(sys.stdin.fileno(), 1)
+sys.stdout.write(f"BYTE={received[0]}\n")
+sys.stdout.flush()
+'''
+DESCENDANT_CHILD = r'''
+import pathlib, subprocess, sys, time
+pid_path = pathlib.Path(sys.argv[1])
+descendant = subprocess.Popen(
+    [sys.executable, "-c", "import time; time.sleep(30)"],
+    start_new_session=True,
+)
+pid_path.write_text(str(descendant.pid), encoding="utf-8")
+time.sleep(30)
+'''
+NOISY_CHILD = r'''
+import sys
+sys.stdout.buffer.write(b"x" * 1_100_000)
+sys.stdout.flush()
+'''
 
 
 def load_runner_module():
@@ -26,6 +49,26 @@ def load_runner_module():
     module = importlib.util.module_from_spec(spec)
     loader.exec_module(module)
     return module
+
+
+def process_exists(pid):
+    result = subprocess.run(
+        ["ps", "-p", str(pid), "-o", "pid="],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode == 0 and bool(result.stdout.strip())
+
+
+def terminate_pid(pid):
+    try:
+        os.kill(pid, 15)
+    except ProcessLookupError:
+        return
+    deadline = time.monotonic() + 1
+    while process_exists(pid) and time.monotonic() < deadline:
+        time.sleep(0.02)
 
 
 class PtySmokeTests(unittest.TestCase):
@@ -96,6 +139,76 @@ class PtySmokeTests(unittest.TestCase):
 
         self.assertEqual(result.returncode, 124, result.stderr)
         self.assertTrue(recorded["timed_out"])
+        self.assertEqual(recorded["exit_code"], 124)
+
+    def test_delivers_named_enter_without_terminal_translation(self):
+        scenario = {
+            "cols": 80,
+            "rows": 24,
+            "timeout_ms": 3000,
+            "steps": [{"after_ms": 10, "key": "enter"}],
+            "expect_exit": 0,
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            scenario_path = self.write_scenario(directory, scenario)
+            output_ansi = pathlib.Path(directory) / "session.ansi"
+            output_result = pathlib.Path(directory) / "result.json"
+            result = self.run_runner(
+                scenario_path,
+                output_ansi,
+                output_result,
+                [sys.executable, "-c", BYTE_CHILD],
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            raw = output_ansi.read_bytes()
+
+        self.assertIn(b"BYTE=13", raw)
+
+    def test_timeout_terminates_new_session_descendant(self):
+        scenario = {"cols": 80, "rows": 24, "timeout_ms": 300, "steps": []}
+        with tempfile.TemporaryDirectory() as directory:
+            scenario_path = self.write_scenario(directory, scenario)
+            output_ansi = pathlib.Path(directory) / "session.ansi"
+            output_result = pathlib.Path(directory) / "result.json"
+            descendant_path = pathlib.Path(directory) / "descendant.pid"
+            result = self.run_runner(
+                scenario_path,
+                output_ansi,
+                output_result,
+                [sys.executable, "-c", DESCENDANT_CHILD, str(descendant_path)],
+            )
+            self.assertEqual(result.returncode, 124, result.stderr)
+            descendant_pid = int(descendant_path.read_text(encoding="utf-8"))
+
+            deadline = time.monotonic() + 2
+            while process_exists(descendant_pid) and time.monotonic() < deadline:
+                time.sleep(0.02)
+            try:
+                self.assertFalse(process_exists(descendant_pid))
+            finally:
+                terminate_pid(descendant_pid)
+
+    def test_truncates_noisy_transcript_at_documented_limit(self):
+        runner = load_runner_module()
+        scenario = {"cols": 80, "rows": 24, "timeout_ms": 3000, "steps": []}
+        with tempfile.TemporaryDirectory() as directory:
+            scenario_path = self.write_scenario(directory, scenario)
+            output_ansi = pathlib.Path(directory) / "session.ansi"
+            output_result = pathlib.Path(directory) / "result.json"
+            result = self.run_runner(
+                scenario_path,
+                output_ansi,
+                output_result,
+                [sys.executable, "-c", NOISY_CHILD],
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            raw = output_ansi.read_bytes()
+            recorded = json.loads(output_result.read_text(encoding="utf-8"))
+
+        self.assertTrue(recorded["transcript_truncated"])
+        self.assertEqual(len(raw), runner.MAX_TRANSCRIPT_BYTES)
 
     def test_encodes_named_keys(self):
         runner = load_runner_module()

--- a/.agents/skills/testing-ratatui-tuis/scripts/tests/test_render_buffer.py
+++ b/.agents/skills/testing-ratatui-tuis/scripts/tests/test_render_buffer.py
@@ -4,9 +4,12 @@ import shutil
 import subprocess
 import tempfile
 import unittest
+import xml.etree.ElementTree as ElementTree
 
 
 SCRIPT = pathlib.Path(__file__).resolve().parents[1] / "render-buffer"
+
+
 def available_chromium():
     for name in ("chromium", "chromium-browser", "google-chrome"):
         executable = shutil.which(name)
@@ -92,6 +95,61 @@ class RenderBufferTests(unittest.TestCase):
             self.assertIn('font-weight="bold"', svg)
             self.assertIn('fill="#bf616a"', svg)
             self.assertIn('class="cursor"', svg)
+            ElementTree.fromstring(svg)
+
+    def test_renders_reversed_and_remaining_modifiers(self):
+        value = capture()
+        value["cells"][0].update(
+            {
+                "symbol": "R",
+                "fg": "#112233",
+                "bg": "#445566",
+                "modifiers": [
+                    "reversed",
+                    "dim",
+                    "italic",
+                    "underlined",
+                    "crossed_out",
+                ],
+            }
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            svg_path = pathlib.Path(directory) / "capture.svg"
+            result = self.render(self.write_capture(directory, value), svg_path)
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            svg = svg_path.read_text(encoding="utf-8")
+
+        self.assertIn('x="0" y="0" width="10" height="20" fill="#112233"', svg)
+        self.assertIn('fill="#445566" opacity="0.6"', svg)
+        self.assertIn('font-style="italic"', svg)
+        self.assertIn('text-decoration="underline line-through"', svg)
+
+    def test_rejects_boolean_version(self):
+        value = capture()
+        value["version"] = True
+        with tempfile.TemporaryDirectory() as directory:
+            result = self.render(
+                self.write_capture(directory, value), pathlib.Path(directory) / "out.svg"
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(result.stderr, "error: version must be integer 1\n")
+
+    def test_rejects_xml_forbidden_symbol_characters_without_writing_svg(self):
+        for symbol, codepoint in (("\x01", "U+0001"), ("\ud800", "U+D800")):
+            with self.subTest(codepoint=codepoint), tempfile.TemporaryDirectory() as directory:
+                value = capture()
+                value["cells"][0]["symbol"] = symbol
+                svg_path = pathlib.Path(directory) / "out.svg"
+                result = self.render(self.write_capture(directory, value), svg_path)
+
+                self.assertNotEqual(result.returncode, 0)
+                self.assertEqual(
+                    result.stderr,
+                    f"error: cell symbol contains XML 1.0-forbidden character: {codepoint}\n",
+                )
+                self.assertFalse(svg_path.exists())
 
     def test_rejects_out_of_range_cell_coordinate(self):
         value = capture()

--- a/.agents/skills/testing-ratatui-tuis/scripts/tests/test_render_buffer.py
+++ b/.agents/skills/testing-ratatui-tuis/scripts/tests/test_render_buffer.py
@@ -1,0 +1,138 @@
+import json
+import pathlib
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+SCRIPT = pathlib.Path(__file__).resolve().parents[1] / "render-buffer"
+def available_chromium():
+    for name in ("chromium", "chromium-browser", "google-chrome"):
+        executable = shutil.which(name)
+        if executable is None:
+            continue
+        version = subprocess.run(
+            [executable, "--version"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if version.returncode == 0:
+            return executable
+    return None
+
+
+CHROMIUM = available_chromium()
+
+
+def capture():
+    return {
+        "version": 1,
+        "width": 2,
+        "height": 1,
+        "cell_width": 10,
+        "cell_height": 20,
+        "default_fg": "#d8dee9",
+        "default_bg": "#2e3440",
+        "cells": [
+            {
+                "x": 0,
+                "y": 0,
+                "symbol": "A<&",
+                "fg": "#ffffff",
+                "bg": "#2e3440",
+                "modifiers": ["bold"],
+            },
+            {
+                "x": 1,
+                "y": 0,
+                "symbol": " ",
+                "fg": "#d8dee9",
+                "bg": "#bf616a",
+                "modifiers": [],
+            },
+        ],
+        "cursor": {"x": 0, "y": 0},
+    }
+
+
+class RenderBufferTests(unittest.TestCase):
+    def write_capture(self, directory, value):
+        path = pathlib.Path(directory) / "capture.json"
+        path.write_text(json.dumps(value), encoding="utf-8")
+        return path
+
+    def render(self, input_path, svg_path, *extra):
+        return subprocess.run(
+            [str(SCRIPT), "--input", str(input_path), "--svg", str(svg_path), *extra],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_renders_deterministic_escaped_svg(self):
+        value = capture()
+        value["cells"][0]["symbol"] = "Ω<&"
+        with tempfile.TemporaryDirectory() as directory:
+            input_path = self.write_capture(directory, value)
+            first_svg = pathlib.Path(directory) / "first.svg"
+            second_svg = pathlib.Path(directory) / "second.svg"
+
+            first = self.render(input_path, first_svg)
+            second = self.render(input_path, second_svg)
+
+            self.assertEqual(first.returncode, 0, first.stderr)
+            self.assertEqual(second.returncode, 0, second.stderr)
+            self.assertEqual(first_svg.read_bytes(), second_svg.read_bytes())
+            svg = first_svg.read_text(encoding="utf-8")
+            self.assertIn('width="20" height="20"', svg)
+            self.assertIn('viewBox="0 0 20 20"', svg)
+            self.assertIn("Ω&lt;&amp;", svg)
+            self.assertIn('font-weight="bold"', svg)
+            self.assertIn('fill="#bf616a"', svg)
+            self.assertIn('class="cursor"', svg)
+
+    def test_rejects_out_of_range_cell_coordinate(self):
+        value = capture()
+        value["cells"][0]["x"] = 2
+        with tempfile.TemporaryDirectory() as directory:
+            result = self.render(
+                self.write_capture(directory, value), pathlib.Path(directory) / "out.svg"
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(result.stderr, "error: cell coordinate out of bounds: (2, 0)\n")
+
+    def test_rejects_duplicate_cell_coordinate(self):
+        value = capture()
+        value["cells"][1]["x"] = 0
+        with tempfile.TemporaryDirectory() as directory:
+            result = self.render(
+                self.write_capture(directory, value), pathlib.Path(directory) / "out.svg"
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(result.stderr, "error: duplicate cell coordinate: (0, 0)\n")
+
+    @unittest.skipUnless(CHROMIUM, "Chromium is not installed")
+    def test_rasterizes_svg_to_png_when_chromium_is_available(self):
+        with tempfile.TemporaryDirectory() as directory:
+            input_path = self.write_capture(directory, capture())
+            svg_path = pathlib.Path(directory) / "capture.svg"
+            png_path = pathlib.Path(directory) / "capture.png"
+            result = self.render(
+                input_path,
+                svg_path,
+                "--png",
+                str(png_path),
+                "--chromium",
+                CHROMIUM,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(png_path.read_bytes()[:8], b"\x89PNG\r\n\x1a\n")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/skills/testing-ratatui-tuis/scripts/tests/test_render_buffer.py
+++ b/.agents/skills/testing-ratatui-tuis/scripts/tests/test_render_buffer.py
@@ -1,32 +1,21 @@
+import importlib.machinery
+import importlib.util
 import json
+import os
 import pathlib
-import shutil
 import subprocess
 import tempfile
 import unittest
 import xml.etree.ElementTree as ElementTree
+from unittest import mock
 
 
 SCRIPT = pathlib.Path(__file__).resolve().parents[1] / "render-buffer"
-
-
-def available_chromium():
-    for name in ("chromium", "chromium-browser", "google-chrome"):
-        executable = shutil.which(name)
-        if executable is None:
-            continue
-        version = subprocess.run(
-            [executable, "--version"],
-            check=False,
-            capture_output=True,
-            text=True,
-        )
-        if version.returncode == 0:
-            return executable
-    return None
-
-
-CHROMIUM = available_chromium()
+LOADER = importlib.machinery.SourceFileLoader("render_buffer", str(SCRIPT))
+SPEC = importlib.util.spec_from_loader(LOADER.name, LOADER)
+RENDER_BUFFER = importlib.util.module_from_spec(SPEC)
+LOADER.exec_module(RENDER_BUFFER)
+CHROMIUM = RENDER_BUFFER.find_chromium(None)
 
 
 def capture():
@@ -173,6 +162,57 @@ class RenderBufferTests(unittest.TestCase):
         self.assertNotEqual(result.returncode, 0)
         self.assertEqual(result.stderr, "error: duplicate cell coordinate: (0, 0)\n")
 
+    def test_finds_executable_standard_macos_browser_when_path_candidates_are_absent(self):
+        browsers = (
+            "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+            "/Applications/Chromium.app/Contents/MacOS/Chromium",
+        )
+        for browser in browsers:
+            with (
+                self.subTest(browser=browser),
+                mock.patch.object(RENDER_BUFFER.shutil, "which", return_value=None),
+                mock.patch.object(
+                    pathlib.Path, "is_file", lambda path: str(path) == browser
+                ),
+                mock.patch(
+                    "os.access",
+                    lambda path, mode: str(path) == browser and mode == os.X_OK,
+                ),
+                mock.patch.object(
+                    RENDER_BUFFER.subprocess,
+                    "run",
+                    return_value=subprocess.CompletedProcess([browser, "--version"], 0),
+                ),
+            ):
+                self.assertEqual(RENDER_BUFFER.find_chromium(None), browser)
+
+    def test_skips_broken_path_candidate_for_working_standard_macos_chrome(self):
+        broken = "/opt/homebrew/bin/chromium"
+        chrome = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+
+        def which(name):
+            return broken if name == "chromium" else None
+
+        def probe(command, **options):
+            self.assertLessEqual(options["timeout"], 5)
+            return subprocess.CompletedProcess(
+                command,
+                126 if command[0] == broken else 0,
+            )
+
+        with (
+            mock.patch.object(RENDER_BUFFER.shutil, "which", side_effect=which),
+            mock.patch.object(
+                pathlib.Path, "is_file", lambda path: str(path) == chrome
+            ),
+            mock.patch(
+                "os.access",
+                lambda path, mode: str(path) == chrome and mode == os.X_OK,
+            ),
+            mock.patch.object(RENDER_BUFFER.subprocess, "run", side_effect=probe),
+        ):
+            self.assertEqual(RENDER_BUFFER.find_chromium(None), chrome)
+
     @unittest.skipUnless(CHROMIUM, "Chromium is not installed")
     def test_rasterizes_svg_to_png_when_chromium_is_available(self):
         with tempfile.TemporaryDirectory() as directory:
@@ -184,8 +224,6 @@ class RenderBufferTests(unittest.TestCase):
                 svg_path,
                 "--png",
                 str(png_path),
-                "--chromium",
-                CHROMIUM,
             )
 
             self.assertEqual(result.returncode, 0, result.stderr)


### PR DESCRIPTION
## Description

Add a repository-local Codex skill for implementing, reviewing, and debugging Ratatui/Crossterm TUIs with deterministic, reviewable evidence.

The skill combines:

- change-specific scenario contracts and state/input assertions;
- exhaustive Ratatui `TestBackend` buffer captures and semantic screenshot review;
- a deterministic SVG/PNG buffer renderer;
- a bounded macOS/Linux PTY smoke runner for interaction and terminal lifecycle checks; and
- an iterative RED/GREEN workflow with compact persisted coverage and explicit uncertainty reporting.

The bundled scripts are application-independent, while the reference harness is aligned with Grafatui's current Ratatui version. Evaluation covered clean terminal restoration, panel search/fullscreen behavior, annotation interaction at short viewports, an empty-dashboard forward feature, and a seeded input/layout regression.

No linked issue.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Testing

- `cargo test --all-targets --quiet` — 222 unit tests and 4 integration tests passed after merging `main`
- `python3 -m unittest discover -s .agents/skills/testing-ratatui-tuis/scripts/tests -p 'test_*.py' -v` — 18 tests passed
- `quick_validate.py .agents/skills/testing-ratatui-tuis` — skill valid
- `git diff --check` — clean
- Generated and visually inspected a deterministic 2×1 renderer artifact
- Ran an explicit PTY lifecycle smoke with alternate-screen entry/exit

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have checked whether the [user guide](https://fedexist.github.io/grafatui/) needs an update
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have used Conventional Commits for my commit messages
