### PR TITLE
feat: add Grafana v2 RowsLayout support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ cargo run -- --grafana-json examples/dashboards/prometheus_demo.json --prometheu
 ## Features
 
 - Prometheus range and instant queries with async fetching.
-- Grafana Classic and fixed-grid V2 Resource JSON import for graph, timeseries, stat, gauge, bar gauge, table, and heatmap panels.
+- Grafana Classic and V2 Resource JSON import for graph, timeseries, stat, gauge, bar gauge, table, and heatmap panels, including interactive nested rows.
 - Template variables, Grafana built-in PromQL variables, legend formatting, thresholds, and grid layout support.
 - Grafana timeseries draw styles for lines, points, bars, area fill, hidden axes, and per-panel grid visibility.
-- Keyboard-first navigation, panel search, fullscreen mode, mouse selection, and value inspection.
+- Keyboard-first navigation, row/panel search, interactive row collapse, fullscreen mode, mouse selection, and value inspection.
 - SVG/PNG export and changed-frame recording bundles.
 - TOML configuration and built-in themes.
 - Read-only external file or command-backed JSONL point annotations with panel targeting, tag filtering, and navigable cluster details.
@@ -93,8 +93,10 @@ grafatui man
 ```
 
 Grafana 13 users can import an exact `dashboard.grafana.app/v2` JSON resource
-with a `GridLayout`. For advanced V2 dashboards, export **Model: Classic**
-under **Export as code → Advanced options** instead. See the
+with a `GridLayout` or nested `RowsLayout`. Tabs, auto-grid, repeat,
+conditional rendering, nested non-empty row variables, library panels, and
+Resource YAML remain unsupported; export **Model: Classic** under **Export as
+code → Advanced options** for those dashboards. See the
 [dashboard import guide](https://fedexist.github.io/grafatui/grafana-dashboard-import.html)
 for the current format requirements.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,7 +8,7 @@ oriented around two priorities:
 2. **User-visible product value** - parity work should make real dashboards
    easier to read, debug, and share.
 
-> **Current version**: 0.1.11 · **Status**: Active development, pre-1.0
+> **Current version**: 0.1.12 · **Status**: Active development, pre-1.0
 
 **Legend**:
 - 🟢 Low complexity · 🟡 Medium complexity · 🔴 High complexity
@@ -35,6 +35,7 @@ These features are shipped and available today:
 | UI | **Time controls** | Zoom in/out, pan left/right, live mode toggle |
 | UI | **Panel navigation** | Arrow keys, vim-style `j`/`k`, PgUp/PgDn, fullscreen, inspect mode |
 | UI | **Panel search** | `/` to fuzzy-search panels by name |
+| UI | **Interactive dashboard rows** | Classic row headers and collapsed state plus nested V2 `RowsLayout`; Enter/Space toggles, Left collapses, and Right expands selected rows |
 | UI | **Mouse support** | Click to select, scroll, drag cursor in fullscreen inspect mode |
 | UI | **Value inspection** | Cursor-based point-in-time data exploration |
 | UI | **Series toggling** | Show/hide individual series with `1`-`9` |
@@ -177,8 +178,8 @@ This is the main backlog, ordered by Grafana parity domain.
 
 | Feature | Grafana panel type | User value | Complexity | Status |
 |---|---|---|---|---|
-| **Row headers** | `row` | Dashboard sections stay recognizable | 🟢 | 📋 |
-| **Collapsed rows** | `row.collapsed` | Large dashboards can start folded | 🟡 | 📋 |
+| **Row headers** | `row` | Dashboard sections stay recognizable | 🟢 | ✅ |
+| **Collapsed rows** | `row.collapsed` | Large dashboards can start folded | 🟡 | ✅ |
 | **Text panel** | `text` | Notes/runbook snippets survive import | 🟢 | 📋 |
 | **Histogram panel** | `histogram` | Histogram dashboards import with fewer skips | 🟡 | 💡 |
 | **Pie chart fallback** | `piechart` | Small category summaries can render as bars/table | 🟡 | 💡 |
@@ -205,7 +206,7 @@ with a clear import error rather than silently changing the dashboard.
 | Feature | Grafana field / behavior | User value | Complexity | Status |
 |---|---|---|---|---|
 | **V2 Resource JSON compatibility** | `apiVersion: dashboard.grafana.app/v2` with a `GridLayout` | Imports Grafana 13's default JSON format without requiring a Classic export | 🔴 | ✅ |
-| **Rows layout** | `RowsLayout` and nested row layouts | Preserves dashboard grouping and collapsed sections | 🔴 | 📋 |
+| **Rows layout** | `RowsLayout` and nested row layouts | Preserves dashboard grouping and collapsed sections | 🔴 | ✅ |
 | **Tabs layout** | `TabsLayout` and nested tabs | Preserves tabbed dashboard organization | 🔴 | 📋 |
 | **Auto-grid layout** | `AutoGridLayout` | Preserves automatic panel placement and sizing | 🔴 | 📋 |
 | **Repeat and dynamic layouts** | Layout and element `repeat` settings | Expands panels or groups from variable values | 🔴 | 📋 |
@@ -258,7 +259,7 @@ constraints.
 | Stacking | Common Grafana area/bar semantics | 🟡 | 📋 |
 | Axis labels and placement | Preserves context for imported charts | 🟡 | 📋 |
 | Scale distribution handling | Honor or warn on log/non-linear scales | 🟡 | 💡 |
-| Row headers and collapsed rows | Keeps large dashboard structure intact | 🟡 | 📋 |
+| Row headers and collapsed rows | Keeps large dashboard structure intact | 🟡 | ✅ |
 
 ### v0.5 - Exploration Workflow
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -36,6 +36,12 @@ docker-compose down -v
   cargo run -- --grafana-json examples/dashboards/grafana_v2_compatibility.json --prometheus-url http://localhost:19090
   ```
 
+- `examples/dashboards/grafana_v2_rows.json`: exact Grafana V2 resource showing expanded, nested, and initially collapsed `RowsLayout` rows with three Prometheus panels. Run it with:
+
+  ```bash
+  cargo run -- --grafana-json examples/dashboards/grafana_v2_rows.json --prometheus-url http://localhost:19090
+  ```
+
 - `examples/demo/vllm/grafana.json`: vLLM-oriented dashboard for the mock demo services.
 
 ## More Detail

--- a/docs/grafana-compatibility.md
+++ b/docs/grafana-compatibility.md
@@ -4,7 +4,7 @@ This document provides a comprehensive feature-parity table between the
 [Grafana dashboard JSON models](https://grafana.com/docs/grafana/latest/visualizations/dashboards/build-dashboards/view-dashboard-json-model/)
 and what Grafatui currently supports.
 
-> **Snapshot**: Grafatui v0.1.11. The roadmap prioritizes Grafana parity first,
+> **Snapshot**: Grafatui v0.1.12. The roadmap prioritizes Grafana parity first,
 > then user-visible product value. See the [roadmap](https://github.com/fedexist/grafatui/blob/main/ROADMAP.md) for milestone
 > slices built from this compatibility ladder.
 
@@ -18,16 +18,17 @@ and what Grafatui currently supports.
 
 ## Dashboard Schema Models
 
-Grafatui imports the non-resource Classic JSON model and a fixed-grid subset of
-the V2 Resource JSON model. In Grafana 13, use **Export as code → Advanced
-options → Model: Classic** as the fallback for advanced V2 dashboards. See the
+Grafatui imports the non-resource Classic JSON model and a `GridLayout` plus
+recursive `RowsLayout` subset of the V2 Resource JSON model. In Grafana 13, use
+**Export as code → Advanced options → Model: Classic** as the fallback for
+unsupported advanced V2 dashboards. See the
 [dashboard import guide](grafana-dashboard-import.md) for detailed steps.
 
 | Model | Status | Notes |
 |---|---|---|
 | Classic JSON | ✅ Supported | Accepted by `--grafana-json`; the remaining tables describe support for its fields |
 | V1 Resource JSON | ❌ Not Implemented | The Kubernetes-style `dashboard.grafana.app/v1` resource envelope is not accepted |
-| V2 Resource JSON | 🔶 Partial | JSON-only exact `dashboard.grafana.app/v2` resources with `GridLayout` are supported |
+| V2 Resource JSON | 🔶 Partial | JSON-only exact `dashboard.grafana.app/v2` resources with `GridLayout` and nested `RowsLayout` are supported |
 | Resource YAML | ❌ Not Implemented | `--grafana-json` accepts JSON only |
 
 ### V2 Resource JSON Subset
@@ -36,17 +37,18 @@ options → Model: Classic** as the fallback for advanced V2 dashboards. See the
 |---|---|---|
 | Exact `apiVersion: dashboard.grafana.app/v2` | ✅ Supported | Other resource versions are rejected |
 | `spec.layout.kind: GridLayout` | ✅ Supported | `GridLayoutItem` coordinates map to Grafatui's fixed 24-column grid |
+| `spec.layout.kind: RowsLayout` | ✅ Supported | Nested `GridLayout` and `RowsLayout` children preserve row titles, nesting, collapsed state, and hidden-header transparency |
 | Inline `Panel` elements | ✅ Supported | Supported panel visualization groups map through the Classic-equivalent importer |
 | Prometheus `PanelQuery` queries | ✅ Supported | Non-Prometheus datasources emit import diagnostics and are skipped |
 | Top-level `spec.variables` | 🔶 Partial | Supported variable kinds map to Grafatui variables; unsupported kinds emit diagnostics |
 | `spec.timeSettings.autoRefresh` | ✅ Supported | Used as the dashboard refresh interval |
 | `vizConfig.spec.fieldConfig` | 🔶 Partial | The supported Classic-equivalent field configuration subset applies |
-| Rows, Tabs, and Auto-grid layouts | ❌ Not Implemented | Rejected as fatal import errors |
-| Repeated grid items | ❌ Not Implemented | Rejected as fatal import errors |
-| Conditional rendering, nested variables, and library panels | ❌ Not Implemented | Deferred V2 features |
+| Tabs and Auto-grid layouts | ❌ Not Implemented | Rejected as fatal import errors |
+| Repeated grid items and row repeat | ❌ Not Implemented | Rejected as fatal import errors |
+| Conditional rendering, non-empty nested variables, and library panels | ❌ Not Implemented | Deferred V2 features |
 
 Grafana V2 Resource YAML remains unsupported. Use a Classic export for any
-advanced V2 dashboard outside this fixed-grid subset.
+advanced V2 dashboard outside this fixed-grid-and-rows subset.
 
 ---
 
@@ -85,7 +87,7 @@ advanced V2 dashboard outside this fixed-grid subset.
 | `bargauge` | ✅ Supported | Vertical bar chart |
 | `table` | ✅ Supported | Two-column table (Series, Value) |
 | `heatmap` | ✅ Supported | Character-based block heatmap |
-| `row` | 🔶 Partial | Row panels are traversed for nested panels, but row headers/collapse are not rendered |
+| `row` | ✅ Supported | Headers, nested rows, and collapsed state are rendered and interactive |
 | `text` | ❌ Not Implemented | Skipped during import |
 | `dashlist` | ❌ Not Implemented | Skipped during import |
 | `alertlist` | ❌ Not Implemented | Skipped during import |
@@ -136,8 +138,8 @@ advanced V2 dashboard outside this fixed-grid subset.
 | `repeat` | ❌ Not Implemented | Template repeat not supported |
 | `repeatDirection` | ❌ Not Implemented | |
 | `maxPerRow` | ❌ Not Implemented | |
-| `collapsed` (row) | ❌ Not Implemented | Rows are always expanded |
-| `panels` (nested in row) | ✅ Supported | Nested panels are extracted recursively |
+| `collapsed` (row) | ✅ Supported | Initial collapsed state is preserved and interactive |
+| `panels` (nested in row) | ✅ Supported | Nested panels and rows retain their hierarchy |
 
 ---
 
@@ -331,8 +333,8 @@ compatibility with Grafana annotation queries, APIs, `annotations`, or
 | Category | Supported | Partial | Not Implemented | Not Applicable |
 |---|---|---|---|---|
 | Dashboard Properties | 1 | 0 | 10 | 4 |
-| Panel Types | 7 | 1 | 14 | 5 |
-| Panel Common Fields | 8 | 0 | 6 | 2 |
+| Panel Types | 8 | 0 | 14 | 5 |
+| Panel Common Fields | 9 | 0 | 5 | 2 |
 | Targets / Queries | 3 | 0 | 8 | 1 |
 | PromQL Variables | 7 | 0 | 0 | 0 |
 | Templating | 6 | 6 | 6 | 0 |
@@ -344,7 +346,7 @@ compatibility with Grafana annotation queries, APIs, `annotations`, or
 | Data Links / Transforms | 0 | 0 | 2 | 1 |
 | Alert Rules | 0 | 0 | 3 | 0 |
 | Datasources | 3 | 0 | 5 | 0 |
-| **Total** | **47** | **13** | **85** | **15** |
+| **Total** | **49** | **12** | **84** | **15** |
 
 ---
 
@@ -382,4 +384,4 @@ Grafatui provides several TUI-native capabilities that don't map directly to Gra
 
 ---
 
-*This document was reviewed against the Grafatui source code at v0.1.11. If you notice any inaccuracies, please open an issue or PR.*
+*This document was reviewed against the Grafatui source code at v0.1.12. If you notice any inaccuracies, please open an issue or PR.*

--- a/docs/grafana-dashboard-import.md
+++ b/docs/grafana-dashboard-import.md
@@ -6,18 +6,20 @@ panels in the terminal.
 | Format | Status | Requirements |
 |---|---|---|
 | Classic JSON | ✅ Supported | Non-resource object with fields such as `title`, `panels`, and `templating` |
-| V2 Resource JSON | 🔶 Partial | JSON only, exact `apiVersion: dashboard.grafana.app/v2`, and `spec.layout.kind: GridLayout` |
+| V2 Resource JSON | 🔶 Partial | JSON only, exact `apiVersion: dashboard.grafana.app/v2`, and `GridLayout` or nested `RowsLayout` containers |
 | V1 Resource JSON | ❌ Unsupported | The `dashboard.grafana.app/v1` resource envelope is not accepted |
 | Resource YAML | ❌ Unsupported | `--grafana-json` accepts JSON only |
 
 The supported V2 subset maps inline `Panel` elements, Prometheus `PanelQuery`
 queries, top-level variables, `timeSettings.autoRefresh`, supported field
-configuration, and fixed-grid positions to the same Grafatui behavior as
-Classic JSON.
+configuration, fixed-grid positions, and nested `RowsLayout` containers to the
+same Grafatui behavior as Classic JSON.
 
-V2 layouts other than `GridLayout` (including Rows, Tabs, and Auto-grid) are
-fatal import errors. Repeated grid items are also rejected rather than silently
-changing the dashboard.
+`RowsLayout` rows may contain a `GridLayout` or another `RowsLayout`. Tabs,
+auto-grid, repeat, conditional rendering, nested non-empty row variables,
+library panels, and Resource YAML remain unsupported; unsupported V2 layouts
+and fields are fatal import errors. Repeated grid items are also rejected rather
+than silently changing the dashboard.
 
 ## Export From Grafana
 
@@ -32,9 +34,9 @@ changing the dashboard.
 grafatui --prometheus-url http://localhost:9090 --grafana-json ./node-exporter.json
 ```
 
-Grafana 13 defaults to the V2 Resource model. Its fixed-grid JSON resources can
-be imported directly. For advanced V2 dashboards, use this Classic export path
-as the fallback. Grafana documents the available models and export controls in
+Grafana 13 defaults to the V2 Resource model. Its fixed-grid and supported rows
+JSON resources can be imported directly. For tabs, auto-grid, or other deferred
+V2 features, use this Classic export path as the fallback. Grafana documents the available models and export controls in
 [Export a dashboard as code](https://grafana.com/docs/grafana/latest/visualizations/dashboards/share-dashboards-panels/#export-a-dashboard-as-code).
 
 ## Supported Panel Types
@@ -49,7 +51,10 @@ Grafatui currently supports:
 - `table`
 - `heatmap`
 
-Row panels are traversed so nested panels can be imported, but row headers and collapsed row behavior are not rendered.
+Classic row headers and their collapsed state are rendered and interactive.
+Collapsed descendants are excluded from navigation, search, refresh, and
+export. Hidden-header rows are transparent: they consume no header and their
+children remain visible.
 
 ## Variables
 

--- a/docs/keyboard-and-mouse.md
+++ b/docs/keyboard-and-mouse.md
@@ -11,7 +11,9 @@ Grafatui is designed for keyboard-first dashboard inspection.
 | `+` / `-` | Zoom out / in |
 | `[` / `]` | Pan left / right in time |
 | `0` | Reset to live mode |
-| `Up` / `Down` or `k` / `j` | Select previous or next panel |
+| `Up` / `Down` or `k` / `j` | Select previous or next visible row or panel |
+| `Enter` / `Space` | Toggle the selected row |
+| `Left` / `Right` | Collapse / expand the selected row |
 | `PgUp` / `PgDn` | Scroll vertically, or select panels in fullscreen |
 | `Home` / `End` | Jump to top or bottom |
 | `y` | Toggle Y-axis mode |
@@ -19,12 +21,12 @@ Grafatui is designed for keyboard-first dashboard inspection.
 | `a` | Toggle external annotation markers |
 | `t` | Open the global annotation tag filter |
 | `1` through `9` | Toggle series visibility |
-| `f` / `Enter` | Toggle fullscreen mode |
+| `f` | Toggle fullscreen mode for the selected panel |
 | `v` | Toggle value inspection mode |
 | `Enter` in inspect mode | Open the selected panel's annotation cluster at the cursor |
 | `e` | Export current view |
 | `Ctrl+E` | Start or stop changed-frame recording |
-| `/` | Search panels |
+| `/` | Search visible rows and panels |
 | `Left` / `Right` | Move cursor in inspect mode |
 | `?` | Toggle debug info |
 
@@ -32,11 +34,12 @@ Grafatui is designed for keyboard-first dashboard inspection.
 
 | Action | Behavior |
 |---|---|
-| Click | Select a panel, or move the cursor in fullscreen inspect mode |
+| Click | Select a row or panel; click a row disclosure marker to toggle it; move the cursor in fullscreen inspect mode |
 | Drag | Move the cursor in fullscreen inspect mode |
 | Scroll | Scroll the dashboard vertically |
 
-In normal mode, clicking selects panels. Press `v` or `f` to use cursor-focused interactions.
+In normal mode, clicking selects rows or panels. Press `v` or `f` on a selected
+panel to use cursor-focused interactions.
 
 ## Annotation Modals
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -17,16 +17,18 @@ grafatui --prometheus-url http://prometheus.example.com:9090
 ## Import a Grafana Dashboard
 
 Grafatui imports either a Classic JSON dashboard or an exact
-`dashboard.grafana.app/v2` JSON resource that uses a `GridLayout`:
+`dashboard.grafana.app/v2` JSON resource that uses a `GridLayout` or nested
+`RowsLayout` containers:
 
 ```bash
 grafatui --prometheus-url http://localhost:9090 --grafana-json ./dashboard.json
 ```
 
-For advanced V2 dashboards that use rows, tabs, auto-grid, repeat, conditional
-rendering, nested variables, or library panels, use the Classic export fallback:
-open **Export as code → Advanced options**, set **Model** to **Classic**, then
-download or copy the JSON. V1 Resource and Resource YAML files are unsupported.
+For V2 dashboards that use tabs, auto-grid, repeat, conditional rendering,
+nested non-empty row variables, or library panels, use the Classic export
+fallback: open **Export as code → Advanced options**, set **Model** to
+**Classic**, then download or copy the JSON. V1 Resource and Resource YAML
+files are unsupported.
 See [Grafana Dashboard Import](grafana-dashboard-import.md) for the full format
 requirements.
 
@@ -62,6 +64,8 @@ docker-compose down -v
 | `r` | Force refresh |
 | `+` / `-` | Zoom out / in |
 | `[` / `]` | Pan left / right |
-| `f` / `Enter` | Fullscreen selected panel |
+| `f` | Fullscreen selected panel |
+| `Enter` / `Space` on a row | Toggle the row |
+| `Left` / `Right` on a row | Collapse / expand the row |
 | `v` | Inspect values |
-| `/` | Search panels |
+| `/` | Search visible rows and panels |

--- a/examples/README.md
+++ b/examples/README.md
@@ -84,6 +84,16 @@ demo stack:
 cargo run -- --grafana-json examples/dashboards/grafana_v2_compatibility.json --prometheus-url http://localhost:19090
 ```
 
+### `grafana_v2_rows.json`
+An exact Grafana V2 `RowsLayout` resource demonstrating expanded, nested, and
+initially collapsed rows with three Prometheus panels. It also includes a
+hidden-header container, whose child panel flows directly beneath its parent
+row. Run it against the bundled demo stack:
+
+```bash
+cargo run -- --grafana-json examples/dashboards/grafana_v2_rows.json --prometheus-url http://localhost:19090
+```
+
 ### Usage
 
 ```bash

--- a/examples/dashboards/grafana_v2_rows.json
+++ b/examples/dashboards/grafana_v2_rows.json
@@ -1,0 +1,261 @@
+{
+  "apiVersion": "dashboard.grafana.app/v2",
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "grafana-v2-rows"
+  },
+  "spec": {
+    "title": "Grafana V2 Rows",
+    "elements": {
+      "request-rate": {
+        "kind": "Panel",
+        "spec": {
+          "id": 1,
+          "title": "Mock request rate",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [{
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "refId": "A",
+                  "query": {
+                    "kind": "DataQuery",
+                    "group": "prometheus",
+                    "version": "v0",
+                    "spec": {
+                      "expr": "rate(prometheus_http_requests_total[5m])",
+                      "legendFormat": "Request rate",
+                      "instant": false
+                    }
+                  }
+                }
+              }],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.0",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "reqps",
+                  "decimals": 2,
+                  "min": 0,
+                  "custom": {
+                    "drawStyle": "line",
+                    "showPoints": "auto",
+                    "fillOpacity": 10,
+                    "axisPlacement": "auto",
+                    "axisGridShow": true
+                  }
+                },
+                "overrides": []
+              },
+              "options": {}
+            }
+          }
+        }
+      },
+      "request-total": {
+        "kind": "Panel",
+        "spec": {
+          "id": 2,
+          "title": "Mock request total",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [{
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "refId": "A",
+                  "query": {
+                    "kind": "DataQuery",
+                    "group": "prometheus",
+                    "version": "v0",
+                    "spec": {
+                      "expr": "sum(prometheus_http_requests_total)",
+                      "legendFormat": "Request total",
+                      "instant": true
+                    }
+                  }
+                }
+              }],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.0",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "decimals": 0,
+                  "min": 0
+                },
+                "overrides": []
+              },
+              "options": {}
+            }
+          }
+        }
+      },
+      "targets-up": {
+        "kind": "Panel",
+        "spec": {
+          "id": 3,
+          "title": "Mock targets up",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [{
+                "kind": "PanelQuery",
+                "spec": {
+                  "hidden": false,
+                  "refId": "A",
+                  "query": {
+                    "kind": "DataQuery",
+                    "group": "prometheus",
+                    "version": "v0",
+                    "spec": {
+                      "expr": "sum(up)",
+                      "legendFormat": "Targets up",
+                      "instant": true
+                    }
+                  }
+                }
+              }],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.0.0",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "unit": "short",
+                  "decimals": 0,
+                  "min": 0
+                },
+                "overrides": []
+              },
+              "options": {}
+            }
+          }
+        }
+      }
+    },
+    "layout": {
+      "kind": "RowsLayout",
+      "spec": {
+        "rows": [{
+          "kind": "RowsLayoutRow",
+          "spec": {
+            "title": "Expanded",
+            "collapse": false,
+            "hideHeader": false,
+            "layout": {
+              "kind": "RowsLayout",
+              "spec": {
+                "rows": [{
+                  "kind": "RowsLayoutRow",
+                  "spec": {
+                    "title": "Expanded panels",
+                    "collapse": false,
+                    "hideHeader": true,
+                    "layout": {
+                      "kind": "GridLayout",
+                      "spec": {
+                        "items": [
+                          {
+                            "kind": "GridLayoutItem",
+                            "spec": {
+                              "x": 0,
+                              "y": 0,
+                              "width": 24,
+                              "height": 8,
+                              "element": {"kind": "ElementReference", "name": "request-rate"}
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }, {
+                  "kind": "RowsLayoutRow",
+                  "spec": {
+                    "title": "Nested",
+                    "collapse": false,
+                    "hideHeader": false,
+                    "layout": {
+                      "kind": "GridLayout",
+                      "spec": {
+                        "items": [
+                          {
+                            "kind": "GridLayoutItem",
+                            "spec": {
+                              "x": 0,
+                              "y": 0,
+                              "width": 12,
+                              "height": 8,
+                              "element": {"kind": "ElementReference", "name": "request-total"}
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }]
+              }
+            }
+          }
+        }, {
+          "kind": "RowsLayoutRow",
+          "spec": {
+            "title": "Collapsed details",
+            "collapse": true,
+            "hideHeader": false,
+            "layout": {
+              "kind": "GridLayout",
+              "spec": {
+                "items": [
+                  {
+                    "kind": "GridLayoutItem",
+                    "spec": {
+                      "x": 0,
+                      "y": 0,
+                      "width": 12,
+                      "height": 8,
+                      "element": {"kind": "ElementReference", "name": "targets-up"}
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }]
+      }
+    },
+    "variables": [],
+    "timeSettings": {
+      "from": "now-6h",
+      "to": "now",
+      "autoRefresh": "5s"
+    }
+  },
+  "status": {}
+}

--- a/src/app/event_loop.rs
+++ b/src/app/event_loop.rs
@@ -50,7 +50,7 @@ where
                 }
                 Event::Mouse(mouse) => {
                     let size = terminal.size()?;
-                    input::handle_mouse(mouse, size, app)?
+                    input::handle_mouse(mouse, size, app).await?
                 }
                 _ => InputAction::Redraw,
             };

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -64,11 +64,11 @@ pub(super) async fn handle_key(
     }
 
     let action = match app.mode {
-        AppMode::Search => handle_search_key(key, app),
+        AppMode::Search => handle_search_key(key, terminal_size, app),
         AppMode::Inspect => handle_inspect_key(key, app),
         AppMode::Fullscreen => handle_fullscreen_key(key, app).await?,
         AppMode::FullscreenInspect => handle_fullscreen_inspect_key(key, app),
-        AppMode::Normal => handle_normal_key(key, app).await?,
+        AppMode::Normal => handle_normal_key(key, terminal_size, app).await?,
     };
     Ok(action)
 }
@@ -122,7 +122,7 @@ fn handle_annotation_modal_key(
     InputAction::Redraw
 }
 
-pub(super) fn handle_mouse(
+pub(super) async fn handle_mouse(
     mouse: MouseEvent,
     terminal_size: Size,
     app: &mut AppState,
@@ -134,17 +134,28 @@ pub(super) fn handle_mouse(
     match mouse.kind {
         MouseEventKind::Down(MouseButton::Left) | MouseEventKind::Drag(MouseButton::Left) => {
             let rect = Rect::new(0, 0, terminal_size.width, terminal_size.height);
-            if let Some((idx, panel_rect)) = ui::hit_test(app, rect, mouse.column, mouse.row) {
-                app.selected_item = Some(DashboardItemId::Panel(idx));
+            if let Some(item) = ui::hit_test(app, rect, mouse.column, mouse.row) {
+                let clicked_disclosure =
+                    matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left))
+                        && item.disclosure_rect.is_some_and(|disclosure| {
+                            disclosure.contains(ratatui::layout::Position {
+                                x: mouse.column,
+                                y: mouse.row,
+                            })
+                        });
+                app.selected_item = Some(item.id);
+                if clicked_disclosure {
+                    app.toggle_selected_row().await?;
+                }
 
                 match app.mode {
                     AppMode::Normal | AppMode::Inspect => {}
                     AppMode::Fullscreen | AppMode::FullscreenInspect => {
                         app.mode = AppMode::FullscreenInspect;
 
-                        let chart_width = panel_rect.width.saturating_sub(2) as f64;
+                        let chart_width = item.rect.width.saturating_sub(2) as f64;
                         if chart_width > 0.0 {
-                            let relative_x = (mouse.column.saturating_sub(panel_rect.x + 1)) as f64;
+                            let relative_x = (mouse.column.saturating_sub(item.rect.x + 1)) as f64;
                             let fraction = (relative_x / chart_width).clamp(0.0, 1.0);
                             let (start_ts, _) = app.time_bounds();
                             app.cursor_x = Some(start_ts + fraction * app.range.as_secs_f64());
@@ -167,7 +178,7 @@ pub(super) fn handle_mouse(
     }
 }
 
-fn handle_search_key(key: KeyEvent, app: &mut AppState) -> InputAction {
+fn handle_search_key(key: KeyEvent, terminal_size: Size, app: &mut AppState) -> InputAction {
     match key.code {
         KeyCode::Esc => {
             app.mode = AppMode::Normal;
@@ -175,11 +186,17 @@ fn handle_search_key(key: KeyEvent, app: &mut AppState) -> InputAction {
             app.search_results.clear();
         }
         KeyCode::Enter => {
-            if let Some(&DashboardItemId::Panel(index)) = app.search_results.first() {
-                app.selected_item = Some(DashboardItemId::Panel(index));
-                app.mode = AppMode::Fullscreen;
+            if let Some(&item) = app.search_results.first() {
+                app.selected_item = Some(item);
+                app.mode = match item {
+                    DashboardItemId::Row(_) => AppMode::Normal,
+                    DashboardItemId::Panel(_) => AppMode::Fullscreen,
+                };
                 app.search_query.clear();
                 app.search_results.clear();
+                if matches!(item, DashboardItemId::Row(_)) {
+                    ensure_selected_item_visible(terminal_size, app);
+                }
             }
         }
         KeyCode::Backspace => {
@@ -271,7 +288,11 @@ fn handle_fullscreen_inspect_key(key: KeyEvent, app: &mut AppState) -> InputActi
     }
 }
 
-async fn handle_normal_key(key: KeyEvent, app: &mut AppState) -> Result<InputAction> {
+async fn handle_normal_key(
+    key: KeyEvent,
+    terminal_size: Size,
+    app: &mut AppState,
+) -> Result<InputAction> {
     let action = match key.code {
         KeyCode::Char('f') if app.selected_panel_index().is_some() => {
             app.mode = AppMode::Fullscreen;
@@ -284,10 +305,24 @@ async fn handle_normal_key(key: KeyEvent, app: &mut AppState) -> Result<InputAct
         }
         KeyCode::Up | KeyCode::Char('k') => {
             app.select_previous_item();
+            ensure_selected_item_visible(terminal_size, app);
             InputAction::Redraw
         }
         KeyCode::Down | KeyCode::Char('j') => {
             app.select_next_item();
+            ensure_selected_item_visible(terminal_size, app);
+            InputAction::Redraw
+        }
+        KeyCode::Enter | KeyCode::Char(' ') if key.modifiers.is_empty() => {
+            app.toggle_selected_row().await?;
+            InputAction::Redraw
+        }
+        KeyCode::Left if key.modifiers.is_empty() => {
+            app.set_selected_row_collapsed(true).await?;
+            InputAction::Redraw
+        }
+        KeyCode::Right if key.modifiers.is_empty() => {
+            app.set_selected_row_collapsed(false).await?;
             InputAction::Redraw
         }
         KeyCode::PageUp => {
@@ -323,6 +358,45 @@ async fn handle_normal_key(key: KeyEvent, app: &mut AppState) -> Result<InputAct
         _ => shared_key_action(handle_shared_keys(key, app).await?),
     };
     Ok(action)
+}
+
+fn ensure_selected_item_visible(terminal_size: Size, app: &mut AppState) {
+    let Some(selected) = app.selected_item else {
+        return;
+    };
+    let area = Rect::new(0, 0, terminal_size.width, terminal_size.height);
+    let is_visible = |app: &AppState| {
+        ui::visible_dashboard_rects(area, app)
+            .iter()
+            .any(|item| item.id == selected)
+    };
+    if is_visible(app) {
+        return;
+    }
+
+    let current = app.vertical_scroll;
+    let grid_extent = app
+        .panels
+        .iter()
+        .filter_map(|panel| panel.grid)
+        .filter_map(|grid| (grid.y >= 0 && grid.h > 0).then_some(grid.y.saturating_add(grid.h)))
+        .max()
+        .unwrap_or(0) as usize;
+    let search_limit = grid_extent
+        .saturating_add(app.layout.visible_items().len().saturating_mul(4))
+        .saturating_add(1);
+    for distance in 1..=search_limit {
+        for candidate in [
+            current.saturating_sub(distance),
+            current.saturating_add(distance),
+        ] {
+            app.vertical_scroll = candidate;
+            if is_visible(app) {
+                return;
+            }
+        }
+    }
+    app.vertical_scroll = current;
 }
 
 async fn handle_shared_keys(key: KeyEvent, app: &mut AppState) -> Result<SharedKeyResult> {
@@ -401,15 +475,21 @@ fn update_search_results(app: &mut AppState) {
     }
 
     let query = app.search_query.to_lowercase();
-    let visible_panels = app.visible_panel_indices();
     app.search_results = app
-        .panels
-        .iter()
-        .enumerate()
-        .filter(|(index, panel)| {
-            visible_panels.contains(index) && panel.title.to_lowercase().contains(&query)
+        .layout
+        .visible_items()
+        .into_iter()
+        .filter(|item| match item.id {
+            DashboardItemId::Row(row_id) => app
+                .layout
+                .row(row_id)
+                .is_some_and(|row| row.title.to_lowercase().contains(&query)),
+            DashboardItemId::Panel(index) => app
+                .panels
+                .get(index)
+                .is_some_and(|panel| panel.title.to_lowercase().contains(&query)),
         })
-        .map(|(index, _)| DashboardItemId::Panel(index))
+        .map(|item| item.id)
         .collect();
 }
 
@@ -454,6 +534,10 @@ mod tests {
 
     fn ctrl_key(code: KeyCode) -> KeyEvent {
         KeyEvent::new(code, KeyModifiers::CONTROL)
+    }
+
+    fn shift_key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::SHIFT)
     }
 
     fn size() -> Size {
@@ -531,6 +615,7 @@ mod tests {
             KeyCode::Char('f'),
             KeyCode::Char('v'),
             KeyCode::Char('y'),
+            KeyCode::Char('0'),
             KeyCode::Char('1'),
         ] {
             let mut app = row_selected_app();
@@ -559,6 +644,202 @@ mod tests {
                 "key {code:?} changed series visibility"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn row_keys_toggle_collapse_and_preserve_shift_time_panning() {
+        let mut app = row_selected_app();
+
+        handle_key(key(KeyCode::Enter), size(), &mut app)
+            .await
+            .unwrap();
+        assert!(app.layout.row(RowId::new(0)).unwrap().collapsed);
+        assert_eq!(app.selected_item, Some(DashboardItemId::Row(RowId::new(0))));
+
+        handle_key(key(KeyCode::Char(' ')), size(), &mut app)
+            .await
+            .unwrap();
+        assert!(!app.layout.row(RowId::new(0)).unwrap().collapsed);
+
+        handle_key(key(KeyCode::Left), size(), &mut app)
+            .await
+            .unwrap();
+        assert!(app.layout.row(RowId::new(0)).unwrap().collapsed);
+
+        handle_key(key(KeyCode::Right), size(), &mut app)
+            .await
+            .unwrap();
+        assert!(!app.layout.row(RowId::new(0)).unwrap().collapsed);
+
+        handle_key(shift_key(KeyCode::Left), size(), &mut app)
+            .await
+            .unwrap();
+        assert_eq!(app.time_offset, app.range / 4);
+        assert!(!app.layout.row(RowId::new(0)).unwrap().collapsed);
+
+        handle_key(shift_key(KeyCode::Right), size(), &mut app)
+            .await
+            .unwrap();
+        assert_eq!(app.time_offset, Duration::ZERO);
+        assert!(!app.layout.row(RowId::new(0)).unwrap().collapsed);
+    }
+
+    #[tokio::test]
+    async fn navigation_keys_traverse_visible_rows_and_panels() {
+        let mut app = row_selected_app();
+
+        for code in [KeyCode::Char('j'), KeyCode::Down] {
+            handle_key(key(code), size(), &mut app).await.unwrap();
+        }
+        assert_eq!(app.selected_item, Some(DashboardItemId::Panel(1)));
+        handle_key(key(KeyCode::Down), size(), &mut app)
+            .await
+            .unwrap();
+        assert_eq!(app.selected_item, Some(DashboardItemId::Panel(1)));
+
+        for code in [KeyCode::Char('k'), KeyCode::Up] {
+            handle_key(key(code), size(), &mut app).await.unwrap();
+        }
+        assert_eq!(app.selected_item, Some(DashboardItemId::Row(RowId::new(0))));
+        handle_key(key(KeyCode::Up), size(), &mut app)
+            .await
+            .unwrap();
+        assert_eq!(app.selected_item, Some(DashboardItemId::Row(RowId::new(0))));
+    }
+
+    #[tokio::test]
+    async fn navigation_scrolls_mixed_items_into_a_short_viewport() {
+        let mut app = test_app();
+        app.panels.truncate(1);
+        app.panels[0].grid = Some(crate::app::GridUnit {
+            x: 0,
+            y: 0,
+            w: 24,
+            h: 2,
+        });
+        app.apply_layout(DashboardLayout::new(vec![
+            DashboardLayoutItem::Panel(0),
+            DashboardLayoutItem::Row(DashboardRow::new(
+                RowId::new(0),
+                "Lower row",
+                true,
+                false,
+                vec![],
+            )),
+        ]));
+        let short = Size::new(100, 12);
+        let area = Rect::new(0, 0, short.width, short.height);
+
+        handle_key(key(KeyCode::Char('j')), short, &mut app)
+            .await
+            .unwrap();
+
+        assert_eq!(app.selected_item, Some(DashboardItemId::Row(RowId::new(0))));
+        assert!(
+            ui::visible_dashboard_rects(area, &app)
+                .iter()
+                .any(|item| item.id == DashboardItemId::Row(RowId::new(0)))
+        );
+
+        handle_key(key(KeyCode::Char('k')), short, &mut app)
+            .await
+            .unwrap();
+        assert_eq!(app.selected_item, Some(DashboardItemId::Panel(0)));
+        assert!(
+            ui::visible_dashboard_rects(area, &app)
+                .iter()
+                .any(|item| item.id == DashboardItemId::Panel(0))
+        );
+    }
+
+    #[tokio::test]
+    async fn search_acceptance_scrolls_selected_row_into_a_short_viewport() {
+        let mut app = test_app();
+        app.panels.truncate(1);
+        app.apply_layout(DashboardLayout::new(vec![
+            DashboardLayoutItem::Row(DashboardRow::new(
+                RowId::new(0),
+                "Top row",
+                false,
+                false,
+                vec![DashboardLayoutItem::Panel(0)],
+            )),
+            DashboardLayoutItem::Row(DashboardRow::new(
+                RowId::new(1),
+                "Offscreen row",
+                true,
+                false,
+                vec![],
+            )),
+        ]));
+        let short = Size::new(100, 12);
+        let area = Rect::new(0, 0, short.width, short.height);
+
+        handle_key(key(KeyCode::Char('/')), short, &mut app)
+            .await
+            .unwrap();
+        for character in "Offscreen row".chars() {
+            handle_key(key(KeyCode::Char(character)), short, &mut app)
+                .await
+                .unwrap();
+        }
+        assert_eq!(
+            app.search_results,
+            vec![DashboardItemId::Row(RowId::new(1))]
+        );
+
+        handle_key(key(KeyCode::Enter), short, &mut app)
+            .await
+            .unwrap();
+
+        assert_eq!(app.mode, AppMode::Normal);
+        assert_eq!(app.selected_item, Some(DashboardItemId::Row(RowId::new(1))));
+        assert!(app.search_query.is_empty());
+        assert!(app.search_results.is_empty());
+        assert!(app.vertical_scroll > 0);
+        assert!(
+            ui::visible_dashboard_rects(area, &app)
+                .iter()
+                .any(|item| item.id == DashboardItemId::Row(RowId::new(1)))
+        );
+    }
+
+    #[tokio::test]
+    async fn search_includes_visible_rows_and_panels_with_type_specific_acceptance() {
+        let mut app = row_selected_app();
+
+        handle_key(key(KeyCode::Char('/')), size(), &mut app)
+            .await
+            .unwrap();
+        for character in "row".chars() {
+            handle_key(key(KeyCode::Char(character)), size(), &mut app)
+                .await
+                .unwrap();
+        }
+        assert_eq!(
+            app.search_results,
+            vec![DashboardItemId::Row(RowId::new(0))]
+        );
+        handle_key(key(KeyCode::Enter), size(), &mut app)
+            .await
+            .unwrap();
+        assert_eq!(app.mode, AppMode::Normal);
+        assert_eq!(app.selected_item, Some(DashboardItemId::Row(RowId::new(0))));
+
+        handle_key(key(KeyCode::Char('/')), size(), &mut app)
+            .await
+            .unwrap();
+        for character in "cpu".chars() {
+            handle_key(key(KeyCode::Char(character)), size(), &mut app)
+                .await
+                .unwrap();
+        }
+        assert_eq!(app.search_results, vec![DashboardItemId::Panel(0)]);
+        handle_key(key(KeyCode::Enter), size(), &mut app)
+            .await
+            .unwrap();
+        assert_eq!(app.mode, AppMode::Fullscreen);
+        assert_eq!(app.selected_item, Some(DashboardItemId::Panel(0)));
     }
 
     fn tagged_event(text: &str, tag: &str) -> crate::annotations::AnnotationEvent {
@@ -822,8 +1103,8 @@ mod tests {
         assert!(app.annotation_modal.is_some());
     }
 
-    #[test]
-    fn mouse_events_do_not_mutate_dashboard_state_while_modal_is_open() {
+    #[tokio::test]
+    async fn mouse_events_do_not_mutate_dashboard_state_while_modal_is_open() {
         let mut app = test_app();
         app.annotations =
             crate::annotations::AnnotationState::from_events_for_test(vec![tagged_event(
@@ -850,12 +1131,58 @@ mod tests {
                 size(),
                 &mut app,
             )
+            .await
             .unwrap();
             assert_eq!(action, InputAction::Redraw);
             assert_eq!(app.selected_panel_index(), Some(1));
             assert_eq!(app.cursor_x, Some(50.0));
             assert_eq!(app.vertical_scroll, 3);
         }
+    }
+
+    #[tokio::test]
+    async fn header_click_selects_row_and_disclosure_click_toggles_it() {
+        let mut app = row_selected_app();
+        app.selected_item = Some(DashboardItemId::Panel(0));
+        let area = Rect::new(0, 0, size().width, size().height);
+        let row_hit = (0..area.height)
+            .flat_map(|y| (0..area.width).map(move |x| (x, y)))
+            .find_map(|(x, y)| {
+                let item = ui::hit_test(&app, area, x, y)?;
+                (item.id == DashboardItemId::Row(RowId::new(0))).then_some(item)
+            })
+            .unwrap();
+        let disclosure = row_hit.disclosure_rect.unwrap();
+
+        handle_mouse(
+            MouseEvent {
+                kind: MouseEventKind::Down(MouseButton::Left),
+                column: row_hit.rect.right() - 1,
+                row: row_hit.rect.y,
+                modifiers: KeyModifiers::NONE,
+            },
+            size(),
+            &mut app,
+        )
+        .await
+        .unwrap();
+        assert_eq!(app.selected_item, Some(DashboardItemId::Row(RowId::new(0))));
+        assert!(!app.layout.row(RowId::new(0)).unwrap().collapsed);
+
+        handle_mouse(
+            MouseEvent {
+                kind: MouseEventKind::Down(MouseButton::Left),
+                column: disclosure.x,
+                row: disclosure.y,
+                modifiers: KeyModifiers::NONE,
+            },
+            size(),
+            &mut app,
+        )
+        .await
+        .unwrap();
+        assert_eq!(app.selected_item, Some(DashboardItemId::Row(RowId::new(0))));
+        assert!(app.layout.row(RowId::new(0)).unwrap().collapsed);
     }
 
     #[tokio::test]

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -16,6 +16,7 @@
 
 use super::state::{AppMode, AppState, YAxisMode};
 use crate::annotations::AnnotationModal;
+use crate::dashboard::DashboardItemId;
 use crate::ui;
 use anyhow::Result;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
@@ -134,7 +135,7 @@ pub(super) fn handle_mouse(
         MouseEventKind::Down(MouseButton::Left) | MouseEventKind::Drag(MouseButton::Left) => {
             let rect = Rect::new(0, 0, terminal_size.width, terminal_size.height);
             if let Some((idx, panel_rect)) = ui::hit_test(app, rect, mouse.column, mouse.row) {
-                app.selected_panel = idx;
+                app.selected_item = Some(DashboardItemId::Panel(idx));
 
                 match app.mode {
                     AppMode::Normal | AppMode::Inspect => {}
@@ -174,8 +175,8 @@ fn handle_search_key(key: KeyEvent, app: &mut AppState) -> InputAction {
             app.search_results.clear();
         }
         KeyCode::Enter => {
-            if let Some(&idx) = app.search_results.first() {
-                app.selected_panel = idx;
+            if let Some(&DashboardItemId::Panel(index)) = app.search_results.first() {
+                app.selected_item = Some(DashboardItemId::Panel(index));
                 app.mode = AppMode::Fullscreen;
                 app.search_query.clear();
                 app.search_results.clear();
@@ -272,21 +273,21 @@ fn handle_fullscreen_inspect_key(key: KeyEvent, app: &mut AppState) -> InputActi
 
 async fn handle_normal_key(key: KeyEvent, app: &mut AppState) -> Result<InputAction> {
     let action = match key.code {
-        KeyCode::Char('f') => {
+        KeyCode::Char('f') if app.selected_panel_index().is_some() => {
             app.mode = AppMode::Fullscreen;
             InputAction::Redraw
         }
-        KeyCode::Char('v') => {
+        KeyCode::Char('v') if app.selected_panel_index().is_some() => {
             app.mode = AppMode::Inspect;
             app.center_cursor();
             InputAction::Redraw
         }
         KeyCode::Up | KeyCode::Char('k') => {
-            app.select_previous_panel();
+            app.select_previous_item();
             InputAction::Redraw
         }
         KeyCode::Down | KeyCode::Char('j') => {
-            app.select_next_panel();
+            app.select_next_item();
             InputAction::Redraw
         }
         KeyCode::PageUp => {
@@ -367,7 +368,10 @@ async fn handle_shared_keys(key: KeyEvent, app: &mut AppState) -> Result<SharedK
             Ok(SharedKeyResult::Handled)
         }
         KeyCode::Char('y') => {
-            if let Some(panel) = app.panels.get_mut(app.selected_panel) {
+            if let Some(panel) = app
+                .selected_panel_index()
+                .and_then(|index| app.panels.get_mut(index))
+            {
                 panel.y_axis_mode = match panel.y_axis_mode {
                     YAxisMode::Auto => YAxisMode::ZeroBased,
                     YAxisMode::ZeroBased => YAxisMode::Auto,
@@ -397,12 +401,15 @@ fn update_search_results(app: &mut AppState) {
     }
 
     let query = app.search_query.to_lowercase();
+    let visible_panels = app.visible_panel_indices();
     app.search_results = app
         .panels
         .iter()
         .enumerate()
-        .filter(|(_, panel)| panel.title.to_lowercase().contains(&query))
-        .map(|(i, _)| i)
+        .filter(|(index, panel)| {
+            visible_panels.contains(index) && panel.title.to_lowercase().contains(&query)
+        })
+        .map(|(index, _)| DashboardItemId::Panel(index))
         .collect();
 }
 
@@ -410,7 +417,10 @@ fn toggle_series_visibility(app: &mut AppState, c: char) {
     let Some(digit) = c.to_digit(10) else {
         return;
     };
-    let Some(panel) = app.panels.get_mut(app.selected_panel) else {
+    let Some(panel) = app
+        .selected_panel_index()
+        .and_then(|index| app.panels.get_mut(index))
+    else {
         return;
     };
 
@@ -430,6 +440,9 @@ fn toggle_series_visibility(app: &mut AppState, c: char) {
 mod tests {
     use super::*;
     use crate::app::{GraphOptions, PanelOptions, PanelState, PanelType, SeriesView};
+    use crate::dashboard::{
+        DashboardItemId, DashboardLayout, DashboardLayoutItem, DashboardRow, RowId,
+    };
     use crate::export::ExportOptions;
     use crate::prom;
     use crate::theme::Theme;
@@ -494,6 +507,57 @@ mod tests {
             autogrid: None,
             display: crate::ui::DisplayFormat::default(),
             options: PanelOptions::Graph(GraphOptions::default()),
+        }
+    }
+
+    fn row_selected_app() -> AppState {
+        let mut app = test_app();
+        app.apply_layout(DashboardLayout::new(vec![DashboardLayoutItem::Row(
+            DashboardRow::new(
+                RowId::new(0),
+                "Row",
+                false,
+                false,
+                vec![DashboardLayoutItem::Panel(0), DashboardLayoutItem::Panel(1)],
+            ),
+        )]));
+        assert_eq!(app.selected_item, Some(DashboardItemId::Row(RowId::new(0))));
+        app
+    }
+
+    #[tokio::test]
+    async fn panel_only_normal_actions_no_op_when_a_row_is_selected() {
+        for code in [
+            KeyCode::Char('f'),
+            KeyCode::Char('v'),
+            KeyCode::Char('y'),
+            KeyCode::Char('1'),
+        ] {
+            let mut app = row_selected_app();
+            let series_visibility = app.panels[0]
+                .series
+                .iter()
+                .map(|series| series.visible)
+                .collect::<Vec<_>>();
+
+            handle_key(key(code), size(), &mut app).await.unwrap();
+
+            assert_eq!(app.mode, AppMode::Normal, "key {code:?} changed mode");
+            assert_eq!(app.cursor_x, None, "key {code:?} created a cursor");
+            assert_eq!(
+                app.panels[0].y_axis_mode,
+                YAxisMode::Auto,
+                "key {code:?} changed y axis"
+            );
+            assert_eq!(
+                app.panels[0]
+                    .series
+                    .iter()
+                    .map(|series| series.visible)
+                    .collect::<Vec<_>>(),
+                series_visibility,
+                "key {code:?} changed series visibility"
+            );
         }
     }
 
@@ -646,7 +710,7 @@ mod tests {
             panic!("tag modal should remain open");
         };
         assert_eq!(modal.selected(), 1);
-        assert_eq!(app.selected_panel, 0);
+        assert_eq!(app.selected_panel_index(), Some(0));
         assert_eq!(app.range, original_range);
     }
 
@@ -767,7 +831,7 @@ mod tests {
             )]);
         app.open_tag_filter_modal();
         app.mode = AppMode::FullscreenInspect;
-        app.selected_panel = 1;
+        app.selected_item = Some(DashboardItemId::Panel(1));
         app.cursor_x = Some(50.0);
         app.vertical_scroll = 3;
 
@@ -788,7 +852,7 @@ mod tests {
             )
             .unwrap();
             assert_eq!(action, InputAction::Redraw);
-            assert_eq!(app.selected_panel, 1);
+            assert_eq!(app.selected_panel_index(), Some(1));
             assert_eq!(app.cursor_x, Some(50.0));
             assert_eq!(app.vertical_scroll, 3);
         }
@@ -801,12 +865,12 @@ mod tests {
         handle_key(key(KeyCode::Char('j')), size(), &mut app)
             .await
             .unwrap();
-        assert_eq!(app.selected_panel, 1);
+        assert_eq!(app.selected_panel_index(), Some(1));
 
         handle_key(key(KeyCode::Char('k')), size(), &mut app)
             .await
             .unwrap();
-        assert_eq!(app.selected_panel, 0);
+        assert_eq!(app.selected_panel_index(), Some(0));
     }
 
     #[tokio::test]
@@ -893,7 +957,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(app.search_query, "m");
-        assert_eq!(app.search_results, vec![1]);
+        assert_eq!(app.search_results, vec![DashboardItemId::Panel(1)]);
 
         handle_key(key(KeyCode::Backspace), size(), &mut app)
             .await
@@ -907,7 +971,7 @@ mod tests {
         handle_key(key(KeyCode::Enter), size(), &mut app)
             .await
             .unwrap();
-        assert_eq!(app.selected_panel, 0);
+        assert_eq!(app.selected_panel_index(), Some(0));
         assert_eq!(app.mode, AppMode::Fullscreen);
 
         handle_key(key(KeyCode::Esc), size(), &mut app)
@@ -924,12 +988,12 @@ mod tests {
         handle_key(key(KeyCode::PageDown), size(), &mut app)
             .await
             .unwrap();
-        assert_eq!(app.selected_panel, 1);
+        assert_eq!(app.selected_panel_index(), Some(1));
 
         handle_key(key(KeyCode::PageUp), size(), &mut app)
             .await
             .unwrap();
-        assert_eq!(app.selected_panel, 0);
+        assert_eq!(app.selected_panel_index(), Some(0));
 
         handle_key(key(KeyCode::Char('v')), size(), &mut app)
             .await

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -16,6 +16,7 @@
 
 use crate::app::data::{downsample, expand_expr, format_legend};
 use crate::app::variables::refresh_query_variables;
+use crate::dashboard::{DashboardItemId, DashboardLayout, RowId};
 use crate::export::{ExportOptions, RecordingState};
 use crate::grafana::TemplateQueryVar;
 use crate::prom;
@@ -24,7 +25,7 @@ use crate::ui::DisplayFormat;
 use anyhow::Result;
 use futures::StreamExt;
 use ratatui::style::Color;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::time::{Duration, Instant};
 
 /// Represents the state of a single dashboard panel.
@@ -302,8 +303,10 @@ pub(crate) struct AppState {
     pub(crate) query_vars: Vec<TemplateQueryVar>,
     /// Count of panels skipped during import.
     pub(crate) skipped_panels: usize,
-    /// Index of the currently selected panel.
-    pub(crate) selected_panel: usize,
+    /// Recursive row/panel dashboard layout.
+    pub(crate) layout: DashboardLayout,
+    /// Currently selected visible row or panel.
+    pub(crate) selected_item: Option<DashboardItemId>,
     /// UI Theme.
     pub(crate) theme: Theme,
     /// Time offset from "now" for panning backward in time (0 = live mode).
@@ -312,8 +315,8 @@ pub(crate) struct AppState {
     pub(crate) mode: AppMode,
     /// Search query string.
     pub(crate) search_query: String,
-    /// Filtered panel indices based on search query.
-    pub(crate) search_results: Vec<usize>,
+    /// Filtered dashboard items based on search query.
+    pub(crate) search_results: Vec<DashboardItemId>,
     /// Cursor X position (timestamp) for inspection.
     pub(crate) cursor_x: Option<f64>,
     /// Global marker set for rendering thresholds
@@ -356,6 +359,8 @@ impl AppState {
         threshold_marker: String,
         export: ExportOptions,
     ) -> Self {
+        let layout = DashboardLayout::flat(panels.len());
+        let selected_item = layout.first_visible();
         Self {
             prometheus,
             annotations: crate::annotations::AnnotationState::from_path(None),
@@ -373,7 +378,8 @@ impl AppState {
             vars: HashMap::new(),
             query_vars: Vec::new(),
             skipped_panels,
-            selected_panel: 0,
+            layout,
+            selected_item,
             theme,
             time_offset: Duration::from_secs(0),
             mode: AppMode::Normal,
@@ -412,7 +418,9 @@ impl AppState {
 
     /// Automatically scroll to ensure the selected panel is visible.
     pub(crate) fn scroll_to_selected_panel(&mut self) {
-        if let Some(panel) = self.panels.get(self.selected_panel)
+        if let Some(panel) = self
+            .selected_panel_index()
+            .and_then(|index| self.panels.get(index))
             && let Some(grid) = panel.grid
         {
             let py = grid.y;
@@ -428,20 +436,132 @@ impl AppState {
         }
     }
 
-    /// Selects the previous panel, keeping the dashboard scrolled to it.
-    pub(crate) fn select_previous_panel(&mut self) {
-        if self.selected_panel > 0 {
-            self.selected_panel -= 1;
-            self.scroll_to_selected_panel();
+    pub(crate) fn apply_layout(&mut self, layout: DashboardLayout) {
+        self.layout = layout;
+        self.selected_item = self.layout.first_visible();
+        self.scroll_to_selected_panel();
+    }
+
+    pub(crate) fn selected_panel_index(&self) -> Option<usize> {
+        match self.selected_item {
+            Some(DashboardItemId::Panel(index)) => Some(index),
+            Some(DashboardItemId::Row(_)) | None => None,
         }
     }
 
-    /// Selects the next panel, keeping the dashboard scrolled to it.
-    pub(crate) fn select_next_panel(&mut self) {
-        if self.selected_panel < self.panels.len().saturating_sub(1) {
-            self.selected_panel += 1;
-            self.scroll_to_selected_panel();
+    pub(crate) fn selected_row_id(&self) -> Option<RowId> {
+        match self.selected_item {
+            Some(DashboardItemId::Row(id)) => Some(id),
+            Some(DashboardItemId::Panel(_)) | None => None,
         }
+    }
+
+    pub(crate) fn visible_panel_indices(&self) -> Vec<usize> {
+        self.layout.visible_panel_indices()
+    }
+
+    /// Selects the previous visible dashboard item.
+    pub(crate) fn select_previous_item(&mut self) {
+        self.move_selection(-1);
+    }
+
+    /// Selects the next visible dashboard item.
+    pub(crate) fn select_next_item(&mut self) {
+        self.move_selection(1);
+    }
+
+    fn move_selection(&mut self, direction: isize) {
+        let visible = self.layout.visible_items();
+        let Some(first) = visible.first() else {
+            self.selected_item = None;
+            return;
+        };
+        let Some(selected) = self.selected_item else {
+            self.selected_item = Some(first.id);
+            self.scroll_to_selected_panel();
+            return;
+        };
+        let Some(current) = visible.iter().position(|item| item.id == selected) else {
+            self.selected_item = Some(first.id);
+            self.scroll_to_selected_panel();
+            return;
+        };
+        let next = current
+            .saturating_add_signed(direction)
+            .min(visible.len() - 1);
+        self.selected_item = Some(visible[next].id);
+        self.scroll_to_selected_panel();
+    }
+
+    fn ensure_selection_visible(&mut self) {
+        self.selected_item = self
+            .selected_item
+            .and_then(|item| self.layout.nearest_visible_ancestor(item))
+            .or_else(|| self.layout.first_visible());
+        self.scroll_to_selected_panel();
+    }
+
+    pub(crate) async fn set_selected_row_collapsed(&mut self, collapsed: bool) -> Result<()> {
+        let Some(row_id) = self.selected_row_id() else {
+            return Ok(());
+        };
+        let Some(change) = self.layout.set_row_collapsed(row_id, collapsed) else {
+            return Ok(());
+        };
+        if !change.newly_visible_panels.is_empty() {
+            self.refresh_panel_indices(&change.newly_visible_panels, false)
+                .await;
+        }
+        self.reconcile_visible_annotation_targets();
+        self.ensure_selection_visible();
+        Ok(())
+    }
+
+    pub(crate) async fn toggle_selected_row(&mut self) -> Result<()> {
+        let Some(row_id) = self.selected_row_id() else {
+            return Ok(());
+        };
+        let Some(change) = self.layout.toggle_row(row_id) else {
+            return Ok(());
+        };
+        if !change.newly_visible_panels.is_empty() {
+            self.refresh_panel_indices(&change.newly_visible_panels, false)
+                .await;
+        }
+        self.reconcile_visible_annotation_targets();
+        self.ensure_selection_visible();
+        Ok(())
+    }
+
+    /// Compatibility wrapper for panel-only fullscreen navigation.
+    pub(crate) fn select_previous_panel(&mut self) {
+        self.move_panel_selection(-1);
+    }
+
+    /// Compatibility wrapper for panel-only fullscreen navigation.
+    pub(crate) fn select_next_panel(&mut self) {
+        self.move_panel_selection(1);
+    }
+
+    fn move_panel_selection(&mut self, direction: isize) {
+        let panels = self.visible_panel_indices();
+        let Some(&first) = panels.first() else {
+            self.selected_item = None;
+            return;
+        };
+        let Some(current) = self.selected_panel_index() else {
+            self.selected_item = Some(DashboardItemId::Panel(first));
+            self.scroll_to_selected_panel();
+            return;
+        };
+        let Some(index) = panels.iter().position(|&panel| panel == current) else {
+            self.selected_item = Some(DashboardItemId::Panel(first));
+            self.scroll_to_selected_panel();
+            return;
+        };
+        let next = index.saturating_add_signed(direction).min(panels.len() - 1);
+        self.selected_item = Some(DashboardItemId::Panel(panels[next]));
+        self.scroll_to_selected_panel();
     }
 
     /// Pan right: shift the time window forward (toward "now").
@@ -508,18 +628,12 @@ impl AppState {
     pub(crate) async fn refresh(&mut self) -> Result<()> {
         let range = self.range;
         let step = self.step;
+        let visible_panel_indices = self.visible_panel_indices();
 
         // Calculate end timestamp: "now" minus time_offset
         let end_ts = chrono::Utc::now().timestamp() - self.time_offset.as_secs() as i64;
         let annotation_context =
             crate::annotations::AnnotationRefreshContext::from_unix_window(end_ts, range);
-        let eligible_titles = self
-            .panels
-            .iter()
-            .filter(|panel| panel.panel_type == PanelType::Graph)
-            .map(|panel| panel.title.clone())
-            .collect::<Vec<_>>();
-
         let annotation_refresh = self.annotations.refresh(&annotation_context);
         let prometheus_refresh = Self::refresh_prometheus_data(
             &self.prometheus,
@@ -529,18 +643,53 @@ impl AppState {
             end_ts,
             &mut self.vars,
             &mut self.panels,
+            &visible_panel_indices,
+            true,
         );
-        let (annotations_changed, ()) = tokio::join!(annotation_refresh, prometheus_refresh);
+        let (_, ()) = tokio::join!(annotation_refresh, prometheus_refresh);
 
-        if annotations_changed {
-            self.annotations.reconcile_targets(&eligible_titles);
-        }
+        self.reconcile_visible_annotation_targets();
 
         self.view_end_ts = end_ts;
         self.last_refresh = Instant::now();
         Ok(())
     }
 
+    fn reconcile_visible_annotation_targets(&mut self) {
+        let visible_panels = self
+            .visible_panel_indices()
+            .into_iter()
+            .collect::<HashSet<_>>();
+        let titles = self
+            .panels
+            .iter()
+            .enumerate()
+            .filter(|(index, _)| visible_panels.contains(index))
+            .filter(|(_, panel)| panel.panel_type == PanelType::Graph)
+            .map(|(_, panel)| panel.title.clone())
+            .collect::<Vec<_>>();
+        self.annotations.reconcile_targets(&titles);
+    }
+
+    async fn refresh_panel_indices(&mut self, indices: &[usize], refresh_variables: bool) {
+        let range = self.range;
+        let step = self.step;
+        let end_ts = self.view_end_ts;
+        Self::refresh_prometheus_data(
+            &self.prometheus,
+            &self.query_vars,
+            range,
+            step,
+            end_ts,
+            &mut self.vars,
+            &mut self.panels,
+            indices,
+            refresh_variables,
+        )
+        .await;
+    }
+
+    #[allow(clippy::too_many_arguments)]
     async fn refresh_prometheus_data(
         prometheus: &prom::PromClient,
         query_vars: &[TemplateQueryVar],
@@ -549,13 +698,24 @@ impl AppState {
         end_ts: i64,
         vars: &mut HashMap<String, String>,
         panels: &mut [PanelState],
+        indices: &[usize],
+        refresh_variables: bool,
     ) {
-        let _ = refresh_query_variables(prometheus, query_vars, range, step, end_ts, vars).await;
+        if refresh_variables {
+            let _ =
+                refresh_query_variables(prometheus, query_vars, range, step, end_ts, vars).await;
+        }
 
         // Create a stream of futures for fetching panel data
-        let mut futures = futures::stream::iter(panels.iter_mut())
-            .map(|p| Self::fetch_single_panel_data(prometheus, p, range, step, vars, end_ts))
-            .buffer_unordered(4); // Max 4 concurrent panel refreshes
+        let indices = indices.iter().copied().collect::<HashSet<_>>();
+        let mut futures = futures::stream::iter(
+            panels
+                .iter_mut()
+                .enumerate()
+                .filter_map(|(index, panel)| indices.contains(&index).then_some(panel)),
+        )
+        .map(|p| Self::fetch_single_panel_data(prometheus, p, range, step, vars, end_ts))
+        .buffer_unordered(4); // Max 4 concurrent panel refreshes
 
         while let Some((p, results, url, err)) = futures.next().await {
             p.series = results;
@@ -670,6 +830,9 @@ mod tests {
         AnnotationProvider, AnnotationRefreshContext, AnnotationSnapshot, ProviderFuture,
         ProviderPoll,
     };
+    use crate::dashboard::{
+        DashboardItemId, DashboardLayout, DashboardLayoutItem, DashboardRow, RowId,
+    };
     use std::sync::{Arc, Mutex};
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
@@ -723,6 +886,212 @@ mod tests {
         }
     }
 
+    fn row_test_layout(parent_collapsed: bool) -> DashboardLayout {
+        DashboardLayout::new(vec![DashboardLayoutItem::Row(DashboardRow::new(
+            RowId::new(0),
+            "Parent",
+            parent_collapsed,
+            false,
+            vec![
+                DashboardLayoutItem::Panel(0),
+                DashboardLayoutItem::Row(DashboardRow::new(
+                    RowId::new(1),
+                    "Nested",
+                    true,
+                    false,
+                    vec![DashboardLayoutItem::Panel(1)],
+                )),
+            ],
+        ))])
+    }
+
+    fn row_test_app() -> AppState {
+        let mut app = create_test_app();
+        app.panels = vec![
+            test_panel("Visible", PanelType::Graph),
+            test_panel("Nested hidden", PanelType::Graph),
+        ];
+        app.apply_layout(row_test_layout(false));
+        app
+    }
+
+    fn row_test_app_with_queries(base_url: &str) -> AppState {
+        let mut app = create_test_app();
+        app.prometheus = prom::PromClient::new(base_url.to_string());
+        app.panels = vec![
+            test_panel("Visible", PanelType::Graph),
+            test_panel("Nested hidden", PanelType::Graph),
+        ];
+        for panel in &mut app.panels {
+            panel.exprs = vec!["up".to_string()];
+            panel.legends = vec![None];
+            panel.query_modes = vec![QueryMode::Range];
+        }
+        app.apply_layout(row_test_layout(true));
+        app
+    }
+
+    #[tokio::test]
+    async fn navigation_uses_visible_items_and_preserves_nested_state() {
+        let mut app = row_test_app();
+        assert_eq!(app.selected_item, Some(DashboardItemId::Row(RowId::new(0))));
+
+        app.select_next_item();
+        assert_eq!(app.selected_panel_index(), Some(0));
+        app.select_previous_item();
+        app.toggle_selected_row().await.unwrap();
+
+        assert!(app.visible_panel_indices().is_empty());
+        assert_eq!(app.selected_item, Some(DashboardItemId::Row(RowId::new(0))));
+
+        app.toggle_selected_row().await.unwrap();
+        assert!(app.layout.row(RowId::new(1)).unwrap().collapsed);
+        assert_eq!(app.visible_panel_indices(), vec![0]);
+    }
+
+    #[test]
+    fn fullscreen_navigation_skips_visible_row_items() {
+        let mut app = create_test_app();
+        app.panels = vec![
+            test_panel("First", PanelType::Graph),
+            test_panel("Second", PanelType::Graph),
+        ];
+        app.apply_layout(DashboardLayout::new(vec![DashboardLayoutItem::Row(
+            DashboardRow::new(
+                RowId::new(0),
+                "Parent",
+                false,
+                false,
+                vec![
+                    DashboardLayoutItem::Panel(0),
+                    DashboardLayoutItem::Row(DashboardRow::new(
+                        RowId::new(1),
+                        "Nested",
+                        false,
+                        false,
+                        vec![DashboardLayoutItem::Panel(1)],
+                    )),
+                ],
+            ),
+        )]));
+        app.selected_item = Some(DashboardItemId::Panel(0));
+
+        app.select_next_panel();
+
+        assert_eq!(app.selected_item, Some(DashboardItemId::Panel(1)));
+        app.select_previous_panel();
+        assert_eq!(app.selected_item, Some(DashboardItemId::Panel(0)));
+    }
+
+    #[test]
+    fn empty_dashboard_has_no_selection_and_navigation_is_safe() {
+        let mut app = create_test_app();
+
+        assert_eq!(app.selected_item, None);
+        assert_eq!(app.selected_panel_index(), None);
+        app.select_previous_item();
+        app.select_next_item();
+
+        assert_eq!(app.selected_item, None);
+    }
+
+    #[tokio::test]
+    async fn refresh_skips_collapsed_panels_and_expand_fetches_only_newly_visible() {
+        let mut app = row_test_app_with_queries("http://127.0.0.1:9");
+
+        app.refresh().await.unwrap();
+        assert!(app.panels[0].last_error.is_none());
+        assert!(app.panels[1].last_error.is_none());
+
+        app.toggle_selected_row().await.unwrap();
+        assert!(app.panels[0].last_error.is_some());
+        assert!(app.panels[1].last_error.is_none());
+    }
+
+    #[tokio::test]
+    async fn expansion_uses_the_displayed_window_without_resetting_refresh_clock() {
+        let mut app = row_test_app_with_queries("http://127.0.0.1:9");
+        app.view_end_ts = 1_700_000_000;
+        app.last_refresh = Instant::now() - Duration::from_secs(30);
+        let last_refresh = app.last_refresh;
+
+        app.toggle_selected_row().await.unwrap();
+
+        assert_eq!(app.view_end_ts, 1_700_000_000);
+        assert_eq!(app.last_refresh, last_refresh);
+        assert!(
+            app.panels[0]
+                .last_url
+                .as_deref()
+                .unwrap()
+                .contains("end=1700000000")
+        );
+    }
+
+    #[tokio::test]
+    async fn refresh_reconciles_annotations_against_visible_graph_panels_only() {
+        let path = temp_annotation_path("visible-target-reconciliation");
+        let time = chrono::Utc::now().to_rfc3339();
+        std::fs::write(
+            &path,
+            format!("{{\"time\":\"{time}\",\"text\":\"cpu\",\"panel_titles\":[\"CPU\"]}}\n"),
+        )
+        .unwrap();
+        let mut app = create_test_app();
+        app.panels = vec![
+            test_panel("CPU", PanelType::Graph),
+            test_panel("CPU", PanelType::Graph),
+        ];
+        app.apply_layout(DashboardLayout::new(vec![
+            DashboardLayoutItem::Panel(0),
+            DashboardLayoutItem::Row(DashboardRow::new(
+                RowId::new(0),
+                "Hidden duplicate",
+                true,
+                false,
+                vec![DashboardLayoutItem::Panel(1)],
+            )),
+        ]));
+        app.annotations = crate::annotations::AnnotationState::from_path(Some(path.clone()));
+
+        app.refresh().await.unwrap();
+
+        assert_eq!(app.annotations.footer_status(), None);
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[tokio::test]
+    async fn collapsing_a_row_reconciles_unchanged_annotation_targets() {
+        let mut event = crate::annotations::test_event_at(50.0, "cpu");
+        event.target = crate::annotations::AnnotationTarget::PanelTitles(
+            ["CPU".to_string()].into_iter().collect(),
+        );
+        let mut app = create_test_app();
+        app.panels = vec![
+            test_panel("CPU", PanelType::Graph),
+            test_panel("CPU", PanelType::Graph),
+        ];
+        app.apply_layout(DashboardLayout::new(vec![
+            DashboardLayoutItem::Panel(0),
+            DashboardLayoutItem::Row(DashboardRow::new(
+                RowId::new(0),
+                "Collapsible",
+                false,
+                false,
+                vec![DashboardLayoutItem::Panel(1)],
+            )),
+        ]));
+        app.annotations = crate::annotations::AnnotationState::from_events_for_test(vec![event]);
+        app.annotations
+            .reconcile_targets(&["CPU".to_string(), "CPU".to_string()]);
+        assert!(app.annotations.footer_status().is_some());
+        app.selected_item = Some(DashboardItemId::Row(RowId::new(0)));
+
+        app.set_selected_row_collapsed(true).await.unwrap();
+
+        assert_eq!(app.annotations.footer_status(), None);
+    }
+
     #[derive(Debug)]
     struct RecordingProvider {
         captured: Arc<Mutex<Option<AnnotationRefreshContext>>>,
@@ -764,7 +1133,7 @@ mod tests {
         assert!(app.refresh().await.is_ok());
 
         app.scroll_to_selected_panel();
-        assert_eq!(app.selected_panel, 0);
+        assert_eq!(app.selected_panel_index(), None);
 
         app.move_cursor(1);
     }
@@ -838,6 +1207,7 @@ mod tests {
         panel.legends = vec![None];
         panel.query_modes = vec![QueryMode::Range];
         app.panels = vec![panel];
+        app.apply_layout(DashboardLayout::flat(app.panels.len()));
         app.annotations =
             crate::annotations::AnnotationState::from_provider(Some(Box::new(HandshakeProvider {
                 provider_started,
@@ -908,6 +1278,7 @@ mod tests {
             test_panel("CPU", PanelType::Graph),
             test_panel("OnlyStat", PanelType::Stat),
         ];
+        app.apply_layout(DashboardLayout::flat(app.panels.len()));
         app.annotations = crate::annotations::AnnotationState::from_path(Some(path.clone()));
 
         app.refresh().await.unwrap();
@@ -970,16 +1341,16 @@ mod tests {
         );
 
         app.select_previous_panel();
-        assert_eq!(app.selected_panel, 0);
+        assert_eq!(app.selected_panel_index(), Some(0));
 
         app.select_next_panel();
-        assert_eq!(app.selected_panel, 1);
+        assert_eq!(app.selected_panel_index(), Some(1));
 
         app.select_next_panel();
-        assert_eq!(app.selected_panel, 1);
+        assert_eq!(app.selected_panel_index(), Some(1));
 
         app.select_previous_panel();
-        assert_eq!(app.selected_panel, 0);
+        assert_eq!(app.selected_panel_index(), Some(0));
     }
 
     #[test]

--- a/src/dashboard.rs
+++ b/src/dashboard.rs
@@ -1,0 +1,355 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct RowId(usize);
+
+impl RowId {
+    pub(crate) const fn new(value: usize) -> Self {
+        Self(value)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum DashboardItemId {
+    Row(RowId),
+    Panel(usize),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum DashboardLayoutItem {
+    Row(DashboardRow),
+    Panel(usize),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DashboardRow {
+    pub(crate) id: RowId,
+    pub(crate) title: String,
+    pub(crate) collapsed: bool,
+    pub(crate) hidden_header: bool,
+    pub(crate) children: Vec<DashboardLayoutItem>,
+}
+
+impl DashboardRow {
+    pub(crate) fn new(
+        id: RowId,
+        title: impl Into<String>,
+        collapsed: bool,
+        hidden_header: bool,
+        children: Vec<DashboardLayoutItem>,
+    ) -> Self {
+        Self {
+            id,
+            title: title.into(),
+            collapsed,
+            hidden_header,
+            children,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct VisibleDashboardItem {
+    pub(crate) id: DashboardItemId,
+    pub(crate) depth: usize,
+}
+
+impl VisibleDashboardItem {
+    pub(crate) const fn panel(index: usize, depth: usize) -> Self {
+        Self {
+            id: DashboardItemId::Panel(index),
+            depth,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct DashboardLayout {
+    pub(crate) items: Vec<DashboardLayoutItem>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct LayoutChange {
+    pub(crate) newly_visible_panels: Vec<usize>,
+}
+
+impl DashboardLayout {
+    pub(crate) fn new(items: Vec<DashboardLayoutItem>) -> Self {
+        Self { items }
+    }
+
+    pub(crate) fn flat(panel_count: usize) -> Self {
+        Self::new((0..panel_count).map(DashboardLayoutItem::Panel).collect())
+    }
+
+    pub(crate) fn row(&self, id: RowId) -> Option<&DashboardRow> {
+        find_row(&self.items, id)
+    }
+
+    pub(crate) fn visible_items(&self) -> Vec<VisibleDashboardItem> {
+        let mut visible = Vec::new();
+        collect_visible_items(&self.items, 0, &mut visible);
+        visible
+    }
+
+    pub(crate) fn visible_panel_indices(&self) -> Vec<usize> {
+        self.visible_items()
+            .into_iter()
+            .filter_map(|item| match item.id {
+                DashboardItemId::Panel(index) => Some(index),
+                DashboardItemId::Row(_) => None,
+            })
+            .collect()
+    }
+
+    pub(crate) fn visible_panel_count(&self) -> usize {
+        self.visible_panel_indices().len()
+    }
+
+    pub(crate) fn toggle_row(&mut self, id: RowId) -> Option<LayoutChange> {
+        let collapsed = !self.row(id)?.collapsed;
+        self.set_row_collapsed(id, collapsed)
+    }
+
+    pub(crate) fn set_row_collapsed(&mut self, id: RowId, collapsed: bool) -> Option<LayoutChange> {
+        let before = self.visible_panel_indices();
+        find_row_mut(&mut self.items, id)?.collapsed = collapsed;
+        let after = self.visible_panel_indices();
+        Some(LayoutChange {
+            newly_visible_panels: after
+                .into_iter()
+                .filter(|panel| !before.contains(panel))
+                .collect(),
+        })
+    }
+
+    pub(crate) fn first_visible(&self) -> Option<DashboardItemId> {
+        self.visible_items().first().map(|item| item.id)
+    }
+
+    pub(crate) fn nearest_visible_ancestor(&self, id: DashboardItemId) -> Option<DashboardItemId> {
+        let visible = self.visible_items();
+        if visible.iter().any(|item| item.id == id) {
+            return Some(id);
+        }
+
+        let mut ancestors = Vec::new();
+        if find_ancestors(&self.items, id, &mut ancestors) {
+            for row_id in ancestors.into_iter().rev() {
+                let ancestor = DashboardItemId::Row(row_id);
+                if visible.iter().any(|item| item.id == ancestor) {
+                    return Some(ancestor);
+                }
+            }
+        }
+
+        self.first_visible()
+    }
+}
+
+fn find_row(items: &[DashboardLayoutItem], id: RowId) -> Option<&DashboardRow> {
+    for item in items {
+        if let DashboardLayoutItem::Row(row) = item {
+            if row.id == id {
+                return Some(row);
+            }
+            if let Some(found) = find_row(&row.children, id) {
+                return Some(found);
+            }
+        }
+    }
+    None
+}
+
+fn find_row_mut(items: &mut [DashboardLayoutItem], id: RowId) -> Option<&mut DashboardRow> {
+    for item in items {
+        if let DashboardLayoutItem::Row(row) = item {
+            if row.id == id {
+                return Some(row);
+            }
+            if let Some(found) = find_row_mut(&mut row.children, id) {
+                return Some(found);
+            }
+        }
+    }
+    None
+}
+
+fn collect_visible_items(
+    items: &[DashboardLayoutItem],
+    depth: usize,
+    visible: &mut Vec<VisibleDashboardItem>,
+) {
+    for item in items {
+        match item {
+            DashboardLayoutItem::Panel(index) => {
+                visible.push(VisibleDashboardItem::panel(*index, depth))
+            }
+            DashboardLayoutItem::Row(row) if row.hidden_header => {
+                collect_visible_items(&row.children, depth, visible);
+            }
+            DashboardLayoutItem::Row(row) => {
+                visible.push(VisibleDashboardItem {
+                    id: DashboardItemId::Row(row.id),
+                    depth,
+                });
+                if !row.collapsed {
+                    collect_visible_items(&row.children, depth + 1, visible);
+                }
+            }
+        }
+    }
+}
+
+fn find_ancestors(
+    items: &[DashboardLayoutItem],
+    target: DashboardItemId,
+    ancestors: &mut Vec<RowId>,
+) -> bool {
+    for item in items {
+        match item {
+            DashboardLayoutItem::Panel(index) if target == DashboardItemId::Panel(*index) => {
+                return true;
+            }
+            DashboardLayoutItem::Row(row) => {
+                if target == DashboardItemId::Row(row.id) {
+                    return true;
+                }
+                ancestors.push(row.id);
+                if find_ancestors(&row.children, target, ancestors) {
+                    return true;
+                }
+                ancestors.pop();
+            }
+            DashboardLayoutItem::Panel(_) => {}
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn collapsed_parent_hides_descendants_and_preserves_nested_state() {
+        let nested = DashboardRow::new(
+            RowId::new(2),
+            "Nested",
+            true,
+            false,
+            vec![DashboardLayoutItem::Panel(2)],
+        );
+        let parent = DashboardRow::new(
+            RowId::new(1),
+            "Parent",
+            false,
+            false,
+            vec![
+                DashboardLayoutItem::Panel(0),
+                DashboardLayoutItem::Row(nested),
+                DashboardLayoutItem::Panel(1),
+            ],
+        );
+        let mut layout = DashboardLayout::new(vec![DashboardLayoutItem::Row(parent)]);
+
+        assert_eq!(layout.visible_panel_indices(), vec![0, 1]);
+        layout.set_row_collapsed(RowId::new(1), true).unwrap();
+        assert_eq!(layout.visible_panel_indices(), Vec::<usize>::new());
+        let change = layout.set_row_collapsed(RowId::new(1), false).unwrap();
+        assert_eq!(change.newly_visible_panels, vec![0, 1]);
+        assert!(layout.row(RowId::new(2)).unwrap().collapsed);
+    }
+
+    #[test]
+    fn hidden_header_is_transparent_even_when_marked_collapsed() {
+        let hidden = DashboardRow::new(
+            RowId::new(1),
+            "Hidden",
+            true,
+            true,
+            vec![DashboardLayoutItem::Panel(0)],
+        );
+        let layout = DashboardLayout::new(vec![DashboardLayoutItem::Row(hidden)]);
+        assert_eq!(layout.visible_panel_indices(), vec![0]);
+        assert_eq!(
+            layout.visible_items(),
+            vec![VisibleDashboardItem::panel(0, 0)]
+        );
+    }
+
+    #[test]
+    fn flat_layout_lists_each_panel_at_root_depth() {
+        let layout = DashboardLayout::flat(3);
+
+        assert_eq!(layout.visible_panel_count(), 3);
+        assert_eq!(
+            layout.visible_items(),
+            vec![
+                VisibleDashboardItem::panel(0, 0),
+                VisibleDashboardItem::panel(1, 0),
+                VisibleDashboardItem::panel(2, 0),
+            ]
+        );
+        assert_eq!(layout.first_visible(), Some(DashboardItemId::Panel(0)));
+    }
+
+    #[test]
+    fn toggling_a_collapsed_row_reveals_panels_in_source_order() {
+        let row = DashboardRow::new(
+            RowId::new(1),
+            "Collapsed",
+            true,
+            false,
+            vec![DashboardLayoutItem::Panel(3), DashboardLayoutItem::Panel(1)],
+        );
+        let mut layout = DashboardLayout::new(vec![DashboardLayoutItem::Row(row)]);
+
+        let change = layout.toggle_row(RowId::new(1)).unwrap();
+
+        assert_eq!(change.newly_visible_panels, vec![3, 1]);
+        assert_eq!(layout.visible_panel_indices(), vec![3, 1]);
+    }
+
+    #[test]
+    fn unknown_rows_do_not_change_the_layout() {
+        let mut layout = DashboardLayout::flat(1);
+
+        assert_eq!(layout.set_row_collapsed(RowId::new(99), true), None);
+        assert_eq!(layout.toggle_row(RowId::new(99)), None);
+        assert_eq!(layout.visible_panel_indices(), vec![0]);
+    }
+
+    #[test]
+    fn nearest_visible_ancestor_prefers_the_target_then_visible_rows_then_first_item() {
+        let collapsed_child = DashboardRow::new(
+            RowId::new(2),
+            "Child",
+            true,
+            false,
+            vec![DashboardLayoutItem::Panel(2)],
+        );
+        let parent = DashboardRow::new(
+            RowId::new(1),
+            "Parent",
+            false,
+            false,
+            vec![DashboardLayoutItem::Row(collapsed_child)],
+        );
+        let layout = DashboardLayout::new(vec![
+            DashboardLayoutItem::Panel(0),
+            DashboardLayoutItem::Row(parent),
+        ]);
+
+        assert_eq!(
+            layout.nearest_visible_ancestor(DashboardItemId::Panel(0)),
+            Some(DashboardItemId::Panel(0))
+        );
+        assert_eq!(
+            layout.nearest_visible_ancestor(DashboardItemId::Panel(2)),
+            Some(DashboardItemId::Row(RowId::new(2)))
+        );
+        assert_eq!(
+            layout.nearest_visible_ancestor(DashboardItemId::Panel(99)),
+            Some(DashboardItemId::Panel(0))
+        );
+    }
+}

--- a/src/export.rs
+++ b/src/export.rs
@@ -294,13 +294,30 @@ pub(crate) fn render_svg(app: &AppState, viewport: Rect) -> String {
     .unwrap();
     render_header(app, &mut out, width, &text, &border);
 
-    for (rect, index) in ui::visible_panel_rects(viewport, app) {
-        let Some(panel) = app.panels.get(index) else {
-            continue;
-        };
-        let selected = Some(index) == app.selected_panel_index();
-        let panel_rect = scaled_rect(rect);
-        render_panel(app, index, panel, panel_rect, selected, &mut out);
+    for item in ui::visible_dashboard_rects(viewport, app) {
+        let selected = app.selected_item == Some(item.id);
+        match item.kind {
+            ui::DashboardRectKind::Panel { index } => {
+                let Some(panel) = app.panels.get(index) else {
+                    continue;
+                };
+                let panel_rect = scaled_rect(item.rect);
+                render_panel(app, index, panel, panel_rect, selected, &mut out);
+            }
+            ui::DashboardRectKind::Row {
+                row_id,
+                depth,
+                collapsed,
+            } => render_row_header(
+                app,
+                row_id,
+                depth,
+                collapsed,
+                scaled_rect(item.rect),
+                selected,
+                &mut out,
+            ),
+        }
     }
 
     render_footer(app, &mut out, width, height, &text, &border);
@@ -320,9 +337,63 @@ fn render_header(app: &AppState, out: &mut String, width: f64, text: &str, borde
         app.title,
         humantime::format_duration(app.range),
         humantime::format_duration(app.step),
-        app.panels.len()
+        displayed_panel_count(app)
     );
     write_text(out, width / 2.0, 31.0, &title, text, "middle", FONT_SIZE);
+}
+
+fn displayed_panel_count(app: &AppState) -> String {
+    let total = app.panels.len();
+    let visible = if app
+        .layout
+        .items
+        .iter()
+        .all(|item| matches!(item, crate::dashboard::DashboardLayoutItem::Panel(_)))
+    {
+        total
+    } else {
+        app.layout.visible_panel_count()
+    };
+    if visible == total {
+        total.to_string()
+    } else {
+        format!("{visible}/{total}")
+    }
+}
+
+fn render_row_header(
+    app: &AppState,
+    row_id: crate::dashboard::RowId,
+    depth: usize,
+    collapsed: bool,
+    rect: PlotRect,
+    selected: bool,
+    out: &mut String,
+) {
+    let Some(row) = app.layout.row(row_id) else {
+        return;
+    };
+    let color = color_hex(
+        if selected {
+            app.theme.border_selected
+        } else {
+            app.theme.border
+        },
+        "#555555",
+    );
+    let marker = if collapsed { '▶' } else { '▼' };
+    let title = format!("{marker} {}{}", "  ".repeat(depth), row.title);
+    write_rect(out, rect, "none", &color, if selected { 2.0 } else { 1.0 });
+    write_styled_text(
+        out,
+        rect.left + 4.0,
+        rect.top + (rect.height * 0.75),
+        &title,
+        &color,
+        "start",
+        FONT_SIZE,
+        selected,
+    );
 }
 
 fn render_footer(
@@ -1483,6 +1554,26 @@ fn write_text(out: &mut String, x: f64, y: f64, text: &str, color: &str, anchor:
     .unwrap();
 }
 
+#[allow(clippy::too_many_arguments)]
+fn write_styled_text(
+    out: &mut String,
+    x: f64,
+    y: f64,
+    text: &str,
+    color: &str,
+    anchor: &str,
+    size: f64,
+    bold: bool,
+) {
+    let weight = if bold { r#" font-weight="bold""# } else { "" };
+    write!(
+        out,
+        r#"<text x="{x:.2}" y="{y:.2}" fill="{color}" font-size="{size:.1}" text-anchor="{anchor}"{weight}>{}</text>"#,
+        escape_xml(text)
+    )
+    .unwrap();
+}
+
 fn write_rect(out: &mut String, rect: PlotRect, fill: &str, stroke: &str, stroke_width: f64) {
     write!(
         out,
@@ -1657,6 +1748,9 @@ mod tests {
         GraphAxisPlacement, GraphDrawStyle, GraphOptions, GraphPointMode, GraphStackingMode,
         PanelOptions, PanelState, SeriesView, YAxisMode,
     };
+    use crate::dashboard::{
+        DashboardItemId, DashboardLayout, DashboardLayoutItem, DashboardRow, RowId,
+    };
 
     fn test_panel(start: f64) -> PanelState {
         PanelState {
@@ -1714,6 +1808,35 @@ mod tests {
     fn test_app_with_panel_type(panel_type: PanelType) -> AppState {
         let mut app = test_app(ExportOptions::default());
         app.panels[0].panel_type = panel_type;
+        app
+    }
+
+    fn nested_row_export_app() -> AppState {
+        let mut app = test_app(ExportOptions {
+            dir: test_export_dir("nested-row"),
+            format: ExportFormat::Svg,
+            record_max_frames: 10,
+        });
+        app.panels.push(test_panel(app.view_end_ts as f64 - 100.0));
+        app.panels[0].title = "Visible child".to_string();
+        app.panels[1].title = "Collapsed child".to_string();
+        app.layout = DashboardLayout::new(vec![DashboardLayoutItem::Row(DashboardRow::new(
+            RowId::new(0),
+            "Expanded",
+            false,
+            false,
+            vec![
+                DashboardLayoutItem::Panel(0),
+                DashboardLayoutItem::Row(DashboardRow::new(
+                    RowId::new(1),
+                    "Nested",
+                    true,
+                    false,
+                    vec![DashboardLayoutItem::Panel(1)],
+                )),
+            ],
+        ))]);
+        app.selected_item = Some(DashboardItemId::Row(RowId::new(0)));
         app
     }
 
@@ -1841,6 +1964,89 @@ mod tests {
         assert!(svg.contains("CPU &lt;main&gt;"));
         assert!(svg.contains("<line "));
         assert!(svg.contains("<path "));
+    }
+
+    #[test]
+    fn svg_renders_rows_and_omits_collapsed_descendants() {
+        let app = nested_row_export_app();
+
+        let svg = render_svg(&app, Rect::new(0, 0, 100, 40));
+
+        assert!(svg.contains("▼ Expanded"));
+        assert!(svg.contains("▶   Nested"));
+        assert!(svg.contains("Visible child"));
+        assert!(!svg.contains("Collapsed child"));
+    }
+
+    #[test]
+    fn svg_selected_row_uses_theme_style_and_escapes_title() {
+        let mut app = nested_row_export_app();
+        app.layout = DashboardLayout::new(vec![DashboardLayoutItem::Row(DashboardRow::new(
+            RowId::new(0),
+            "Expanded <&>",
+            false,
+            false,
+            vec![DashboardLayoutItem::Panel(0)],
+        ))]);
+
+        let svg = render_svg(&app, Rect::new(0, 0, 100, 40));
+
+        assert!(svg.contains("▼ Expanded &lt;&amp;&gt;"));
+        assert!(svg.contains(r##"stroke="#d6c343" stroke-width="2.00""##));
+        assert!(svg.contains(r#"font-weight="bold""#));
+        assert!(svg.contains("panels=1/2"));
+    }
+
+    #[test]
+    fn svg_keeps_hidden_header_rows_transparent() {
+        let mut app = nested_row_export_app();
+        app.layout = DashboardLayout::new(vec![DashboardLayoutItem::Row(DashboardRow::new(
+            RowId::new(0),
+            "Hidden row",
+            true,
+            true,
+            vec![DashboardLayoutItem::Panel(0)],
+        ))]);
+
+        let svg = render_svg(&app, Rect::new(0, 0, 100, 40));
+
+        assert!(svg.contains("Visible child"));
+        assert!(!svg.contains("Hidden row"));
+        assert!(svg.contains("panels=1/2"));
+    }
+
+    #[test]
+    fn toggling_a_header_only_row_changes_the_recorded_frame() {
+        let mut app = test_app(ExportOptions {
+            dir: test_export_dir("header-only-row-recording"),
+            format: ExportFormat::Svg,
+            record_max_frames: 10,
+        });
+        app.layout = DashboardLayout::new(vec![DashboardLayoutItem::Row(DashboardRow::new(
+            RowId::new(0),
+            "Header only",
+            false,
+            false,
+            vec![],
+        ))]);
+        app.selected_item = Some(DashboardItemId::Row(RowId::new(0)));
+        start_recording(&mut app, Rect::new(0, 0, 100, 40)).unwrap();
+        let expanded_svg = app.recording.as_ref().unwrap().last_svg.clone().unwrap();
+
+        app.layout.set_row_collapsed(RowId::new(0), true).unwrap();
+        capture_recording_frame(&mut app, Rect::new(0, 0, 100, 40)).unwrap();
+
+        let recording = app.recording.as_ref().unwrap();
+        assert!(expanded_svg.contains("▼ Header only"));
+        assert!(
+            recording
+                .last_svg
+                .as_deref()
+                .unwrap()
+                .contains("▶ Header only")
+        );
+        assert_ne!(recording.last_svg.as_deref().unwrap(), expanded_svg);
+        assert_eq!(recording.frame_count, 2);
     }
 
     #[test]

--- a/src/export.rs
+++ b/src/export.rs
@@ -298,7 +298,7 @@ pub(crate) fn render_svg(app: &AppState, viewport: Rect) -> String {
         let Some(panel) = app.panels.get(index) else {
             continue;
         };
-        let selected = index == app.selected_panel;
+        let selected = Some(index) == app.selected_panel_index();
         let panel_rect = scaled_rect(rect);
         render_panel(app, index, panel, panel_rect, selected, &mut out);
     }

--- a/src/grafana.rs
+++ b/src/grafana.rs
@@ -553,6 +553,57 @@ mod tests {
     }
 
     #[test]
+    fn classic_rows_group_expanded_siblings_and_collapsed_nested_panels() {
+        let dashboard =
+            parse_grafana_dashboard(include_str!("../tests/fixtures/grafana/classic_rows.json"))
+                .unwrap();
+
+        assert_eq!(dashboard.queries.len(), 2);
+        assert_eq!(dashboard.layout.visible_panel_indices(), vec![0]);
+        let visible = dashboard.layout.visible_items();
+        assert_eq!(
+            visible[0].id,
+            crate::dashboard::DashboardItemId::Row(crate::dashboard::RowId::new(0))
+        );
+        assert_eq!(
+            visible[2].id,
+            crate::dashboard::DashboardItemId::Row(crate::dashboard::RowId::new(1))
+        );
+    }
+
+    #[test]
+    fn classic_rows_make_child_grid_y_relative_to_each_row() {
+        let dashboard = parse_grafana_dashboard(
+            r#"{
+                "panels": [{
+                    "type": "row", "title": "Outer", "collapsed": true,
+                    "gridPos": {"x": 0, "y": 10, "w": 24, "h": 2},
+                    "panels": [
+                        {
+                            "type": "timeseries", "title": "Direct child",
+                            "gridPos": {"x": 0, "y": 13, "w": 24, "h": 8},
+                            "targets": [{"expr": "up"}]
+                        },
+                        {
+                            "type": "row", "title": "Nested", "collapsed": true,
+                            "gridPos": {"x": 0, "y": 20, "w": 24, "h": 3},
+                            "panels": [{
+                                "type": "stat", "title": "Nested child",
+                                "gridPos": {"x": 0, "y": 25, "w": 24, "h": 6},
+                                "targets": [{"expr": "sum(up)"}]
+                            }]
+                        }
+                    ]
+                }]
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(dashboard.queries[0].grid.unwrap().y, 1);
+        assert_eq!(dashboard.queries[1].grid.unwrap().y, 2);
+    }
+
+    #[test]
     fn v2_rows_hidden_header_is_transparent_even_when_collapsed() {
         let mut json = valid_v2_resource();
         make_v2_panel_importable(&mut json);

--- a/src/grafana.rs
+++ b/src/grafana.rs
@@ -31,6 +31,8 @@ pub(crate) struct DashboardImport {
     pub(crate) title: String,
     /// List of panels extracted.
     pub(crate) queries: Vec<QueryPanel>,
+    /// Recursive layout of panels and rows.
+    pub(crate) layout: crate::dashboard::DashboardLayout,
     /// Variables extracted from `templating.list`.
     pub(crate) vars: HashMap<String, String>,
     /// Dynamic query variables extracted from `templating.list`.
@@ -314,6 +316,51 @@ fn is_variable_name_char(ch: char) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn test_model_panel(kind: &str, expr: Option<&str>) -> model::LayoutNode {
+        model::LayoutNode::Panel(model::Panel {
+            kind: kind.into(),
+            title: kind.into(),
+            source_path: format!("layout.{kind}"),
+            targets: expr
+                .into_iter()
+                .map(|expr| model::Target {
+                    expr: Some(expr.into()),
+                    expr_path: format!("layout.{kind}.expr"),
+                    legend_format: None,
+                    instant: None,
+                    hidden: false,
+                })
+                .collect(),
+            count_as_skipped_if_empty: false,
+            grid: None,
+            field_defaults: None,
+            reduce_options_path: None,
+            transformations_path: None,
+        })
+    }
+
+    #[test]
+    fn normalized_layout_references_only_imported_panel_indices() {
+        let dashboard = model::Dashboard {
+            title: "Rows".into(),
+            layout: vec![model::LayoutNode::Row(model::Row {
+                title: "Group".into(),
+                collapsed: false,
+                hidden_header: false,
+                source_path: "layout.row".into(),
+                children: vec![
+                    test_model_panel("piechart", None),
+                    test_model_panel("timeseries", Some("up")),
+                ],
+            })],
+            ..model::Dashboard::default()
+        };
+        let imported = import::finish(dashboard).unwrap();
+        assert_eq!(imported.queries.len(), 1);
+        assert_eq!(imported.layout.visible_panel_indices(), vec![0]);
+        assert_eq!(imported.skipped_panels, 1);
+    }
 
     fn minimal_v2_with_layout(layout: serde_json::Value) -> serde_json::Value {
         serde_json::json!({

--- a/src/grafana.rs
+++ b/src/grafana.rs
@@ -406,6 +406,40 @@ mod tests {
         })
     }
 
+    fn v2_row_resource_with_field(field: &str, value: serde_json::Value) -> serde_json::Value {
+        let mut json = valid_v2_resource();
+        let mut row_spec = serde_json::json!({
+            "title": "Row",
+            "layout": {"kind": "GridLayout", "spec": {"items": []}}
+        });
+        row_spec
+            .as_object_mut()
+            .unwrap()
+            .insert(field.into(), value);
+        json["spec"]["layout"] = serde_json::json!({
+            "kind": "RowsLayout",
+            "spec": {
+                "rows": [{"kind": "RowsLayoutRow", "spec": row_spec}]
+            }
+        });
+        json
+    }
+
+    fn make_v2_panel_importable(json: &mut serde_json::Value) {
+        json["spec"]["elements"]["panel-1"]["spec"]["data"]["spec"]["queries"] = serde_json::json!([{
+            "kind": "PanelQuery",
+            "spec": {
+                "hidden": false,
+                "refId": "A",
+                "query": {
+                    "kind": "DataQuery",
+                    "group": "prometheus",
+                    "spec": {"expr": "up"}
+                }
+            }
+        }]);
+    }
+
     #[test]
     fn v2_fixed_grid_panel_matches_classic_semantics() {
         let classic = parse_grafana_dashboard(include_str!(
@@ -497,14 +531,222 @@ mod tests {
 
     #[test]
     fn rejects_unsupported_v2_layouts() {
-        for kind in ["RowsLayout", "TabsLayout", "AutoGridLayout"] {
+        for kind in ["TabsLayout", "AutoGridLayout"] {
             let json = minimal_v2_with_layout(serde_json::json!({"kind": kind, "spec": {}}));
             let error = parse_grafana_dashboard(&json.to_string())
                 .unwrap_err()
                 .to_string();
             assert!(error.contains(kind));
             assert!(error.contains("spec.layout.kind"));
-            assert!(error.contains("GridLayout"));
+        }
+    }
+
+    #[test]
+    fn v2_rows_import_expanded_collapsed_and_nested_content() {
+        let dashboard = parse_grafana_dashboard(include_str!(
+            "../tests/fixtures/grafana/v2_rows_layout.json"
+        ))
+        .unwrap();
+
+        assert_eq!(dashboard.queries.len(), 3);
+        assert_eq!(dashboard.layout.visible_panel_indices(), vec![0]);
+    }
+
+    #[test]
+    fn v2_rows_hidden_header_is_transparent_even_when_collapsed() {
+        let mut json = valid_v2_resource();
+        make_v2_panel_importable(&mut json);
+        let grid = json["spec"]["layout"].clone();
+        json["spec"]["layout"] = serde_json::json!({
+            "kind": "RowsLayout",
+            "spec": {"rows": [{
+                "kind": "RowsLayoutRow",
+                "spec": {
+                    "title": "Hidden",
+                    "collapse": true,
+                    "hideHeader": true,
+                    "layout": grid
+                }
+            }]}
+        });
+
+        let dashboard = parse_grafana_dashboard(&json.to_string()).unwrap();
+
+        assert_eq!(dashboard.queries.len(), 1);
+        assert_eq!(dashboard.layout.visible_panel_indices(), vec![0]);
+        assert_eq!(dashboard.layout.visible_items().len(), 1);
+    }
+
+    #[test]
+    fn v2_rows_reject_deferred_semantics_at_native_paths() {
+        for (field, value) in [
+            (
+                "repeat",
+                serde_json::json!({"mode": "variable", "value": "job"}),
+            ),
+            (
+                "conditionalRendering",
+                serde_json::json!({"kind": "ConditionalRenderingGroup", "spec": {}}),
+            ),
+            (
+                "variables",
+                serde_json::json!([{"kind": "TextVariable", "spec": {"name": "x"}}]),
+            ),
+            ("fillScreen", serde_json::json!(true)),
+        ] {
+            let error =
+                parse_grafana_dashboard(&v2_row_resource_with_field(field, value).to_string())
+                    .unwrap_err()
+                    .to_string();
+            assert!(
+                error.contains(&format!("spec.layout.spec.rows[0].spec.{field}")),
+                "unexpected error for {field}: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn v2_rows_default_absent_title_to_empty_string() {
+        let mut json = valid_v2_resource();
+        let grid = json["spec"]["layout"].clone();
+        json["spec"]["layout"] = serde_json::json!({
+            "kind": "RowsLayout",
+            "spec": {"rows": [{
+                "kind": "RowsLayoutRow",
+                "spec": {"layout": grid}
+            }]}
+        });
+
+        let dashboard = parse_grafana_dashboard(&json.to_string()).unwrap();
+
+        assert_eq!(
+            dashboard
+                .layout
+                .row(crate::dashboard::RowId::new(0))
+                .unwrap()
+                .title,
+            ""
+        );
+    }
+
+    #[test]
+    fn v2_rows_default_absent_collapse_and_hide_header_to_false() {
+        let mut json = valid_v2_resource();
+        make_v2_panel_importable(&mut json);
+        let grid = json["spec"]["layout"].clone();
+        json["spec"]["layout"] = serde_json::json!({
+            "kind": "RowsLayout",
+            "spec": {"rows": [{
+                "kind": "RowsLayoutRow",
+                "spec": {"title": "Defaults", "layout": grid}
+            }]}
+        });
+
+        let dashboard = parse_grafana_dashboard(&json.to_string()).unwrap();
+        let row = dashboard
+            .layout
+            .row(crate::dashboard::RowId::new(0))
+            .unwrap();
+
+        assert!(!row.collapsed);
+        assert!(!row.hidden_header);
+        assert_eq!(dashboard.layout.visible_panel_indices(), vec![0]);
+        assert_eq!(
+            dashboard
+                .layout
+                .visible_items()
+                .into_iter()
+                .map(|item| item.id)
+                .collect::<Vec<_>>(),
+            vec![
+                crate::dashboard::DashboardItemId::Row(crate::dashboard::RowId::new(0)),
+                crate::dashboard::DashboardItemId::Panel(0),
+            ]
+        );
+    }
+
+    #[test]
+    fn v2_rows_accept_empty_deferred_fields() {
+        for (field, value) in [
+            ("variables", serde_json::json!([])),
+            ("fillScreen", serde_json::json!(false)),
+        ] {
+            let dashboard =
+                parse_grafana_dashboard(&v2_row_resource_with_field(field, value).to_string())
+                    .unwrap();
+            assert!(dashboard.layout.visible_panel_indices().is_empty());
+        }
+    }
+
+    #[test]
+    fn v2_rows_reject_malformed_rows_at_native_paths() {
+        let cases = [
+            (
+                serde_json::json!({"kind": "RowsLayout", "spec": {"rows": {}}}),
+                "spec.layout.spec.rows",
+            ),
+            (
+                serde_json::json!({"kind": "RowsLayout", "spec": {"rows": [null]}}),
+                "spec.layout.spec.rows[0]",
+            ),
+            (
+                serde_json::json!({"kind": "RowsLayout", "spec": {"rows": [{"kind": "GridLayoutItem", "spec": {}}]}}),
+                "spec.layout.spec.rows[0].kind",
+            ),
+            (
+                serde_json::json!({"kind": "RowsLayout", "spec": {"rows": [{"kind": "RowsLayoutRow", "spec": []}]}}),
+                "spec.layout.spec.rows[0].spec",
+            ),
+            (
+                serde_json::json!({"kind": "RowsLayout", "spec": {"rows": [{"kind": "RowsLayoutRow", "spec": {"title": 7, "layout": {"kind": "GridLayout", "spec": {"items": []}}}}]}}),
+                "spec.layout.spec.rows[0].spec.title",
+            ),
+            (
+                serde_json::json!({"kind": "RowsLayout", "spec": {"rows": [{"kind": "RowsLayoutRow", "spec": {"title": "Row", "layout": []}}]}}),
+                "spec.layout.spec.rows[0].spec.layout",
+            ),
+        ];
+
+        for (layout, expected_path) in cases {
+            let json = minimal_v2_with_layout(layout);
+            let error = parse_grafana_dashboard(&json.to_string())
+                .unwrap_err()
+                .to_string();
+            assert!(
+                error.contains(expected_path),
+                "expected {expected_path}, got {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn v2_rows_reject_non_boolean_options_at_native_paths() {
+        for field in ["collapse", "hideHeader", "fillScreen"] {
+            let error = parse_grafana_dashboard(
+                &v2_row_resource_with_field(field, serde_json::json!("false")).to_string(),
+            )
+            .unwrap_err()
+            .to_string();
+            assert!(
+                error.contains(&format!("spec.layout.spec.rows[0].spec.{field}")),
+                "unexpected error for {field}: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn v2_rows_reject_nested_unsupported_layouts_at_native_paths() {
+        for kind in ["TabsLayout", "AutoGridLayout"] {
+            let json =
+                v2_row_resource_with_field("layout", serde_json::json!({"kind": kind, "spec": {}}));
+            let error = parse_grafana_dashboard(&json.to_string())
+                .unwrap_err()
+                .to_string();
+            assert!(error.contains(kind));
+            assert!(
+                error.contains("spec.layout.spec.rows[0].spec.layout.kind"),
+                "unexpected error for {kind}: {error}"
+            );
         }
     }
 

--- a/src/grafana/classic.rs
+++ b/src/grafana/classic.rs
@@ -160,7 +160,7 @@ pub(super) fn adapt(value: Value) -> Result<model::Dashboard> {
     normalize_panels(
         raw.panels.unwrap_or_default(),
         "panels",
-        &mut dashboard.panels,
+        &mut dashboard.layout,
     );
     Ok(dashboard)
 }
@@ -199,7 +199,7 @@ impl RawVar {
     }
 }
 
-fn normalize_panels(panels: Vec<RawPanel>, path: &str, out: &mut Vec<model::Panel>) {
+fn normalize_panels(panels: Vec<RawPanel>, path: &str, out: &mut Vec<model::LayoutNode>) {
     for (index, panel) in panels.into_iter().enumerate() {
         let source_path = format!("{path}[{index}]");
         if let Some(children) = panel.panels {
@@ -242,7 +242,7 @@ fn normalize_panels(panels: Vec<RawPanel>, path: &str, out: &mut Vec<model::Pane
                     .then(|| format!("{source_path}.fieldConfig.defaults.mappings")),
             })
         });
-        out.push(model::Panel {
+        out.push(model::LayoutNode::Panel(model::Panel {
             kind: panel.panel_type,
             title: panel.title.unwrap_or_default(),
             source_path: source_path.clone(),
@@ -273,7 +273,7 @@ fn normalize_panels(panels: Vec<RawPanel>, path: &str, out: &mut Vec<model::Pane
                 .is_some()
                 .then(|| format!("{source_path}.options.reduceOptions")),
             transformations_path: None,
-        });
+        }));
     }
 }
 

--- a/src/grafana/classic.rs
+++ b/src/grafana/classic.rs
@@ -48,6 +48,7 @@ struct RawPanel {
     #[serde(rename = "type")]
     panel_type: String,
     title: Option<String>,
+    collapsed: Option<bool>,
     targets: Option<Vec<RawTarget>>,
     #[serde(rename = "gridPos")]
     grid_pos: Option<RawGridPos>,
@@ -157,11 +158,7 @@ pub(super) fn adapt(value: Value) -> Result<model::Dashboard> {
         .enumerate()
         .map(|(index, variable)| variable.normalize(index))
         .collect();
-    normalize_panels(
-        raw.panels.unwrap_or_default(),
-        "panels",
-        &mut dashboard.layout,
-    );
+    dashboard.layout = normalize_layout(raw.panels.unwrap_or_default(), "panels");
     Ok(dashboard)
 }
 
@@ -199,82 +196,158 @@ impl RawVar {
     }
 }
 
-fn normalize_panels(panels: Vec<RawPanel>, path: &str, out: &mut Vec<model::LayoutNode>) {
+fn normalize_layout(panels: Vec<RawPanel>, path: &str) -> Vec<model::LayoutNode> {
+    let mut output = Vec::new();
+    let mut expanded_row = None;
+
     for (index, panel) in panels.into_iter().enumerate() {
         let source_path = format!("{path}[{index}]");
-        if let Some(children) = panel.panels {
-            normalize_panels(children, &format!("{source_path}.panels"), out);
-        }
+        if panel.panel_type == "row" {
+            if let Some((row, _)) = expanded_row.take() {
+                output.push(model::LayoutNode::Row(row));
+            }
 
-        let field_defaults = panel.field_config.and_then(|config| {
-            config.defaults.map(|defaults| model::FieldDefaults {
-                unit: defaults.unit,
-                decimals: defaults.decimals,
-                no_value: defaults.no_value,
-                min: defaults.min,
-                max: defaults.max,
-                thresholds: defaults.thresholds.map(|thresholds| model::Thresholds {
-                    mode: thresholds.mode,
-                    steps: thresholds
-                        .steps
-                        .unwrap_or_default()
-                        .into_iter()
-                        .map(|step| model::ThresholdStep {
-                            value: step.value,
-                            color: step.color,
-                        })
-                        .collect(),
-                }),
-                custom: defaults.custom.map(|custom| model::GraphCustom {
-                    draw_style: custom.draw_style,
-                    show_points: custom.show_points,
-                    fill_opacity: custom.fill_opacity,
-                    axis_placement: custom.axis_placement,
-                    line_interpolation: custom.line_interpolation,
-                    stacking_mode: custom.stacking.and_then(|stacking| stacking.mode),
-                    axis_grid_show: custom.axis_grid_show,
-                    thresholds_style_mode: custom.thresholds_style.and_then(|style| style.mode),
-                }),
-                mappings_path: defaults
-                    .mappings
-                    .as_ref()
-                    .is_some_and(non_empty_json_value)
-                    .then(|| format!("{source_path}.fieldConfig.defaults.mappings")),
-            })
-        });
-        out.push(model::LayoutNode::Panel(model::Panel {
-            kind: panel.panel_type,
-            title: panel.title.unwrap_or_default(),
-            source_path: source_path.clone(),
-            targets: panel
-                .targets
-                .unwrap_or_default()
-                .into_iter()
-                .enumerate()
-                .map(|(index, target)| model::Target {
-                    expr: target.expr,
-                    expr_path: format!("{source_path}.targets[{index}].expr"),
-                    legend_format: target.legend_format,
-                    instant: target.instant,
-                    hidden: target.hide == Some(true),
-                })
-                .collect(),
-            count_as_skipped_if_empty: false,
-            grid: panel.grid_pos.map(|grid| model::GridPos {
-                x: grid.x,
-                y: grid.y,
-                w: grid.w,
-                h: grid.h,
-            }),
-            field_defaults,
-            reduce_options_path: panel
-                .options
-                .and_then(|options| options.reduce_options)
-                .is_some()
-                .then(|| format!("{source_path}.options.reduceOptions")),
-            transformations_path: None,
-        }));
+            let collapsed = panel.collapsed.unwrap_or(false);
+            let (row, row_base_y) = normalize_classic_row(panel, source_path, collapsed);
+            if collapsed {
+                output.push(model::LayoutNode::Row(row));
+            } else {
+                expanded_row = Some((row, row_base_y));
+            }
+        } else if let Some((row, row_base_y)) = expanded_row.as_mut() {
+            row.children.push(normalize_classic_panel(
+                panel,
+                source_path,
+                Some(*row_base_y),
+            ));
+        } else {
+            output.push(normalize_classic_panel(panel, source_path, None));
+        }
     }
+
+    if let Some((row, _)) = expanded_row {
+        output.push(model::LayoutNode::Row(row));
+    }
+
+    output
+}
+
+fn normalize_classic_row(
+    panel: RawPanel,
+    source_path: String,
+    collapsed: bool,
+) -> (model::Row, i32) {
+    let row_base_y = panel
+        .grid_pos
+        .as_ref()
+        .map_or(0, |grid| grid.y.saturating_add(grid.h));
+    let children = normalize_layout(
+        panel.panels.unwrap_or_default(),
+        &format!("{source_path}.panels"),
+    )
+    .into_iter()
+    .map(|node| normalize_child_y(node, row_base_y))
+    .collect();
+
+    (
+        model::Row {
+            title: panel.title.unwrap_or_default(),
+            collapsed,
+            hidden_header: false,
+            source_path,
+            children,
+        },
+        row_base_y,
+    )
+}
+
+fn normalize_child_y(node: model::LayoutNode, row_base_y: i32) -> model::LayoutNode {
+    match node {
+        model::LayoutNode::Panel(mut panel) => {
+            if let Some(grid) = panel.grid.as_mut() {
+                grid.y = grid.y.saturating_sub(row_base_y).max(0);
+            }
+            model::LayoutNode::Panel(panel)
+        }
+        model::LayoutNode::Row(row) => model::LayoutNode::Row(row),
+    }
+}
+
+fn normalize_classic_panel(
+    panel: RawPanel,
+    source_path: String,
+    row_base_y: Option<i32>,
+) -> model::LayoutNode {
+    let field_defaults = panel.field_config.and_then(|config| {
+        config.defaults.map(|defaults| model::FieldDefaults {
+            unit: defaults.unit,
+            decimals: defaults.decimals,
+            no_value: defaults.no_value,
+            min: defaults.min,
+            max: defaults.max,
+            thresholds: defaults.thresholds.map(|thresholds| model::Thresholds {
+                mode: thresholds.mode,
+                steps: thresholds
+                    .steps
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|step| model::ThresholdStep {
+                        value: step.value,
+                        color: step.color,
+                    })
+                    .collect(),
+            }),
+            custom: defaults.custom.map(|custom| model::GraphCustom {
+                draw_style: custom.draw_style,
+                show_points: custom.show_points,
+                fill_opacity: custom.fill_opacity,
+                axis_placement: custom.axis_placement,
+                line_interpolation: custom.line_interpolation,
+                stacking_mode: custom.stacking.and_then(|stacking| stacking.mode),
+                axis_grid_show: custom.axis_grid_show,
+                thresholds_style_mode: custom.thresholds_style.and_then(|style| style.mode),
+            }),
+            mappings_path: defaults
+                .mappings
+                .as_ref()
+                .is_some_and(non_empty_json_value)
+                .then(|| format!("{source_path}.fieldConfig.defaults.mappings")),
+        })
+    });
+    model::LayoutNode::Panel(model::Panel {
+        kind: panel.panel_type,
+        title: panel.title.unwrap_or_default(),
+        source_path: source_path.clone(),
+        targets: panel
+            .targets
+            .unwrap_or_default()
+            .into_iter()
+            .enumerate()
+            .map(|(index, target)| model::Target {
+                expr: target.expr,
+                expr_path: format!("{source_path}.targets[{index}].expr"),
+                legend_format: target.legend_format,
+                instant: target.instant,
+                hidden: target.hide == Some(true),
+            })
+            .collect(),
+        count_as_skipped_if_empty: false,
+        grid: panel.grid_pos.map(|grid| model::GridPos {
+            x: grid.x,
+            y: row_base_y
+                .map(|base| grid.y.saturating_sub(base).max(0))
+                .unwrap_or(grid.y),
+            w: grid.w,
+            h: grid.h,
+        }),
+        field_defaults,
+        reduce_options_path: panel
+            .options
+            .and_then(|options| options.reduce_options)
+            .is_some()
+            .then(|| format!("{source_path}.options.reduceOptions")),
+        transformations_path: None,
+    })
 }
 
 fn non_empty_json_value(value: &Value) -> bool {

--- a/src/grafana/import.rs
+++ b/src/grafana/import.rs
@@ -3,15 +3,28 @@ use anyhow::Result;
 use super::{DashboardImport, GridPos, ImportDiagnostic, QueryPanel, TemplateQueryVar, model};
 
 pub(super) fn finish(dashboard: model::Dashboard) -> Result<DashboardImport> {
+    let model::Dashboard {
+        title,
+        refresh,
+        variables,
+        layout,
+        skipped_panels,
+        diagnostics,
+    } = dashboard;
     let mut out = DashboardImport {
-        title: dashboard.title,
-        refresh_rate_ms: dashboard.refresh.as_deref().and_then(parse_refresh_rate_ms),
-        skipped_panels: dashboard.skipped_panels,
-        diagnostics: dashboard.diagnostics,
+        title,
+        refresh_rate_ms: refresh.as_deref().and_then(parse_refresh_rate_ms),
+        skipped_panels,
+        diagnostics,
         ..DashboardImport::default()
     };
-    import_variables(&mut out, dashboard.variables);
-    import_panels(&mut out, dashboard.panels)?;
+    import_variables(&mut out, variables);
+    let mut next_row_id = 0;
+    out.layout = crate::dashboard::DashboardLayout::new(import_layout_nodes(
+        layout,
+        &mut out,
+        &mut next_row_id,
+    )?);
     Ok(out)
 }
 
@@ -79,125 +92,159 @@ fn value_is_all(value: Option<&serde_json::Value>) -> bool {
     }
 }
 
-fn import_panels(out: &mut DashboardImport, panels: Vec<model::Panel>) -> Result<()> {
-    for panel in panels {
-        let panel_type = match panel.kind.as_str() {
-            "graph" | "timeseries" => crate::app::PanelType::Graph,
-            "stat" => crate::app::PanelType::Stat,
-            "gauge" => crate::app::PanelType::Gauge,
-            "bargauge" => crate::app::PanelType::BarGauge,
-            "table" => crate::app::PanelType::Table,
-            "heatmap" => crate::app::PanelType::Heatmap,
-            _ => crate::app::PanelType::Unknown,
-        };
+fn import_panel(panel: model::Panel, out: &mut DashboardImport) -> Result<Option<usize>> {
+    let panel_type = match panel.kind.as_str() {
+        "graph" | "timeseries" => crate::app::PanelType::Graph,
+        "stat" => crate::app::PanelType::Stat,
+        "gauge" => crate::app::PanelType::Gauge,
+        "bargauge" => crate::app::PanelType::BarGauge,
+        "table" => crate::app::PanelType::Table,
+        "heatmap" => crate::app::PanelType::Heatmap,
+        _ => crate::app::PanelType::Unknown,
+    };
 
-        if panel_type == crate::app::PanelType::Unknown {
-            if !panel.kind.is_empty() && panel.kind != "row" {
-                out.skipped_panels += 1;
-                out.diagnostics.push(ImportDiagnostic::new(
-                    "skipped_panel",
-                    panel.source_path,
-                    format!(
-                        "unsupported panel type `{}` skipped for panel `{}`",
-                        panel.kind, panel.title
-                    ),
-                ));
-            }
+    if panel_type == crate::app::PanelType::Unknown {
+        if !panel.kind.is_empty() && panel.kind != "row" {
+            out.skipped_panels += 1;
+            out.diagnostics.push(ImportDiagnostic::new(
+                "skipped_panel",
+                panel.source_path,
+                format!(
+                    "unsupported panel type `{}` skipped for panel `{}`",
+                    panel.kind, panel.title
+                ),
+            ));
+        }
+        return Ok(None);
+    }
+
+    let mut exprs = Vec::new();
+    let mut expr_paths = Vec::new();
+    let mut legends = Vec::new();
+    let mut query_modes = Vec::new();
+    for target in panel.targets {
+        if target.hidden {
             continue;
         }
-
-        let mut exprs = Vec::new();
-        let mut expr_paths = Vec::new();
-        let mut legends = Vec::new();
-        let mut query_modes = Vec::new();
-        for target in panel.targets {
-            if target.hidden {
-                continue;
-            }
-            if let Some(expr) = target.expr {
-                exprs.push(expr);
-                expr_paths.push(target.expr_path);
-                legends.push(target.legend_format);
-                query_modes.push(query_mode_for_target(target.instant, panel_type));
-            }
+        if let Some(expr) = target.expr {
+            exprs.push(expr);
+            expr_paths.push(target.expr_path);
+            legends.push(target.legend_format);
+            query_modes.push(query_mode_for_target(target.instant, panel_type));
         }
+    }
 
-        let mut thresholds = None;
-        let mut min = None;
-        let mut max = None;
-        let mut autogrid = None;
-        let mut display = crate::ui::DisplayFormat::default();
-        let mut graph_options = crate::app::GraphOptions::default();
+    let mut thresholds = None;
+    let mut min = None;
+    let mut max = None;
+    let mut autogrid = None;
+    let mut display = crate::ui::DisplayFormat::default();
+    let mut graph_options = crate::app::GraphOptions::default();
 
-        if let Some(path) = panel.transformations_path {
+    if let Some(path) = panel.transformations_path {
+        out.diagnostics.push(ImportDiagnostic::new(
+            "ignored_field",
+            path,
+            "`transformations` are not supported yet; queries will run without Grafana transformations",
+        ));
+    }
+
+    if let Some(path) = panel.reduce_options_path {
+        out.diagnostics.push(ImportDiagnostic::new(
+            "ignored_field",
+            path,
+            "`options.reduceOptions` is not supported yet; Grafatui will use default value selection",
+        ));
+    }
+
+    if let Some(defaults) = panel.field_defaults {
+        if let Some(path) = defaults.mappings_path {
             out.diagnostics.push(ImportDiagnostic::new(
-                "ignored_field",
-                path,
-                "`transformations` are not supported yet; queries will run without Grafana transformations",
-            ));
-        }
-
-        if let Some(path) = panel.reduce_options_path {
-            out.diagnostics.push(ImportDiagnostic::new(
-                "ignored_field",
-                path,
-                "`options.reduceOptions` is not supported yet; Grafatui will use default value selection",
-            ));
-        }
-
-        if let Some(defaults) = panel.field_defaults {
-            if let Some(path) = defaults.mappings_path {
-                out.diagnostics.push(ImportDiagnostic::new(
                     "ignored_field",
                     path,
                     "`fieldConfig.defaults.mappings` is not supported yet; value mappings will be ignored",
                 ));
-            }
-            graph_options = graph_options_from_custom(defaults.custom.as_ref());
-            display = crate::ui::DisplayFormat {
-                unit: defaults.unit,
-                decimals: defaults.decimals,
-                no_value: defaults.no_value,
-            };
-            min = defaults.min;
-            max = defaults.max;
-            autogrid = defaults
-                .custom
-                .as_ref()
-                .and_then(|custom| custom.axis_grid_show);
-            thresholds = thresholds_from_model(defaults.thresholds, defaults.custom.as_ref());
         }
+        graph_options = graph_options_from_custom(defaults.custom.as_ref());
+        display = crate::ui::DisplayFormat {
+            unit: defaults.unit,
+            decimals: defaults.decimals,
+            no_value: defaults.no_value,
+        };
+        min = defaults.min;
+        max = defaults.max;
+        autogrid = defaults
+            .custom
+            .as_ref()
+            .and_then(|custom| custom.axis_grid_show);
+        thresholds = thresholds_from_model(defaults.thresholds, defaults.custom.as_ref());
+    }
 
-        if !exprs.is_empty() {
-            let options = match panel_type {
-                crate::app::PanelType::Graph => crate::app::PanelOptions::Graph(graph_options),
-                _ => crate::app::PanelOptions::None,
-            };
-            out.queries.push(QueryPanel {
-                title: panel.title,
-                exprs,
-                expr_paths,
-                legends,
-                query_modes,
-                grid: panel.grid.map(|grid| GridPos {
-                    x: grid.x,
-                    y: grid.y,
-                    w: grid.w,
-                    h: grid.h,
-                }),
-                panel_type,
-                thresholds,
-                min,
-                max,
-                autogrid,
-                display,
-                options,
-            });
-        } else if panel.count_as_skipped_if_empty {
+    if !exprs.is_empty() {
+        let options = match panel_type {
+            crate::app::PanelType::Graph => crate::app::PanelOptions::Graph(graph_options),
+            _ => crate::app::PanelOptions::None,
+        };
+        let index = out.queries.len();
+        out.queries.push(QueryPanel {
+            title: panel.title,
+            exprs,
+            expr_paths,
+            legends,
+            query_modes,
+            grid: panel.grid.map(|grid| GridPos {
+                x: grid.x,
+                y: grid.y,
+                w: grid.w,
+                h: grid.h,
+            }),
+            panel_type,
+            thresholds,
+            min,
+            max,
+            autogrid,
+            display,
+            options,
+        });
+        Ok(Some(index))
+    } else {
+        if panel.count_as_skipped_if_empty {
             out.skipped_panels += 1;
         }
+        Ok(None)
     }
-    Ok(())
+}
+
+fn import_layout_nodes(
+    nodes: Vec<model::LayoutNode>,
+    out: &mut DashboardImport,
+    next_row_id: &mut usize,
+) -> Result<Vec<crate::dashboard::DashboardLayoutItem>> {
+    let mut items = Vec::new();
+    for node in nodes {
+        match node {
+            model::LayoutNode::Panel(panel) => {
+                if let Some(index) = import_panel(panel, out)? {
+                    items.push(crate::dashboard::DashboardLayoutItem::Panel(index));
+                }
+            }
+            model::LayoutNode::Row(row) => {
+                let id = crate::dashboard::RowId::new(*next_row_id);
+                *next_row_id += 1;
+                let children = import_layout_nodes(row.children, out, next_row_id)?;
+                items.push(crate::dashboard::DashboardLayoutItem::Row(
+                    crate::dashboard::DashboardRow::new(
+                        id,
+                        row.title,
+                        row.collapsed,
+                        row.hidden_header,
+                        children,
+                    ),
+                ));
+            }
+        }
+    }
+    Ok(items)
 }
 
 fn query_mode_for_target(

--- a/src/grafana/model.rs
+++ b/src/grafana/model.rs
@@ -7,9 +7,26 @@ pub(super) struct Dashboard {
     pub(super) title: String,
     pub(super) refresh: Option<String>,
     pub(super) variables: Vec<Variable>,
-    pub(super) panels: Vec<Panel>,
+    pub(super) layout: Vec<LayoutNode>,
     pub(super) skipped_panels: usize,
     pub(super) diagnostics: Vec<ImportDiagnostic>,
+}
+
+#[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
+pub(super) enum LayoutNode {
+    Panel(Panel),
+    Row(Row),
+}
+
+#[derive(Debug)]
+pub(super) struct Row {
+    pub(super) title: String,
+    pub(super) collapsed: bool,
+    pub(super) hidden_header: bool,
+    #[allow(dead_code)]
+    pub(super) source_path: String,
+    pub(super) children: Vec<LayoutNode>,
 }
 
 #[derive(Debug)]

--- a/src/grafana/v2.rs
+++ b/src/grafana/v2.rs
@@ -31,13 +31,6 @@ pub(super) fn adapt(value: Value) -> Result<model::Dashboard> {
     let title = require_string_from(spec, "title", "spec.title")?.to_string();
     let elements = require_object_from(spec, "elements", "spec.elements")?;
     let layout = require_object_from(spec, "layout", "spec.layout")?;
-    let layout_kind = require_string_from(layout, "kind", "spec.layout.kind")?;
-    ensure!(
-        layout_kind == "GridLayout",
-        "unsupported Grafana V2 layout `{layout_kind}` at spec.layout.kind; this release supports `GridLayout` only"
-    );
-    let layout_spec = require_object_from(layout, "spec", "spec.layout.spec")?;
-    let items = require_array_from(layout_spec, "items", "spec.layout.spec.items")?;
 
     let mut dashboard = model::Dashboard {
         title,
@@ -57,8 +50,41 @@ pub(super) fn adapt(value: Value) -> Result<model::Dashboard> {
         ),
     };
     dashboard.variables = normalize_variables(spec, &mut dashboard.diagnostics)?;
+    dashboard.layout = parse_layout(layout, elements, "spec.layout", &mut dashboard.diagnostics)?;
+    dashboard.skipped_panels += dashboard
+        .diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.code == "unsupported_element")
+        .count();
+    Ok(dashboard)
+}
+
+fn parse_layout(
+    layout: &JsonObject,
+    elements: &JsonObject,
+    path: &str,
+    diagnostics: &mut Vec<super::ImportDiagnostic>,
+) -> Result<Vec<model::LayoutNode>> {
+    match require_string_from(layout, "kind", &format!("{path}.kind"))? {
+        "GridLayout" => parse_grid_layout(layout, elements, path, diagnostics),
+        "RowsLayout" => parse_rows_layout(layout, elements, path, diagnostics),
+        kind => anyhow::bail!("unsupported Grafana V2 layout `{kind}` at {path}.kind"),
+    }
+}
+
+fn parse_grid_layout(
+    layout: &JsonObject,
+    elements: &JsonObject,
+    path: &str,
+    diagnostics: &mut Vec<super::ImportDiagnostic>,
+) -> Result<Vec<model::LayoutNode>> {
+    let spec_path = format!("{path}.spec");
+    let spec = require_object_from(layout, "spec", &spec_path)?;
+    let items_path = format!("{spec_path}.items");
+    let items = require_array_from(spec, "items", &items_path)?;
+    let mut nodes = Vec::new();
     for (index, item) in items.iter().enumerate() {
-        let item_path = format!("spec.layout.spec.items[{index}]");
+        let item_path = format!("{items_path}[{index}]");
         let grid = parse_grid_item(item, &item_path)?;
         let element_path = format!("spec.elements[{:?}]", grid.element_name);
         let element = elements.get(&grid.element_name).ok_or_else(|| {
@@ -67,18 +93,80 @@ pub(super) fn adapt(value: Value) -> Result<model::Dashboard> {
                 grid.element_name
             )
         })?;
-        if let Some(panel) = parse_panel(
-            element,
-            &element_path,
-            grid.position,
-            &mut dashboard.diagnostics,
-        )? {
-            dashboard.layout.push(model::LayoutNode::Panel(panel));
-        } else {
-            dashboard.skipped_panels += 1;
+        if let Some(panel) = parse_panel(element, &element_path, grid.position, diagnostics)? {
+            nodes.push(model::LayoutNode::Panel(panel));
         }
     }
-    Ok(dashboard)
+    Ok(nodes)
+}
+
+fn parse_rows_layout(
+    layout: &JsonObject,
+    elements: &JsonObject,
+    path: &str,
+    diagnostics: &mut Vec<super::ImportDiagnostic>,
+) -> Result<Vec<model::LayoutNode>> {
+    let spec_path = format!("{path}.spec");
+    let spec = require_object_from(layout, "spec", &spec_path)?;
+    let rows_path = format!("{spec_path}.rows");
+    let rows = require_array_from(spec, "rows", &rows_path)?;
+    let mut nodes = Vec::new();
+    for (index, row) in rows.iter().enumerate() {
+        let row_path = format!("{rows_path}[{index}]");
+        let row = row
+            .as_object()
+            .ok_or_else(|| anyhow!("invalid Grafana V2 row at {row_path}: expected an object"))?;
+        require_expected_kind(row, &row_path, "RowsLayoutRow")?;
+        let row_spec_path = format!("{row_path}.spec");
+        let row_spec = require_object_from(row, "spec", &row_spec_path)?;
+        let title = match row_spec.get("title") {
+            None => String::new(),
+            Some(Value::String(title)) => title.clone(),
+            Some(_) => anyhow::bail!(
+                "invalid Grafana V2 resource at {row_spec_path}.title: expected a string"
+            ),
+        };
+        let collapsed = optional_bool_from(row_spec, "collapse", &row_spec_path)?;
+        let hidden_header = optional_bool_from(row_spec, "hideHeader", &row_spec_path)?;
+
+        for (field, description) in [
+            ("repeat", "repeated row"),
+            ("conditionalRendering", "conditional row rendering"),
+        ] {
+            ensure!(
+                !row_spec.contains_key(field),
+                "unsupported Grafana V2 {description} at {row_spec_path}.{field}"
+            );
+        }
+
+        let variables_path = format!("{row_spec_path}.variables");
+        match row_spec.get("variables") {
+            None => {}
+            Some(Value::Array(variables)) => ensure!(
+                variables.is_empty(),
+                "unsupported Grafana V2 row variables at {variables_path}"
+            ),
+            Some(_) => {
+                anyhow::bail!("invalid Grafana V2 resource at {variables_path}: expected an array")
+            }
+        }
+
+        if optional_bool_from(row_spec, "fillScreen", &row_spec_path)? {
+            anyhow::bail!("unsupported Grafana V2 full-screen row at {row_spec_path}.fillScreen");
+        }
+
+        let child_path = format!("{row_spec_path}.layout");
+        let child_layout = require_object_from(row_spec, "layout", &child_path)?;
+        let children = parse_layout(child_layout, elements, &child_path, diagnostics)?;
+        nodes.push(model::LayoutNode::Row(model::Row {
+            title,
+            collapsed,
+            hidden_header,
+            source_path: row_path,
+            children,
+        }));
+    }
+    Ok(nodes)
 }
 
 fn normalize_variables(
@@ -265,6 +353,14 @@ fn require_bool_from(object: &JsonObject, key: &str, path: &str) -> Result<bool>
         .get(key)
         .and_then(Value::as_bool)
         .ok_or_else(|| anyhow!("invalid Grafana V2 resource at {path}: expected a boolean"))
+}
+
+fn optional_bool_from(object: &JsonObject, key: &str, path: &str) -> Result<bool> {
+    match object.get(key) {
+        None => Ok(false),
+        Some(Value::Bool(value)) => Ok(*value),
+        Some(_) => anyhow::bail!("invalid Grafana V2 resource at {path}.{key}: expected a boolean"),
+    }
 }
 
 fn require_i32_from(object: &JsonObject, key: &str, path: &str) -> Result<i32> {

--- a/src/grafana/v2.rs
+++ b/src/grafana/v2.rs
@@ -73,7 +73,7 @@ pub(super) fn adapt(value: Value) -> Result<model::Dashboard> {
             grid.position,
             &mut dashboard.diagnostics,
         )? {
-            dashboard.panels.push(panel);
+            dashboard.layout.push(model::LayoutNode::Panel(panel));
         } else {
             dashboard.skipped_panels += 1;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@
 mod annotations;
 mod app;
 mod config;
+mod dashboard;
 mod export;
 mod grafana;
 mod prom;

--- a/src/main.rs
+++ b/src/main.rs
@@ -250,12 +250,14 @@ async fn main() -> Result<()> {
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
-    let res = app::run_app(
-        &mut terminal,
-        &mut state,
-        Duration::from_millis(args.tick_rate),
-    )
-    .await;
+    let res = tokio::select! {
+        res = app::run_app(
+            &mut terminal,
+            &mut state,
+            Duration::from_millis(args.tick_rate),
+        ) => res,
+        _ = tokio::signal::ctrl_c() => Ok(()),
+    };
 
     // Restore terminal
     disable_raw_mode()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -143,7 +143,7 @@ async fn main() -> Result<()> {
     let prom = prom::PromClient::new(prometheus_url);
 
     // Build panels from Grafana import or simple queries.
-    let (title, panels, skipped_panels) = if let Some(path) = dashboard_path {
+    let (title, panels, skipped_panels, imported_layout) = if let Some(path) = dashboard_path {
         let d = grafana::load_grafana_dashboard(&path)?;
         let import_context = build_import_context(&d, config.vars.clone(), &args.var);
         print_import_diagnostics(&import_context.diagnostics);
@@ -179,10 +179,20 @@ async fn main() -> Result<()> {
                 options: q.options,
             })
             .collect();
-        (format!("{} (imported)", d.title), ps, d.skipped_panels)
+        (
+            format!("{} (imported)", d.title),
+            ps,
+            d.skipped_panels,
+            Some(d.layout),
+        )
     } else {
         merge_user_vars(&mut vars, config.vars.clone(), &args.var);
-        ("grafatui".to_string(), app::default_queries(args.query), 0)
+        (
+            "grafatui".to_string(),
+            app::default_queries(args.query),
+            0,
+            None,
+        )
     };
 
     // Determine theme
@@ -221,6 +231,7 @@ async fn main() -> Result<()> {
         }
         .validate()?,
     );
+    apply_imported_layout(&mut state, imported_layout);
     state.annotations = annotations::AnnotationState::from_source(annotation_source);
     state.autogrid_enabled = autogrid_enabled;
     state.autogrid_color = autogrid_color;
@@ -256,6 +267,15 @@ async fn main() -> Result<()> {
     terminal.show_cursor()?;
 
     res
+}
+
+fn apply_imported_layout(
+    state: &mut app::AppState,
+    imported_layout: Option<dashboard::DashboardLayout>,
+) {
+    if let Some(layout) = imported_layout {
+        state.apply_layout(layout);
+    }
 }
 
 fn load_startup_config(path: Option<std::path::PathBuf>) -> Result<Config> {
@@ -459,6 +479,7 @@ fn print_validation_summary(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::dashboard::{DashboardLayout, DashboardLayoutItem, DashboardRow, RowId};
 
     fn temp_config_path(name: &str) -> std::path::PathBuf {
         let suffix = std::time::SystemTime::now()
@@ -469,6 +490,33 @@ mod tests {
             "grafatui-{name}-{}-{suffix}.toml",
             std::process::id()
         ))
+    }
+
+    #[test]
+    fn imported_layout_replaces_the_initial_flat_layout() {
+        let mut state = app::AppState::new(
+            prom::PromClient::new("http://localhost:9090".to_string()),
+            Duration::from_secs(60),
+            Duration::from_secs(5),
+            Duration::from_secs(1),
+            "test".to_string(),
+            app::default_queries(vec!["up".to_string()]),
+            0,
+            Theme::default(),
+            "dashed-line".to_string(),
+            export::ExportOptions::default(),
+        );
+        let layout = DashboardLayout::new(vec![DashboardLayoutItem::Row(DashboardRow::new(
+            RowId::new(0),
+            "Collapsed",
+            true,
+            false,
+            vec![DashboardLayoutItem::Panel(0)],
+        ))]);
+
+        apply_imported_layout(&mut state, Some(layout));
+
+        assert_eq!(state.visible_panel_indices(), Vec::<usize>::new());
     }
 
     #[test]

--- a/src/ui/draw.rs
+++ b/src/ui/draw.rs
@@ -61,16 +61,12 @@ pub(crate) fn draw_ui(frame: &mut Frame, app: &mut AppState) {
 
     let mut selected_rendered_cluster = None;
     if app.mode == AppMode::Fullscreen || app.mode == AppMode::FullscreenInspect {
-        if let Some(p) = app.panels.get(app.selected_panel) {
-            selected_rendered_cluster = render_panel(
-                frame,
-                inner_area,
-                app.selected_panel,
-                p,
-                app,
-                true,
-                app.cursor_x,
-            );
+        if let Some((panel_index, p)) = app
+            .selected_panel_index()
+            .and_then(|index| app.panels.get(index).map(|panel| (index, panel)))
+        {
+            selected_rendered_cluster =
+                render_panel(frame, inner_area, panel_index, p, app, true, app.cursor_x);
         }
     } else {
         let has_grid = app.panels.iter().any(|p| p.grid.is_some());
@@ -84,7 +80,7 @@ pub(crate) fn draw_ui(frame: &mut Frame, app: &mut AppState) {
         for (rect, panel_idx) in &panel_rects {
             // eprintln!("Rendering panel {} at {:?}", panel_idx, rect);
             if let Some(p) = app.panels.get(*panel_idx) {
-                let is_selected = *panel_idx == app.selected_panel;
+                let is_selected = Some(*panel_idx) == app.selected_panel_index();
                 let rendered_cluster =
                     render_panel(frame, *rect, *panel_idx, p, app, is_selected, app.cursor_x);
                 if is_selected {
@@ -169,9 +165,12 @@ pub(crate) fn draw_ui(frame: &mut Frame, app: &mut AppState) {
         let results: Vec<ListItem> = app
             .search_results
             .iter()
-            .map(|&idx| {
-                let p = &app.panels[idx];
-                ListItem::new(format!("• {}", p.title))
+            .filter_map(|item| {
+                let crate::dashboard::DashboardItemId::Panel(index) = item else {
+                    return None;
+                };
+                let panel = app.panels.get(*index)?;
+                Some(ListItem::new(format!("• {}", panel.title)))
             })
             .collect();
         let list = List::new(results)
@@ -383,7 +382,7 @@ mod tests {
         for (width, height) in [(120, 30), (80, 24)] {
             let mut app = v2_compatibility_app();
             assert_eq!(app.panels.len(), 2);
-            assert_eq!(app.selected_panel, 0);
+            assert_eq!(app.selected_panel_index(), Some(0));
             assert_eq!(app.skipped_panels, 0);
             assert_eq!(app.panels[0].panel_type, PanelType::Graph);
             assert_eq!(app.panels[1].panel_type, PanelType::Stat);
@@ -457,6 +456,7 @@ mod tests {
         );
         let mut app = test_app();
         app.panels = vec![graph_panel("CPU"), graph_panel("Memory")];
+        app.apply_layout(crate::dashboard::DashboardLayout::flat(app.panels.len()));
         app.view_end_ts = 100;
         app.range = std::time::Duration::from_secs(100);
         app.mode = AppMode::Inspect;
@@ -483,7 +483,7 @@ mod tests {
             vec!["cpu deploy"]
         );
 
-        app.selected_panel = 1;
+        app.selected_item = Some(crate::dashboard::DashboardItemId::Panel(1));
         terminal.draw(|frame| draw_ui(frame, &mut app)).unwrap();
         assert!(app.rendered_annotation_cluster.is_none());
 

--- a/src/ui/draw.rs
+++ b/src/ui/draw.rs
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-use super::layout::{calculate_grid_layout, calculate_two_column_layout, centered_rect};
+use super::layout::{DashboardRectKind, centered_rect, visible_dashboard_rects};
 use super::panels::render_panel;
 use crate::app::{AppMode, AppState, PanelState};
+use crate::{dashboard::DashboardRow, theme::Theme};
 use humantime::format_duration;
 use ratatui::{
     prelude::*,
@@ -42,7 +43,7 @@ pub(crate) fn draw_ui(frame: &mut Frame, app: &mut AppState) {
         app.title,
         format_duration(app.range),
         format_duration(app.step),
-        app.panels.len(),
+        normal_panel_count(app),
         if app.is_live() { "" } else { "⏸ PAUSED " }
     );
     let title_block = Block::default()
@@ -69,33 +70,38 @@ pub(crate) fn draw_ui(frame: &mut Frame, app: &mut AppState) {
                 render_panel(frame, inner_area, panel_index, p, app, true, app.cursor_x);
         }
     } else {
-        let has_grid = app.panels.iter().any(|p| p.grid.is_some());
-
-        let panel_rects = if has_grid {
-            calculate_grid_layout(inner_area, app)
-        } else {
-            calculate_two_column_layout(inner_area, app)
-        };
-
-        for (rect, panel_idx) in &panel_rects {
-            // eprintln!("Rendering panel {} at {:?}", panel_idx, rect);
-            if let Some(p) = app.panels.get(*panel_idx) {
-                let is_selected = Some(*panel_idx) == app.selected_panel_index();
-                let rendered_cluster =
-                    render_panel(frame, *rect, *panel_idx, p, app, is_selected, app.cursor_x);
-                if is_selected {
-                    selected_rendered_cluster = rendered_cluster;
+        for item in visible_dashboard_rects(size, app) {
+            match item.kind {
+                DashboardRectKind::Panel { index } => {
+                    if let Some(panel) = app.panels.get(index) {
+                        let is_selected = app.selected_item == Some(item.id);
+                        let rendered_cluster = render_panel(
+                            frame,
+                            item.rect,
+                            index,
+                            panel,
+                            app,
+                            is_selected,
+                            app.cursor_x,
+                        );
+                        if is_selected {
+                            selected_rendered_cluster = rendered_cluster;
+                        }
+                    }
+                }
+                DashboardRectKind::Row { row_id, depth, .. } => {
+                    if let Some(row) = app.layout.row(row_id) {
+                        render_row_header(
+                            frame,
+                            item.rect,
+                            row,
+                            depth,
+                            app.selected_item == Some(item.id),
+                            &app.theme,
+                        );
+                    }
                 }
             }
-        }
-
-        if !has_grid && app.panels.is_empty() {
-            // No panels to render
-        } else if has_grid {
-            // Check if we need to render extras (panels without grid)
-            // The calculate_grid_layout should handle extras too?
-            // The original code handled extras by stacking them below.
-            // Let's make calculate_grid_layout return extras too.
         }
     }
     app.rendered_annotation_cluster = selected_rendered_cluster;
@@ -106,7 +112,7 @@ pub(crate) fn draw_ui(frame: &mut Frame, app: &mut AppState) {
         if app.mode == AppMode::Fullscreen || app.mode == AppMode::FullscreenInspect {
             "1 (Fullscreen)".to_string()
         } else {
-            format!("{}", app.panels.len())
+            normal_panel_count(app)
         };
 
     let mode_display = match app.mode {
@@ -141,7 +147,7 @@ pub(crate) fn draw_ui(frame: &mut Frame, app: &mut AppState) {
     if app.mode == AppMode::Search {
         let area = centered_rect(60, 20, size);
         let block = Block::default()
-            .title(" Search Panels ")
+            .title(" Search Dashboard ")
             .borders(Borders::ALL)
             .border_style(Style::default().fg(app.theme.border_selected));
         frame.render_widget(Clear, area); // Clear background
@@ -165,16 +171,19 @@ pub(crate) fn draw_ui(frame: &mut Frame, app: &mut AppState) {
         let results: Vec<ListItem> = app
             .search_results
             .iter()
-            .filter_map(|item| {
-                let crate::dashboard::DashboardItemId::Panel(index) = item else {
-                    return None;
-                };
-                let panel = app.panels.get(*index)?;
-                Some(ListItem::new(format!("• {}", panel.title)))
+            .filter_map(|item| match item {
+                crate::dashboard::DashboardItemId::Row(row_id) => {
+                    let row = app.layout.row(*row_id)?;
+                    let marker = if row.collapsed { '▶' } else { '▼' };
+                    Some(ListItem::new(format!("{marker} {}", row.title)))
+                }
+                crate::dashboard::DashboardItemId::Panel(index) => {
+                    let panel = app.panels.get(*index)?;
+                    Some(ListItem::new(format!("• {}", panel.title)))
+                }
             })
             .collect();
         let list = List::new(results)
-            .block(Block::default().borders(Borders::TOP))
             .highlight_style(
                 Style::default()
                     .fg(app.theme.title)
@@ -191,6 +200,49 @@ pub(crate) fn draw_ui(frame: &mut Frame, app: &mut AppState) {
     }
 
     super::render_annotation_modal(frame, app);
+}
+
+fn normal_panel_count(app: &AppState) -> String {
+    let total = app.panels.len();
+    let visible = if app
+        .layout
+        .items
+        .iter()
+        .all(|item| matches!(item, crate::dashboard::DashboardLayoutItem::Panel(_)))
+    {
+        total
+    } else {
+        app.layout.visible_panel_count()
+    };
+    if visible == total {
+        total.to_string()
+    } else {
+        format!("{visible}/{total}")
+    }
+}
+
+pub(crate) fn render_row_header(
+    frame: &mut Frame,
+    rect: Rect,
+    row: &DashboardRow,
+    depth: usize,
+    selected: bool,
+    theme: &Theme,
+) {
+    let marker = if row.collapsed { '▶' } else { '▼' };
+    let text = format!("{marker} {}{}", "  ".repeat(depth), row.title);
+    let style = Style::default()
+        .fg(if selected {
+            theme.border_selected
+        } else {
+            theme.border
+        })
+        .add_modifier(if selected {
+            Modifier::BOLD
+        } else {
+            Modifier::empty()
+        });
+    frame.render_widget(Paragraph::new(text).style(style), rect);
 }
 
 fn build_footer_detail(app: &AppState) -> String {
@@ -287,6 +339,35 @@ mod tests {
         }
     }
 
+    fn nested_row_app() -> AppState {
+        use crate::dashboard::{
+            DashboardItemId, DashboardLayout, DashboardLayoutItem, DashboardRow, RowId,
+        };
+
+        let mut app = test_app();
+        app.panels = vec![graph_panel("Visible child"), graph_panel("Collapsed child")];
+        app.apply_layout(DashboardLayout::new(vec![DashboardLayoutItem::Row(
+            DashboardRow::new(
+                RowId::new(0),
+                "Expanded",
+                false,
+                false,
+                vec![
+                    DashboardLayoutItem::Panel(0),
+                    DashboardLayoutItem::Row(DashboardRow::new(
+                        RowId::new(1),
+                        "Nested",
+                        true,
+                        false,
+                        vec![DashboardLayoutItem::Panel(1)],
+                    )),
+                ],
+            ),
+        )]));
+        app.selected_item = Some(DashboardItemId::Row(RowId::new(0)));
+        app
+    }
+
     fn v2_compatibility_app() -> AppState {
         let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("examples")
@@ -375,6 +456,108 @@ mod tests {
             })
             .collect::<Vec<_>>()
             .join("\n")
+    }
+
+    fn rect_text(terminal: &Terminal<TestBackend>, rect: Rect) -> String {
+        let buffer = terminal.backend().buffer();
+        (rect.y..rect.bottom())
+            .map(|y| {
+                (rect.x..rect.right())
+                    .map(|x| buffer.cell((x, y)).unwrap().symbol())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn rows_render_disclosures_indentation_selection_and_visible_count() {
+        let mut app = nested_row_app();
+        let row_rects =
+            super::super::layout::visible_dashboard_rects(Rect::new(0, 0, 100, 40), &app);
+        let expanded = row_rects[0].rect;
+        let nested = row_rects[2].rect;
+        let mut terminal = Terminal::new(TestBackend::new(100, 40)).unwrap();
+
+        terminal.draw(|frame| draw_ui(frame, &mut app)).unwrap();
+
+        let text = terminal_text(&terminal);
+        assert!(text.contains("▼ Expanded"));
+        assert!(text.contains("▶   Nested"));
+        assert!(text.contains("Visible child"));
+        assert!(!text.contains("Collapsed child"));
+        assert!(text.contains("panels=1/2"));
+        assert_eq!(
+            terminal
+                .backend()
+                .buffer()
+                .cell((expanded.x, expanded.y))
+                .unwrap()
+                .fg,
+            app.theme.border_selected
+        );
+        assert_eq!(
+            terminal
+                .backend()
+                .buffer()
+                .cell((nested.x, nested.y))
+                .unwrap()
+                .fg,
+            app.theme.border
+        );
+    }
+
+    #[test]
+    fn row_free_dashboard_uses_legacy_count_without_fraction() {
+        let mut app = test_app();
+        app.panels = vec![graph_panel("CPU"), graph_panel("Memory")];
+        app.apply_layout(crate::dashboard::DashboardLayout::flat(2));
+        let mut terminal = Terminal::new(TestBackend::new(100, 40)).unwrap();
+
+        terminal.draw(|frame| draw_ui(frame, &mut app)).unwrap();
+
+        let text = terminal_text(&terminal);
+        assert!(text.contains("panels=2"));
+        assert!(!text.contains("panels=2/2"));
+        assert!(!text.contains('▼'));
+        assert!(!text.contains('▶'));
+    }
+
+    #[test]
+    fn structurally_flat_layout_growth_uses_rendered_panel_count() {
+        let mut app = test_app();
+        app.panels = vec![graph_panel("CPU")];
+        app.apply_layout(crate::dashboard::DashboardLayout::flat(1));
+        app.panels.push(graph_panel("Memory"));
+        let mut terminal = Terminal::new(TestBackend::new(120, 40)).unwrap();
+
+        terminal.draw(|frame| draw_ui(frame, &mut app)).unwrap();
+
+        let text = terminal_text(&terminal);
+        assert!(text.contains("panels=2"));
+        assert!(!text.contains("panels=1/2"));
+        assert!(text.contains("CPU"));
+        assert!(text.contains("Memory"));
+    }
+
+    #[test]
+    fn row_search_overlay_renders_visible_row_candidate_at_narrow_viewport() {
+        let mut app = nested_row_app();
+        app.mode = AppMode::Search;
+        app.search_query = "Expanded".to_string();
+        app.search_results = vec![crate::dashboard::DashboardItemId::Row(
+            crate::dashboard::RowId::new(0),
+        )];
+        let size = Rect::new(0, 0, 72, 24);
+        let overlay = centered_rect(60, 20, size);
+        let mut terminal = Terminal::new(TestBackend::new(size.width, size.height)).unwrap();
+
+        terminal.draw(|frame| draw_ui(frame, &mut app)).unwrap();
+
+        let text = rect_text(&terminal, overlay);
+        assert!(text.contains("Search Dashboard"));
+        assert!(text.contains("> Expanded"));
+        assert!(text.contains("▼ Expanded"));
     }
 
     #[test]

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -210,7 +210,10 @@ pub(crate) fn visible_panel_rects(area: Rect, app: &AppState) -> Vec<(Rect, usiz
     });
 
     if app.mode == AppMode::Fullscreen || app.mode == AppMode::FullscreenInspect {
-        return vec![(inner_area, app.selected_panel)];
+        return app
+            .selected_panel_index()
+            .map(|index| vec![(inner_area, index)])
+            .unwrap_or_default();
     }
 
     if app.panels.iter().any(|p| p.grid.is_some()) {

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -14,8 +14,31 @@
  * limitations under the License.
  */
 
-use crate::app::{AppMode, AppState, PanelState};
+use crate::{
+    app::{AppMode, AppState, PanelState},
+    dashboard::{DashboardItemId, DashboardLayoutItem, RowId},
+};
 use ratatui::prelude::*;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct DashboardRect {
+    pub(crate) id: DashboardItemId,
+    pub(crate) rect: Rect,
+    pub(crate) disclosure_rect: Option<Rect>,
+    pub(crate) kind: DashboardRectKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DashboardRectKind {
+    Row {
+        row_id: RowId,
+        depth: usize,
+        collapsed: bool,
+    },
+    Panel {
+        index: usize,
+    },
+}
 
 pub(crate) fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
     let vertical = Layout::vertical([
@@ -193,7 +216,7 @@ pub(crate) fn calculate_two_column_layout_subset(
     results
 }
 
-pub(crate) fn visible_panel_rects(area: Rect, app: &AppState) -> Vec<(Rect, usize)> {
+fn dashboard_inner_area(area: Rect) -> Rect {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
@@ -203,27 +226,288 @@ pub(crate) fn visible_panel_rects(area: Rect, app: &AppState) -> Vec<(Rect, usiz
         ])
         .split(area);
 
-    let charts_area = chunks[1];
-    let inner_area = charts_area.inner(Margin {
+    chunks[1].inner(Margin {
         vertical: 1,
         horizontal: 1,
-    });
+    })
+}
+
+pub(crate) fn visible_dashboard_rects(area: Rect, app: &AppState) -> Vec<DashboardRect> {
+    let inner_area = dashboard_inner_area(area);
 
     if app.mode == AppMode::Fullscreen || app.mode == AppMode::FullscreenInspect {
         return app
             .selected_panel_index()
-            .map(|index| vec![(inner_area, index)])
+            .map(|index| {
+                vec![DashboardRect {
+                    id: DashboardItemId::Panel(index),
+                    rect: inner_area,
+                    disclosure_rect: None,
+                    kind: DashboardRectKind::Panel { index },
+                }]
+            })
             .unwrap_or_default();
     }
 
-    if app.panels.iter().any(|p| p.grid.is_some()) {
-        calculate_grid_layout(inner_area, app)
-    } else {
-        calculate_two_column_layout(inner_area, app)
+    let visible = app.layout.visible_items();
+    if !visible
+        .iter()
+        .any(|item| matches!(item.id, DashboardItemId::Row(_)))
+    {
+        let structurally_flat = app
+            .layout
+            .items
+            .iter()
+            .all(|item| matches!(item, DashboardLayoutItem::Panel(_)));
+        if structurally_flat {
+            let panel_rects = if app.panels.iter().any(|p| p.grid.is_some()) {
+                calculate_grid_layout(inner_area, app)
+            } else {
+                calculate_two_column_layout(inner_area, app)
+            };
+            return panel_rects
+                .into_iter()
+                .map(|(rect, index)| panel_rect(index, rect))
+                .collect();
+        }
+
+        let cell_h = std::cmp::max(3, inner_area.height / 24);
+        let mut projected = Vec::new();
+        let mut cursor_y = inner_area.y;
+        for group in transparent_panel_groups(&app.layout.items) {
+            cursor_y =
+                project_panel_group(inner_area, cursor_y, cell_h, app, &group, &mut projected);
+        }
+        let scroll_offset = u16::try_from(app.vertical_scroll)
+            .unwrap_or(u16::MAX)
+            .saturating_mul(cell_h);
+        return projected
+            .into_iter()
+            .filter_map(|item| clip_scrolled_rect(item, inner_area, scroll_offset))
+            .collect();
+    }
+
+    let cell_h = std::cmp::max(3, inner_area.height / 24);
+    let mut projected = Vec::new();
+    let mut cursor_y = inner_area.y;
+    let mut position = 0;
+    while position < visible.len() {
+        match visible[position].id {
+            DashboardItemId::Row(row_id) => {
+                let Some(row) = app.layout.row(row_id) else {
+                    position += 1;
+                    continue;
+                };
+                let rect = Rect::new(inner_area.x, cursor_y, inner_area.width, 1);
+                projected.push(DashboardRect {
+                    id: DashboardItemId::Row(row_id),
+                    rect,
+                    disclosure_rect: Some(Rect::new(rect.x, rect.y, rect.width.min(1), 1)),
+                    kind: DashboardRectKind::Row {
+                        row_id,
+                        depth: visible[position].depth,
+                        collapsed: row.collapsed,
+                    },
+                });
+                cursor_y = cursor_y.saturating_add(1);
+                position += 1;
+            }
+            DashboardItemId::Panel(_) => {
+                let start = position;
+                while position < visible.len()
+                    && matches!(visible[position].id, DashboardItemId::Panel(_))
+                {
+                    position += 1;
+                }
+                let indices = visible[start..position]
+                    .iter()
+                    .filter_map(|item| match item.id {
+                        DashboardItemId::Panel(index) => Some(index),
+                        DashboardItemId::Row(_) => None,
+                    })
+                    .collect::<Vec<_>>();
+                cursor_y = project_panel_group(
+                    inner_area,
+                    cursor_y,
+                    cell_h,
+                    app,
+                    &indices,
+                    &mut projected,
+                );
+            }
+        }
+    }
+
+    let scroll_offset = u16::try_from(app.vertical_scroll)
+        .unwrap_or(u16::MAX)
+        .saturating_mul(cell_h);
+    projected
+        .into_iter()
+        .filter_map(|item| clip_scrolled_rect(item, inner_area, scroll_offset))
+        .collect()
+}
+
+fn transparent_panel_groups(items: &[DashboardLayoutItem]) -> Vec<Vec<usize>> {
+    let mut groups = Vec::new();
+    let mut panels = Vec::new();
+    for item in items {
+        match item {
+            DashboardLayoutItem::Panel(index) => panels.push(*index),
+            DashboardLayoutItem::Row(row) => {
+                if !panels.is_empty() {
+                    groups.push(std::mem::take(&mut panels));
+                }
+                if row.hidden_header || !row.collapsed {
+                    groups.extend(transparent_panel_groups(&row.children));
+                }
+            }
+        }
+    }
+    if !panels.is_empty() {
+        groups.push(panels);
+    }
+    groups
+}
+
+fn project_panel_group(
+    area: Rect,
+    origin_y: u16,
+    cell_h: u16,
+    app: &AppState,
+    panel_indices: &[usize],
+    output: &mut Vec<DashboardRect>,
+) -> u16 {
+    let has_grid = panel_indices.iter().any(|&index| {
+        app.panels
+            .get(index)
+            .is_some_and(|panel| panel.grid.is_some())
+    });
+    if !has_grid {
+        let columns = Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)])
+            .split(Rect::new(area.x, origin_y, area.width, u16::MAX - origin_y));
+        for (position, &index) in panel_indices.iter().enumerate() {
+            let row = (position / 2) as u16;
+            let column = position % 2;
+            let rect = Rect::new(
+                columns[column].x,
+                origin_y.saturating_add(row.saturating_mul(12)),
+                columns[column].width,
+                12,
+            );
+            output.push(panel_rect(index, rect));
+        }
+        let rows = panel_indices.len().div_ceil(2) as u16;
+        return origin_y.saturating_add(rows.saturating_mul(12));
+    }
+
+    let cell_w = std::cmp::max(1, area.width / 24);
+    let mut grid_height = 0u16;
+    let mut extras = Vec::new();
+    for &index in panel_indices {
+        let Some(panel) = app.panels.get(index) else {
+            continue;
+        };
+        let Some(grid) = panel.grid else {
+            extras.push(index);
+            continue;
+        };
+        if grid.x < 0 || grid.y < 0 || grid.w <= 0 || grid.h <= 0 {
+            continue;
+        }
+        let x = area
+            .x
+            .saturating_add((grid.x as u16).saturating_mul(cell_w));
+        let y = origin_y.saturating_add((grid.y as u16).saturating_mul(cell_h));
+        let rect = Rect::new(
+            x,
+            y,
+            (grid.w as u16)
+                .saturating_mul(cell_w)
+                .min(area.right().saturating_sub(x)),
+            (grid.h as u16).saturating_mul(cell_h),
+        );
+        if rect.width >= 8 && rect.height >= 4 {
+            output.push(panel_rect(index, rect));
+        }
+        grid_height = grid_height.max(
+            (grid.y as u16)
+                .saturating_add(grid.h as u16)
+                .saturating_mul(cell_h),
+        );
+    }
+
+    let extras_origin = origin_y.saturating_add(grid_height);
+    let columns =
+        Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)]).split(
+            Rect::new(area.x, extras_origin, area.width, u16::MAX - extras_origin),
+        );
+    for (position, index) in extras.iter().copied().enumerate() {
+        let row = (position / 2) as u16;
+        let column = position % 2;
+        output.push(panel_rect(
+            index,
+            Rect::new(
+                columns[column].x,
+                extras_origin.saturating_add(row.saturating_mul(12)),
+                columns[column].width,
+                12,
+            ),
+        ));
+    }
+    origin_y
+        .saturating_add(grid_height)
+        .saturating_add((extras.len().div_ceil(2) as u16).saturating_mul(12))
+}
+
+fn panel_rect(index: usize, rect: Rect) -> DashboardRect {
+    DashboardRect {
+        id: DashboardItemId::Panel(index),
+        rect,
+        disclosure_rect: None,
+        kind: DashboardRectKind::Panel { index },
     }
 }
 
-/// Determines which panel is located at the given coordinates.
+fn clip_scrolled_rect(
+    mut item: DashboardRect,
+    area: Rect,
+    scroll_offset: u16,
+) -> Option<DashboardRect> {
+    let top = item.rect.y.saturating_sub(scroll_offset);
+    let bottom = item.rect.bottom().saturating_sub(scroll_offset);
+    if bottom <= area.y || top >= area.bottom() {
+        return None;
+    }
+    item.rect.y = top.max(area.y);
+    item.rect.height = bottom.min(area.bottom()).saturating_sub(item.rect.y);
+    item.disclosure_rect = item
+        .disclosure_rect
+        .and_then(|rect| {
+            rect.y
+                .checked_sub(scroll_offset)
+                .map(|y| Rect { y, ..rect })
+        })
+        .filter(|rect| {
+            area.contains(Position {
+                x: rect.x,
+                y: rect.y,
+            })
+        });
+    Some(item)
+}
+
+#[allow(dead_code)]
+pub(crate) fn visible_panel_rects(area: Rect, app: &AppState) -> Vec<(Rect, usize)> {
+    visible_dashboard_rects(area, app)
+        .into_iter()
+        .filter_map(|item| match item.kind {
+            DashboardRectKind::Panel { index } => Some((item.rect, index)),
+            DashboardRectKind::Row { .. } => None,
+        })
+        .collect()
+}
+
+/// Determines which visible dashboard item is located at the given coordinates.
 ///
 /// # Arguments
 ///
@@ -234,31 +518,254 @@ pub(crate) fn visible_panel_rects(area: Rect, app: &AppState) -> Vec<(Rect, usiz
 ///
 /// # Returns
 ///
-/// An `Option` containing a tuple of `(panel_index, panel_rect)` if a panel was hit.
-pub(crate) fn hit_test(app: &AppState, area: Rect, x: u16, y: u16) -> Option<(usize, Rect)> {
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length(3),
-            Constraint::Min(5),
-            Constraint::Length(2),
-        ])
-        .split(area);
-
-    let charts_area = chunks[1];
-    let inner_area = charts_area.inner(Margin {
-        vertical: 1,
-        horizontal: 1,
-    });
+/// A copy of the hit rectangle, including its disclosure target for rows.
+pub(crate) fn hit_test(app: &AppState, area: Rect, x: u16, y: u16) -> Option<DashboardRect> {
+    let inner_area = dashboard_inner_area(area);
 
     if !inner_area.contains(ratatui::layout::Position { x, y }) {
         return None;
     }
 
-    for (rect, idx) in visible_panel_rects(area, app) {
-        if rect.contains(ratatui::layout::Position { x, y }) {
-            return Some((idx, rect));
+    visible_dashboard_rects(area, app)
+        .into_iter()
+        .find(|item| item.rect.contains(ratatui::layout::Position { x, y }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        app::{GridUnit, PanelOptions, PanelType, YAxisMode},
+        dashboard::{DashboardItemId, DashboardLayout, DashboardLayoutItem, DashboardRow, RowId},
+        export::ExportOptions,
+        prom::PromClient,
+        theme::Theme,
+        ui::DisplayFormat,
+    };
+    use std::time::Duration;
+
+    fn panel(title: &str, grid: Option<GridUnit>) -> PanelState {
+        PanelState {
+            title: title.to_string(),
+            exprs: vec![],
+            legends: vec![],
+            query_modes: vec![],
+            series: vec![],
+            last_error: None,
+            last_url: None,
+            last_samples: 0,
+            grid,
+            y_axis_mode: YAxisMode::Auto,
+            panel_type: PanelType::Graph,
+            thresholds: None,
+            min: None,
+            max: None,
+            autogrid: None,
+            display: DisplayFormat::default(),
+            options: PanelOptions::None,
         }
     }
-    None
+
+    fn app_with(panels: Vec<PanelState>, layout: DashboardLayout) -> AppState {
+        let mut app = AppState::new(
+            PromClient::new("http://127.0.0.1:9".to_string()),
+            Duration::from_secs(300),
+            Duration::from_secs(5),
+            Duration::from_secs(60),
+            "Rows".to_string(),
+            panels,
+            0,
+            Theme::default(),
+            "dashed".to_string(),
+            ExportOptions::default(),
+        );
+        app.apply_layout(layout);
+        app
+    }
+
+    fn nested_row_app() -> AppState {
+        app_with(
+            vec![
+                panel(
+                    "Visible child",
+                    Some(GridUnit {
+                        x: 0,
+                        y: 0,
+                        w: 24,
+                        h: 2,
+                    }),
+                ),
+                panel(
+                    "Collapsed child",
+                    Some(GridUnit {
+                        x: 0,
+                        y: 0,
+                        w: 24,
+                        h: 2,
+                    }),
+                ),
+            ],
+            DashboardLayout::new(vec![DashboardLayoutItem::Row(DashboardRow::new(
+                RowId::new(0),
+                "Expanded",
+                false,
+                false,
+                vec![
+                    DashboardLayoutItem::Panel(0),
+                    DashboardLayoutItem::Row(DashboardRow::new(
+                        RowId::new(1),
+                        "Nested",
+                        true,
+                        false,
+                        vec![DashboardLayoutItem::Panel(1)],
+                    )),
+                ],
+            ))]),
+        )
+    }
+
+    #[test]
+    fn row_projection_offsets_nested_grid_panels_and_collapses_subtrees() {
+        let app = nested_row_app();
+
+        let rects = visible_dashboard_rects(Rect::new(0, 0, 120, 50), &app);
+
+        assert_eq!(rects.len(), 3);
+        assert!(matches!(
+            rects[0].kind,
+            DashboardRectKind::Row {
+                row_id,
+                depth: 0,
+                collapsed: false,
+            } if row_id == RowId::new(0)
+        ));
+        assert_eq!(rects[0].rect.height, 1);
+        assert!(matches!(
+            rects[1].kind,
+            DashboardRectKind::Panel { index: 0 }
+        ));
+        assert_eq!(rects[1].id, DashboardItemId::Panel(0));
+        assert_eq!(rects[1].rect.y, rects[0].rect.bottom());
+        assert!(matches!(
+            rects[2].kind,
+            DashboardRectKind::Row {
+                row_id,
+                depth: 1,
+                collapsed: true,
+            } if row_id == RowId::new(1)
+        ));
+        assert_eq!(rects[2].rect.y, rects[1].rect.bottom());
+        assert!(
+            rects
+                .iter()
+                .all(|item| item.id != DashboardItemId::Panel(1))
+        );
+    }
+
+    #[test]
+    fn hidden_header_row_is_layout_transparent() {
+        let grid = GridUnit {
+            x: 3,
+            y: 2,
+            w: 9,
+            h: 2,
+        };
+        let hidden = app_with(
+            vec![panel("Panel", Some(grid))],
+            DashboardLayout::new(vec![DashboardLayoutItem::Row(DashboardRow::new(
+                RowId::new(0),
+                "Hidden",
+                true,
+                true,
+                vec![DashboardLayoutItem::Panel(0)],
+            ))]),
+        );
+        let flat = app_with(vec![panel("Panel", Some(grid))], DashboardLayout::flat(1));
+
+        let hidden_rects = visible_dashboard_rects(Rect::new(0, 0, 120, 50), &hidden);
+        let flat_rects = visible_dashboard_rects(Rect::new(0, 0, 120, 50), &flat);
+
+        assert_eq!(hidden_rects.len(), 1);
+        assert_eq!(hidden_rects[0].id, DashboardItemId::Panel(0));
+        assert_eq!(hidden_rects[0].rect, flat_rects[0].rect);
+        assert!(hidden_rects[0].disclosure_rect.is_none());
+    }
+
+    #[test]
+    fn sibling_hidden_header_rows_flow_their_local_grid_children() {
+        let grid = GridUnit {
+            x: 0,
+            y: 0,
+            w: 24,
+            h: 2,
+        };
+        let app = app_with(
+            vec![
+                panel("First child", Some(grid)),
+                panel("Second child", Some(grid)),
+            ],
+            DashboardLayout::new(vec![
+                DashboardLayoutItem::Row(DashboardRow::new(
+                    RowId::new(0),
+                    "Hidden first",
+                    false,
+                    true,
+                    vec![DashboardLayoutItem::Panel(0)],
+                )),
+                DashboardLayoutItem::Row(DashboardRow::new(
+                    RowId::new(1),
+                    "Hidden second",
+                    false,
+                    true,
+                    vec![DashboardLayoutItem::Panel(1)],
+                )),
+            ]),
+        );
+
+        let rects = visible_dashboard_rects(Rect::new(0, 0, 120, 50), &app);
+
+        assert_eq!(rects.len(), 2);
+        assert_eq!(rects[0].id, DashboardItemId::Panel(0));
+        assert_eq!(rects[1].id, DashboardItemId::Panel(1));
+        assert!(rects[0].rect.bottom() <= rects[1].rect.y);
+    }
+
+    #[test]
+    fn row_free_projection_preserves_legacy_panel_vector_growth() {
+        let mut app = app_with(vec![panel("CPU", None)], DashboardLayout::flat(1));
+        app.panels.push(panel("Memory", None));
+
+        let rects = visible_dashboard_rects(Rect::new(0, 0, 120, 50), &app);
+        let panel_indices = rects
+            .into_iter()
+            .filter_map(|item| match item.kind {
+                DashboardRectKind::Panel { index } => Some(index),
+                DashboardRectKind::Row { .. } => None,
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(panel_indices, vec![0, 1]);
+    }
+
+    #[test]
+    fn hit_test_returns_row_and_separate_disclosure_target() {
+        let app = nested_row_app();
+        let area = Rect::new(0, 0, 100, 40);
+        let row = visible_dashboard_rects(area, &app)
+            .into_iter()
+            .find(|item| item.id == DashboardItemId::Row(RowId::new(0)))
+            .unwrap();
+        let disclosure = row.disclosure_rect.unwrap();
+
+        let disclosure_hit = hit_test(&app, area, disclosure.x, disclosure.y).unwrap();
+        let header_hit = hit_test(&app, area, row.rect.right() - 1, row.rect.y).unwrap();
+
+        assert_eq!(disclosure_hit.id, DashboardItemId::Row(RowId::new(0)));
+        assert_eq!(disclosure_hit.disclosure_rect, Some(disclosure));
+        assert_eq!(header_hit.id, DashboardItemId::Row(RowId::new(0)));
+        assert!(!disclosure.contains(Position {
+            x: row.rect.right() - 1,
+            y: row.rect.y,
+        }));
+    }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -23,5 +23,8 @@ mod panels;
 pub(crate) use annotations::{annotation_cluster_page_size, render_annotation_modal};
 pub(crate) use draw::draw_ui;
 pub(crate) use format::{DisplayFormat, format_time, get_hash_color, value_to_heatmap_color};
-pub(crate) use layout::{hit_test, visible_panel_rects};
+#[allow(unused_imports)]
+pub(crate) use layout::{
+    DashboardRect, DashboardRectKind, hit_test, visible_dashboard_rects, visible_panel_rects,
+};
 pub(crate) use panels::calculate_y_bounds;

--- a/tests/fixtures/grafana/classic_rows.json
+++ b/tests/fixtures/grafana/classic_rows.json
@@ -1,0 +1,10 @@
+{
+  "title": "Classic rows",
+  "panels": [
+    {"type":"row","title":"Expanded","collapsed":false,"gridPos":{"x":0,"y":0,"w":24,"h":1}},
+    {"type":"timeseries","title":"Expanded child","gridPos":{"x":0,"y":1,"w":24,"h":8},"targets":[{"expr":"up"}]},
+    {"type":"row","title":"Collapsed","collapsed":true,"gridPos":{"x":0,"y":9,"w":24,"h":1},"panels":[
+      {"type":"stat","title":"Collapsed child","gridPos":{"x":0,"y":10,"w":24,"h":6},"targets":[{"expr":"sum(up)"}]}
+    ]}
+  ]
+}

--- a/tests/fixtures/grafana/v2_rows_layout.json
+++ b/tests/fixtures/grafana/v2_rows_layout.json
@@ -4,8 +4,145 @@
   "metadata": {"name": "rows-layout"},
   "spec": {
     "title": "Rows layout",
-    "elements": {},
-    "layout": {"kind": "RowsLayout", "spec": {"rows": []}},
+    "elements": {
+      "panel-1": {
+        "kind": "Panel",
+        "spec": {
+          "id": 1,
+          "title": "Requests",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {"kind": "PanelQuery", "spec": {"hidden": false, "refId": "A", "query": {"kind": "DataQuery", "group": "prometheus", "version": "v0", "spec": {"expr": "requests_total"}}}}
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.0",
+            "spec": {"fieldConfig": {"defaults": {}, "overrides": []}, "options": {}}
+          }
+        }
+      },
+      "panel-2": {
+        "kind": "Panel",
+        "spec": {
+          "id": 2,
+          "title": "Errors",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {"kind": "PanelQuery", "spec": {"hidden": false, "refId": "A", "query": {"kind": "DataQuery", "group": "prometheus", "version": "v0", "spec": {"expr": "errors_total"}}}}
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.0",
+            "spec": {"fieldConfig": {"defaults": {}, "overrides": []}, "options": {}}
+          }
+        }
+      },
+      "panel-3": {
+        "kind": "Panel",
+        "spec": {
+          "id": 3,
+          "title": "Latency",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {"kind": "PanelQuery", "spec": {"hidden": false, "refId": "A", "query": {"kind": "DataQuery", "group": "prometheus", "version": "v0", "spec": {"expr": "latency_seconds"}}}}
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.0.0",
+            "spec": {"fieldConfig": {"defaults": {}, "overrides": []}, "options": {}}
+          }
+        }
+      }
+    },
+    "layout": {
+      "kind": "RowsLayout",
+      "spec": {
+        "rows": [
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "Expanded",
+              "collapse": false,
+              "hideHeader": false,
+              "fillScreen": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {"x": 0, "y": 0, "width": 12, "height": 8, "element": {"kind": "ElementReference", "name": "panel-1"}}
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "Collapsed",
+              "collapse": true,
+              "hideHeader": false,
+              "layout": {
+                "kind": "RowsLayout",
+                "spec": {
+                  "rows": [
+                    {
+                      "kind": "RowsLayoutRow",
+                      "spec": {
+                        "title": "Nested",
+                        "collapse": false,
+                        "hideHeader": false,
+                        "layout": {
+                          "kind": "GridLayout",
+                          "spec": {
+                            "items": [
+                              {
+                                "kind": "GridLayoutItem",
+                                "spec": {"x": 0, "y": 0, "width": 12, "height": 8, "element": {"kind": "ElementReference", "name": "panel-2"}}
+                              },
+                              {
+                                "kind": "GridLayoutItem",
+                                "spec": {"x": 12, "y": 0, "width": 12, "height": 8, "element": {"kind": "ElementReference", "name": "panel-3"}}
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
     "variables": [],
     "timeSettings": {"from": "now-6h", "to": "now", "autoRefresh": ""}
   },

--- a/tests/validate_cli.rs
+++ b/tests/validate_cli.rs
@@ -170,6 +170,24 @@ fn validate_accepts_live_grafana_v2_compatibility_example() {
 }
 
 #[test]
+fn validate_accepts_live_grafana_v2_rows_example() {
+    let output = Command::new(env!("CARGO_BIN_EXE_grafatui"))
+        .args(["--validate", "--format", "json", "--grafana-json"])
+        .arg(example_dashboard("grafana_v2_rows.json"))
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let summary: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(summary["title"], "Grafana V2 Rows");
+    assert_eq!(summary["panel_count"], 3);
+}
+
+#[test]
 fn validate_accepts_v2_rows_layout() {
     let output = Command::new(env!("CARGO_BIN_EXE_grafatui"))
         .args(["--validate", "--format", "json", "--grafana-json"])

--- a/tests/validate_cli.rs
+++ b/tests/validate_cli.rs
@@ -170,18 +170,42 @@ fn validate_accepts_live_grafana_v2_compatibility_example() {
 }
 
 #[test]
-fn validate_rejects_unsupported_v2_layout() {
+fn validate_accepts_v2_rows_layout() {
     let output = Command::new(env!("CARGO_BIN_EXE_grafatui"))
-        .args(["--validate", "--grafana-json"])
+        .args(["--validate", "--format", "json", "--grafana-json"])
         .arg(fixture("v2_rows_layout.json"))
         .output()
         .unwrap();
 
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let summary: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(summary["title"], "Rows layout");
+    assert_eq!(summary["panel_count"], 3);
+}
+
+#[test]
+fn validate_rejects_nested_v2_tabs_layout() {
+    let mut value: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(fixture("v2_rows_layout.json")).unwrap()).unwrap();
+    value["spec"]["layout"]["spec"]["rows"][0]["spec"]["layout"] =
+        serde_json::json!({"kind": "TabsLayout", "spec": {}});
+    let path = write_dashboard("v2-nested-tabs", &value.to_string());
+
+    let output = Command::new(env!("CARGO_BIN_EXE_grafatui"))
+        .args(["--validate", "--grafana-json"])
+        .arg(&path)
+        .output()
+        .unwrap();
+    fs::remove_file(path).unwrap();
+
     assert!(!output.status.success());
     let stderr = String::from_utf8(output.stderr).unwrap();
-    assert!(stderr.contains("RowsLayout"));
-    assert!(stderr.contains("spec.layout.kind"));
-    assert!(stderr.contains("GridLayout"));
+    assert!(stderr.contains("TabsLayout"));
+    assert!(stderr.contains("spec.layout.spec.rows[0].spec.layout.kind"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Add a shared recursive dashboard layout model for Grafana v2 RowsLayout and Classic rows.
- Support nested rows, collapsed and expanded state, hidden-header transparency, visible-aware navigation and refresh, and row keyboard/mouse controls.
- Export rows through SVG and recording and add a mock-compatible v2 rows example.
- Document shipped compatibility and deferred v2 features.

## Verification

- cargo fmt --all -- --check
- cargo test (304 unit + 11 integration tests)
- cargo clippy --all-targets --all-features -- -D warnings
- tests/install.sh
- mdbook build
- both Grafana example validation commands
- deterministic Ratatui buffer/image and PTY restoration checks